### PR TITLE
Document TypeScript core and Python replay prototype boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,14 @@ Planned improvements include:
 
 ---
 
+# Product Direction
+
+The current FSMS product direction and prototype boundaries are documented in:
+
+- `docs/FSMS_DIRECTION.md`
+
+---
+
 # License
 
 Internal project – FSMS prototype.

--- a/docs/FSMS_DIRECTION.md
+++ b/docs/FSMS_DIRECTION.md
@@ -1,0 +1,101 @@
+# FSMS Product Direction
+
+## Purpose
+
+The end product is a UAV Flight Safety Management System that supports safety assurance from planning through live operations and post-operation review.
+
+The system should help answer:
+
+- Is this mission safe and authorised to proceed?
+- Is the UAV fit to fly?
+- Is the pilot or operator fit and current?
+- Is the mission being operated inside its approved envelope?
+- Can the organisation prove what happened, who decided what, and why?
+
+Future work should stay focused on safety, compliance, operational assurance, and audit evidence.
+
+## Active Product Core
+
+The TypeScript backend is the active FSMS product core.
+
+It owns the long-term direction for:
+
+- missions and lifecycle state
+- telemetry ingestion and telemetry history
+- mission replay from telemetry
+- alerts and running assurance checks
+- audit-relevant mission events
+- future platform, pilot, risk, regulatory, and reporting domains
+
+New durable backend features should normally be added to the TypeScript system unless there is a deliberate migration or prototype reason not to.
+
+## Python Replay Prototype
+
+The Python replay system remains a prototype and reference implementation.
+
+It was built first to prove:
+
+- flight replay behaviour
+- HUD concepts
+- early airspace display
+- early compliance evaluation
+- prediction and risk display ideas
+
+The Python replay should not be treated as the long-term source of truth for mission assurance data. It is valuable as a working reference while replay, compliance, and assurance capabilities move into the TypeScript product core.
+
+## Concept-Test Assumptions
+
+Some current behaviour is intentionally simplified for early system-building.
+
+Known prototype assumptions:
+
+- Terrain elevation is fixed at `20.0 m` because terrain maps have not yet been integrated.
+- A single airspace restriction is used to build and test the system shape.
+- Early compliance and replay behaviour are concept tests rather than complete regulatory automation.
+
+These assumptions are acceptable during prototype development, but they must remain visible. They should not become hidden legal or safety claims.
+
+## Regulatory Direction
+
+The first regulatory profile is UK CAA focused.
+
+The system should be designed so UK requirements can be represented first, while leaving room for later expansion into other countries and possible military use.
+
+Regulatory logic should be structured as profiles or rule packs rather than scattered hardcoded checks. Future profiles may differ by:
+
+- operation category
+- authorisation requirements
+- pilot competency
+- platform requirements
+- airspace permissions
+- evidence retention
+- incident reporting
+- approval and override rules
+
+## Audit Principle
+
+The FSMS should be built as an evidence machine.
+
+Important safety and compliance decisions should produce auditable records, including:
+
+- what was checked
+- what the result was
+- who or what made the decision
+- when it happened
+- what evidence supported it
+- whether anyone overrode it
+
+This applies across planning, pre-flight assurance, live operations, replay, and post-flight review.
+
+## Implementation Focus
+
+Build in this order of importance:
+
+1. Audit trail strength
+2. Mission safety decisions
+3. Planning-to-live-operation continuity
+4. Regulatory clarity
+5. Practical readiness for real users
+
+Avoid spending early effort on polish, advanced terrain, multi-country rule engines, military-specific workflows, or complex UI unless they directly support the current safety and audit path.
+


### PR DESCRIPTION
Title:
Document TypeScript core and Python replay prototype boundaries

## Summary
Documents the focused FSMS product direction for issue #3.

## What changed
- Added `docs/FSMS_DIRECTION.md` describing the TypeScript backend as the active FSMS product core.
- Clarified that the Python replay is a prototype/reference implementation.
- Documented concept-test assumptions for fixed `20.0 m` terrain and the single airspace restriction.
- Captured UK CAA as the first target regulatory profile while leaving room for future jurisdiction and military profiles.
- Stated the audit principle that important safety and compliance decisions should produce auditable records.
- Linked the new document from `README.md`.

## Verification
- Docs-only change; no automated tests run.

Closes #3.
