### PR TITLE
Add platform and maintenance foundation for UAV readiness #4

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add a stable mission lifecycle metadata read model that exposes supported actions, target states, and action labels for clients so operator workflows can use shared lifecycle rules without duplicating logic.",
+ "nextBuildStep": "Add platform readiness assurance checks against the platform maintenance schema so mission gates can detect overdue maintenance.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,10 @@ import { createAlertRouter } from "./alerts/alert.routes";
 import { MissionReplayService } from "./replay/mission-replay.service";
 import { MissionReplayController } from "./replay/mission-replay.controller";
 import { createMissionReplayRouter } from "./replay/mission-replay.routes";
+import { PlatformRepository } from "./platforms/platform.repository";
+import { PlatformService } from "./platforms/platform.service";
+import { PlatformController } from "./platforms/platform.controller";
+import { createPlatformRouter } from "./platforms/platform.routes";
 
 dotenv.config({
   path: path.resolve(process.cwd(), ".env"),
@@ -89,11 +93,15 @@ const missionReplayService = new MissionReplayService(
 const missionReplayController = new MissionReplayController(missionReplayService);
 
 const timelineService = new TimelineService(pool);
+const platformRepository = new PlatformRepository();
+const platformService = new PlatformService(pool, platformRepository);
+const platformController = new PlatformController(platformService);
 
 app.use("/missions", createMissionRouter(missionController));
 app.use("/missions", createMissionReplayRouter(missionReplayController));
 app.use("/missions", createMissionTelemetryRouter(missionTelemetryController));
 app.use("/missions", createAlertRouter(alertController));
+app.use("/platforms", createPlatformRouter(platformController));
 app.use("/timeline", createTimelineRouter(timelineService));
 app.get("/", (_req, res) => {
   res.status(200).send("FSMS backend is running");

--- a/src/migrations/008_create_platforms_maintenance.sql
+++ b/src/migrations/008_create_platforms_maintenance.sql
@@ -1,0 +1,98 @@
+create table if not exists platforms (
+  id uuid primary key,
+  name text not null,
+  registration text null,
+  platform_type text null,
+  manufacturer text null,
+  model text null,
+  serial_number text null,
+  status text not null default 'active',
+  total_flight_hours numeric(10, 2) not null default 0,
+  notes text null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint platforms_status_chk
+    check (status in (
+      'active',
+      'inactive',
+      'maintenance_due',
+      'grounded',
+      'retired'
+    )),
+
+  constraint platforms_total_flight_hours_chk
+    check (total_flight_hours >= 0)
+);
+
+create unique index if not exists idx_platforms_registration_unique
+  on platforms (registration)
+  where registration is not null;
+
+create index if not exists idx_platforms_status
+  on platforms (status);
+
+create table if not exists maintenance_schedules (
+  id uuid primary key,
+  platform_id uuid not null references platforms(id) on delete cascade,
+  task_name text not null,
+  description text null,
+  interval_days integer null,
+  interval_flight_hours numeric(10, 2) null,
+  last_completed_at timestamptz null,
+  last_completed_flight_hours numeric(10, 2) null,
+  next_due_at timestamptz null,
+  next_due_flight_hours numeric(10, 2) null,
+  status text not null default 'active',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint maintenance_schedules_status_chk
+    check (status in ('active', 'inactive')),
+
+  constraint maintenance_schedules_interval_days_chk
+    check (interval_days is null or interval_days > 0),
+
+  constraint maintenance_schedules_interval_flight_hours_chk
+    check (interval_flight_hours is null or interval_flight_hours > 0),
+
+  constraint maintenance_schedules_next_due_flight_hours_chk
+    check (next_due_flight_hours is null or next_due_flight_hours >= 0),
+
+  constraint maintenance_schedules_last_completed_flight_hours_chk
+    check (
+      last_completed_flight_hours is null
+      or last_completed_flight_hours >= 0
+    )
+);
+
+create index if not exists idx_maintenance_schedules_platform
+  on maintenance_schedules (platform_id);
+
+create index if not exists idx_maintenance_schedules_next_due_at
+  on maintenance_schedules (next_due_at);
+
+create table if not exists maintenance_records (
+  id uuid primary key,
+  platform_id uuid not null references platforms(id) on delete cascade,
+  schedule_id uuid null references maintenance_schedules(id) on delete set null,
+  task_name text not null,
+  completed_at timestamptz not null,
+  completed_by text not null,
+  completed_flight_hours numeric(10, 2) null,
+  notes text null,
+  evidence_ref text null,
+  created_at timestamptz not null default now(),
+
+  constraint maintenance_records_completed_flight_hours_chk
+    check (
+      completed_flight_hours is null
+      or completed_flight_hours >= 0
+    )
+);
+
+create index if not exists idx_maintenance_records_platform_completed
+  on maintenance_records (platform_id, completed_at desc);
+
+create index if not exists idx_maintenance_records_schedule
+  on maintenance_records (schedule_id);

--- a/src/platforms/platform.controller.ts
+++ b/src/platforms/platform.controller.ts
@@ -1,0 +1,81 @@
+import type { NextFunction, Request, Response } from "express";
+import { PlatformService } from "./platform.service";
+
+type PlatformIdParams = {
+  id: string;
+};
+
+export class PlatformController {
+  constructor(private readonly platformService: PlatformService) {}
+
+  createPlatform = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const platform = await this.platformService.createPlatform(req.body);
+      res.status(201).json({ platform });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getPlatform = async (
+    req: Request<PlatformIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const platform = await this.platformService.getPlatform(req.params.id);
+      res.status(200).json({ platform });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  createMaintenanceSchedule = async (
+    req: Request<PlatformIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const schedule = await this.platformService.createMaintenanceSchedule(
+        req.params.id,
+        req.body,
+      );
+      res.status(201).json({ schedule });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  createMaintenanceRecord = async (
+    req: Request<PlatformIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const record = await this.platformService.createMaintenanceRecord(
+        req.params.id,
+        req.body,
+      );
+      res.status(201).json({ record });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getMaintenanceStatus = async (
+    req: Request<PlatformIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const status = await this.platformService.getMaintenanceStatus(req.params.id);
+      res.status(200).json(status);
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/platforms/platform.errors.ts
+++ b/src/platforms/platform.errors.ts
@@ -1,0 +1,29 @@
+export class PlatformValidationError extends Error {
+  readonly statusCode = 400;
+  readonly code = "PLATFORM_VALIDATION_ERROR";
+
+  constructor(message: string) {
+    super(message);
+    this.name = "PlatformValidationError";
+  }
+}
+
+export class PlatformNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "PLATFORM_NOT_FOUND";
+
+  constructor(platformId: string) {
+    super(`Platform not found: ${platformId}`);
+    this.name = "PlatformNotFoundError";
+  }
+}
+
+export class MaintenanceScheduleNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "MAINTENANCE_SCHEDULE_NOT_FOUND";
+
+  constructor(scheduleId: string) {
+    super(`Maintenance schedule not found: ${scheduleId}`);
+    this.name = "MaintenanceScheduleNotFoundError";
+  }
+}

--- a/src/platforms/platform.repository.ts
+++ b/src/platforms/platform.repository.ts
@@ -1,0 +1,335 @@
+import { randomUUID } from "crypto";
+import type { PoolClient, QueryResultRow } from "pg";
+import type {
+  MaintenanceRecord,
+  MaintenanceSchedule,
+  Platform,
+} from "./platform.types";
+
+interface PlatformRow extends QueryResultRow {
+  id: string;
+  name: string;
+  registration: string | null;
+  platform_type: string | null;
+  manufacturer: string | null;
+  model: string | null;
+  serial_number: string | null;
+  status: Platform["status"];
+  total_flight_hours: string | number;
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface MaintenanceScheduleRow extends QueryResultRow {
+  id: string;
+  platform_id: string;
+  task_name: string;
+  description: string | null;
+  interval_days: number | null;
+  interval_flight_hours: string | number | null;
+  last_completed_at: Date | null;
+  last_completed_flight_hours: string | number | null;
+  next_due_at: Date | null;
+  next_due_flight_hours: string | number | null;
+  status: MaintenanceSchedule["status"];
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface MaintenanceRecordRow extends QueryResultRow {
+  id: string;
+  platform_id: string;
+  schedule_id: string | null;
+  task_name: string;
+  completed_at: Date;
+  completed_by: string;
+  completed_flight_hours: string | number | null;
+  notes: string | null;
+  evidence_ref: string | null;
+  created_at: Date;
+}
+
+type CreatePlatformRow = Omit<Platform, "id" | "createdAt" | "updatedAt">;
+
+type CreateScheduleRow = {
+  platformId: string;
+  taskName: string;
+  description: string | null;
+  intervalDays: number | null;
+  intervalFlightHours: number | null;
+  nextDueAt: Date | null;
+  nextDueFlightHours: number | null;
+  status: MaintenanceSchedule["status"];
+};
+
+type CreateRecordRow = {
+  platformId: string;
+  scheduleId: string | null;
+  taskName: string;
+  completedAt: Date;
+  completedBy: string;
+  completedFlightHours: number | null;
+  notes: string | null;
+  evidenceRef: string | null;
+};
+
+const numberOrNull = (value: string | number | null): number | null =>
+  value === null ? null : Number(value);
+
+const toPlatform = (row: PlatformRow): Platform => ({
+  id: row.id,
+  name: row.name,
+  registration: row.registration,
+  platformType: row.platform_type,
+  manufacturer: row.manufacturer,
+  model: row.model,
+  serialNumber: row.serial_number,
+  status: row.status,
+  totalFlightHours: Number(row.total_flight_hours),
+  notes: row.notes,
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
+});
+
+const toSchedule = (row: MaintenanceScheduleRow): MaintenanceSchedule => ({
+  id: row.id,
+  platformId: row.platform_id,
+  taskName: row.task_name,
+  description: row.description,
+  intervalDays: row.interval_days,
+  intervalFlightHours: numberOrNull(row.interval_flight_hours),
+  lastCompletedAt: row.last_completed_at?.toISOString() ?? null,
+  lastCompletedFlightHours: numberOrNull(row.last_completed_flight_hours),
+  nextDueAt: row.next_due_at?.toISOString() ?? null,
+  nextDueFlightHours: numberOrNull(row.next_due_flight_hours),
+  status: row.status,
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
+});
+
+const toRecord = (row: MaintenanceRecordRow): MaintenanceRecord => ({
+  id: row.id,
+  platformId: row.platform_id,
+  scheduleId: row.schedule_id,
+  taskName: row.task_name,
+  completedAt: row.completed_at.toISOString(),
+  completedBy: row.completed_by,
+  completedFlightHours: numberOrNull(row.completed_flight_hours),
+  notes: row.notes,
+  evidenceRef: row.evidence_ref,
+  createdAt: row.created_at.toISOString(),
+});
+
+export class PlatformRepository {
+  async insertPlatform(tx: PoolClient, input: CreatePlatformRow): Promise<Platform> {
+    const result = await tx.query<PlatformRow>(
+      `
+      insert into platforms (
+        id,
+        name,
+        registration,
+        platform_type,
+        manufacturer,
+        model,
+        serial_number,
+        status,
+        total_flight_hours,
+        notes
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.name,
+        input.registration,
+        input.platformType,
+        input.manufacturer,
+        input.model,
+        input.serialNumber,
+        input.status,
+        input.totalFlightHours,
+        input.notes,
+      ],
+    );
+
+    return toPlatform(result.rows[0]);
+  }
+
+  async getPlatformById(
+    tx: PoolClient,
+    platformId: string,
+  ): Promise<Platform | null> {
+    const result = await tx.query<PlatformRow>(
+      `
+      select *
+      from platforms
+      where id = $1
+      `,
+      [platformId],
+    );
+
+    return result.rows[0] ? toPlatform(result.rows[0]) : null;
+  }
+
+  async insertMaintenanceSchedule(
+    tx: PoolClient,
+    input: CreateScheduleRow,
+  ): Promise<MaintenanceSchedule> {
+    const result = await tx.query<MaintenanceScheduleRow>(
+      `
+      insert into maintenance_schedules (
+        id,
+        platform_id,
+        task_name,
+        description,
+        interval_days,
+        interval_flight_hours,
+        next_due_at,
+        next_due_flight_hours,
+        status
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.platformId,
+        input.taskName,
+        input.description,
+        input.intervalDays,
+        input.intervalFlightHours,
+        input.nextDueAt,
+        input.nextDueFlightHours,
+        input.status,
+      ],
+    );
+
+    return toSchedule(result.rows[0]);
+  }
+
+  async getMaintenanceScheduleById(
+    tx: PoolClient,
+    platformId: string,
+    scheduleId: string,
+  ): Promise<MaintenanceSchedule | null> {
+    const result = await tx.query<MaintenanceScheduleRow>(
+      `
+      select *
+      from maintenance_schedules
+      where platform_id = $1
+        and id = $2
+      `,
+      [platformId, scheduleId],
+    );
+
+    return result.rows[0] ? toSchedule(result.rows[0]) : null;
+  }
+
+  async listMaintenanceSchedules(
+    tx: PoolClient,
+    platformId: string,
+  ): Promise<MaintenanceSchedule[]> {
+    const result = await tx.query<MaintenanceScheduleRow>(
+      `
+      select *
+      from maintenance_schedules
+      where platform_id = $1
+      order by created_at asc, id asc
+      `,
+      [platformId],
+    );
+
+    return result.rows.map(toSchedule);
+  }
+
+  async insertMaintenanceRecord(
+    tx: PoolClient,
+    input: CreateRecordRow,
+  ): Promise<MaintenanceRecord> {
+    const result = await tx.query<MaintenanceRecordRow>(
+      `
+      insert into maintenance_records (
+        id,
+        platform_id,
+        schedule_id,
+        task_name,
+        completed_at,
+        completed_by,
+        completed_flight_hours,
+        notes,
+        evidence_ref
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.platformId,
+        input.scheduleId,
+        input.taskName,
+        input.completedAt,
+        input.completedBy,
+        input.completedFlightHours,
+        input.notes,
+        input.evidenceRef,
+      ],
+    );
+
+    return toRecord(result.rows[0]);
+  }
+
+  async updateScheduleCompletion(
+    tx: PoolClient,
+    params: {
+      scheduleId: string;
+      completedAt: Date;
+      completedFlightHours: number | null;
+      nextDueAt: Date | null;
+      nextDueFlightHours: number | null;
+    },
+  ): Promise<MaintenanceSchedule> {
+    const result = await tx.query<MaintenanceScheduleRow>(
+      `
+      update maintenance_schedules
+      set
+        last_completed_at = $2,
+        last_completed_flight_hours = $3,
+        next_due_at = $4,
+        next_due_flight_hours = $5,
+        updated_at = now()
+      where id = $1
+      returning *
+      `,
+      [
+        params.scheduleId,
+        params.completedAt,
+        params.completedFlightHours,
+        params.nextDueAt,
+        params.nextDueFlightHours,
+      ],
+    );
+
+    return toSchedule(result.rows[0]);
+  }
+
+  async listMaintenanceRecords(
+    tx: PoolClient,
+    platformId: string,
+    limit = 20,
+  ): Promise<MaintenanceRecord[]> {
+    const result = await tx.query<MaintenanceRecordRow>(
+      `
+      select *
+      from maintenance_records
+      where platform_id = $1
+      order by completed_at desc, created_at desc, id desc
+      limit $2
+      `,
+      [platformId, limit],
+    );
+
+    return result.rows.map(toRecord);
+  }
+}

--- a/src/platforms/platform.routes.ts
+++ b/src/platforms/platform.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import { PlatformController } from "./platform.controller";
+
+export function createPlatformRouter(controller: PlatformController): Router {
+  const router = Router();
+
+  router.post("/", controller.createPlatform);
+  router.get("/:id", controller.getPlatform);
+  router.post("/:id/maintenance-schedules", controller.createMaintenanceSchedule);
+  router.post("/:id/maintenance-records", controller.createMaintenanceRecord);
+  router.get("/:id/maintenance-status", controller.getMaintenanceStatus);
+
+  return router;
+}

--- a/src/platforms/platform.service.ts
+++ b/src/platforms/platform.service.ts
@@ -1,0 +1,250 @@
+import type { Pool } from "pg";
+import {
+  MaintenanceScheduleNotFoundError,
+  PlatformNotFoundError,
+  PlatformValidationError,
+} from "./platform.errors";
+import { PlatformRepository } from "./platform.repository";
+import type {
+  CreateMaintenanceRecordInput,
+  CreateMaintenanceScheduleInput,
+  CreatePlatformInput,
+  MaintenanceSchedule,
+  PlatformMaintenanceStatus,
+} from "./platform.types";
+import {
+  validateCreateMaintenanceRecordInput,
+  validateCreateMaintenanceScheduleInput,
+  validateCreatePlatformInput,
+} from "./platform.validators";
+
+export class PlatformService {
+  constructor(
+    private readonly pool: Pool,
+    private readonly platformRepository: PlatformRepository,
+  ) {}
+
+  async createPlatform(input: CreatePlatformInput) {
+    const validated = validateCreatePlatformInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      return await this.platformRepository.insertPlatform(client, validated);
+    } finally {
+      client.release();
+    }
+  }
+
+  async getPlatform(platformId: string) {
+    const client = await this.pool.connect();
+
+    try {
+      const platform = await this.platformRepository.getPlatformById(
+        client,
+        platformId,
+      );
+
+      if (!platform) {
+        throw new PlatformNotFoundError(platformId);
+      }
+
+      return platform;
+    } finally {
+      client.release();
+    }
+  }
+
+  async createMaintenanceSchedule(
+    platformId: string,
+    input: CreateMaintenanceScheduleInput,
+  ) {
+    const validated = validateCreateMaintenanceScheduleInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      const platform = await this.platformRepository.getPlatformById(
+        client,
+        platformId,
+      );
+
+      if (!platform) {
+        throw new PlatformNotFoundError(platformId);
+      }
+
+      return await this.platformRepository.insertMaintenanceSchedule(client, {
+        platformId,
+        ...validated,
+      });
+    } finally {
+      client.release();
+    }
+  }
+
+  async createMaintenanceRecord(
+    platformId: string,
+    input: CreateMaintenanceRecordInput,
+  ) {
+    const validated = validateCreateMaintenanceRecordInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      await client.query("begin");
+
+      const platform = await this.platformRepository.getPlatformById(
+        client,
+        platformId,
+      );
+
+      if (!platform) {
+        throw new PlatformNotFoundError(platformId);
+      }
+
+      let schedule: MaintenanceSchedule | null = null;
+
+      if (validated.scheduleId) {
+        schedule = await this.platformRepository.getMaintenanceScheduleById(
+          client,
+          platformId,
+          validated.scheduleId,
+        );
+
+        if (!schedule) {
+          throw new MaintenanceScheduleNotFoundError(validated.scheduleId);
+        }
+      }
+
+      const taskName = validated.taskName ?? schedule?.taskName;
+
+      if (!taskName) {
+        throw new PlatformValidationError(
+          "taskName is required when scheduleId is not provided",
+        );
+      }
+
+      const record = await this.platformRepository.insertMaintenanceRecord(
+        client,
+        {
+          platformId,
+          scheduleId: validated.scheduleId,
+          taskName,
+          completedAt: validated.completedAt,
+          completedBy: validated.completedBy,
+          completedFlightHours: validated.completedFlightHours,
+          notes: validated.notes,
+          evidenceRef: validated.evidenceRef,
+        },
+      );
+
+      if (schedule) {
+        await this.platformRepository.updateScheduleCompletion(client, {
+          scheduleId: schedule.id,
+          completedAt: validated.completedAt,
+          completedFlightHours: validated.completedFlightHours,
+          nextDueAt: this.computeNextDueAt(schedule, validated.completedAt),
+          nextDueFlightHours: this.computeNextDueFlightHours(
+            schedule,
+            validated.completedFlightHours,
+          ),
+        });
+      }
+
+      await client.query("commit");
+      return record;
+    } catch (error) {
+      await client.query("rollback");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async getMaintenanceStatus(
+    platformId: string,
+  ): Promise<PlatformMaintenanceStatus> {
+    const client = await this.pool.connect();
+
+    try {
+      const platform = await this.platformRepository.getPlatformById(
+        client,
+        platformId,
+      );
+
+      if (!platform) {
+        throw new PlatformNotFoundError(platformId);
+      }
+
+      const schedules = await this.platformRepository.listMaintenanceSchedules(
+        client,
+        platformId,
+      );
+      const latestRecords = await this.platformRepository.listMaintenanceRecords(
+        client,
+        platformId,
+      );
+
+      const dueSchedules = schedules.filter((schedule) =>
+        this.isScheduleDue(schedule, platform.totalFlightHours),
+      );
+      const upcomingSchedules = schedules.filter(
+        (schedule) => !dueSchedules.some((item) => item.id === schedule.id),
+      );
+
+      return {
+        platform,
+        effectiveStatus:
+          platform.status === "active" && dueSchedules.length > 0
+            ? "maintenance_due"
+            : platform.status,
+        dueSchedules,
+        upcomingSchedules,
+        latestRecords,
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  private computeNextDueAt(
+    schedule: MaintenanceSchedule,
+    completedAt: Date,
+  ): Date | null {
+    if (schedule.intervalDays === null) {
+      return schedule.nextDueAt ? new Date(schedule.nextDueAt) : null;
+    }
+
+    const next = new Date(completedAt);
+    next.setUTCDate(next.getUTCDate() + schedule.intervalDays);
+    return next;
+  }
+
+  private computeNextDueFlightHours(
+    schedule: MaintenanceSchedule,
+    completedFlightHours: number | null,
+  ): number | null {
+    if (
+      schedule.intervalFlightHours === null ||
+      completedFlightHours === null
+    ) {
+      return schedule.nextDueFlightHours;
+    }
+
+    return completedFlightHours + schedule.intervalFlightHours;
+  }
+
+  private isScheduleDue(
+    schedule: MaintenanceSchedule,
+    platformTotalFlightHours: number,
+  ): boolean {
+    if (schedule.status !== "active") {
+      return false;
+    }
+
+    const dueByDate =
+      schedule.nextDueAt !== null && new Date(schedule.nextDueAt) <= new Date();
+    const dueByHours =
+      schedule.nextDueFlightHours !== null &&
+      schedule.nextDueFlightHours <= platformTotalFlightHours;
+
+    return dueByDate || dueByHours;
+  }
+}

--- a/src/platforms/platform.types.ts
+++ b/src/platforms/platform.types.ts
@@ -1,0 +1,92 @@
+export type PlatformStatus =
+  | "active"
+  | "inactive"
+  | "maintenance_due"
+  | "grounded"
+  | "retired";
+
+export type MaintenanceScheduleStatus = "active" | "inactive";
+
+export interface CreatePlatformInput {
+  name?: string;
+  registration?: string | null;
+  platformType?: string | null;
+  manufacturer?: string | null;
+  model?: string | null;
+  serialNumber?: string | null;
+  status?: PlatformStatus;
+  totalFlightHours?: number;
+  notes?: string | null;
+}
+
+export interface Platform {
+  id: string;
+  name: string;
+  registration: string | null;
+  platformType: string | null;
+  manufacturer: string | null;
+  model: string | null;
+  serialNumber: string | null;
+  status: PlatformStatus;
+  totalFlightHours: number;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateMaintenanceScheduleInput {
+  taskName?: string;
+  description?: string | null;
+  intervalDays?: number | null;
+  intervalFlightHours?: number | null;
+  nextDueAt?: string | null;
+  nextDueFlightHours?: number | null;
+  status?: MaintenanceScheduleStatus;
+}
+
+export interface MaintenanceSchedule {
+  id: string;
+  platformId: string;
+  taskName: string;
+  description: string | null;
+  intervalDays: number | null;
+  intervalFlightHours: number | null;
+  lastCompletedAt: string | null;
+  lastCompletedFlightHours: number | null;
+  nextDueAt: string | null;
+  nextDueFlightHours: number | null;
+  status: MaintenanceScheduleStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateMaintenanceRecordInput {
+  scheduleId?: string | null;
+  taskName?: string;
+  completedAt?: string;
+  completedBy?: string;
+  completedFlightHours?: number | null;
+  notes?: string | null;
+  evidenceRef?: string | null;
+}
+
+export interface MaintenanceRecord {
+  id: string;
+  platformId: string;
+  scheduleId: string | null;
+  taskName: string;
+  completedAt: string;
+  completedBy: string;
+  completedFlightHours: number | null;
+  notes: string | null;
+  evidenceRef: string | null;
+  createdAt: string;
+}
+
+export interface PlatformMaintenanceStatus {
+  platform: Platform;
+  effectiveStatus: PlatformStatus;
+  dueSchedules: MaintenanceSchedule[];
+  upcomingSchedules: MaintenanceSchedule[];
+  latestRecords: MaintenanceRecord[];
+}

--- a/src/platforms/platform.validators.ts
+++ b/src/platforms/platform.validators.ts
@@ -1,0 +1,179 @@
+import { PlatformValidationError } from "./platform.errors";
+import type {
+  CreateMaintenanceRecordInput,
+  CreateMaintenanceScheduleInput,
+  CreatePlatformInput,
+  MaintenanceScheduleStatus,
+  PlatformStatus,
+} from "./platform.types";
+
+const PLATFORM_STATUSES = new Set<PlatformStatus>([
+  "active",
+  "inactive",
+  "maintenance_due",
+  "grounded",
+  "retired",
+]);
+
+const SCHEDULE_STATUSES = new Set<MaintenanceScheduleStatus>([
+  "active",
+  "inactive",
+]);
+
+function optionalTrimmed(value: unknown, fieldName: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    throw new PlatformValidationError(`${fieldName} must be a string`);
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function requiredTrimmed(value: unknown, fieldName: string): string {
+  const normalized = optionalTrimmed(value, fieldName);
+
+  if (!normalized) {
+    throw new PlatformValidationError(`${fieldName} is required`);
+  }
+
+  return normalized;
+}
+
+function optionalNonNegativeNumber(
+  value: unknown,
+  fieldName: string,
+): number | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new PlatformValidationError(`${fieldName} must be a non-negative number`);
+  }
+
+  return value;
+}
+
+function optionalPositiveInteger(value: unknown, fieldName: string): number | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new PlatformValidationError(`${fieldName} must be a positive integer`);
+  }
+
+  return value;
+}
+
+function optionalPositiveNumber(value: unknown, fieldName: string): number | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new PlatformValidationError(`${fieldName} must be a positive number`);
+  }
+
+  return value;
+}
+
+function optionalDate(value: unknown, fieldName: string): Date | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    throw new PlatformValidationError(`${fieldName} must be a valid ISO timestamp`);
+  }
+
+  return new Date(value);
+}
+
+export function validateCreatePlatformInput(input: CreatePlatformInput) {
+  if (!input || typeof input !== "object") {
+    throw new PlatformValidationError("Request body must be an object");
+  }
+
+  const status = input.status ?? "active";
+
+  if (!PLATFORM_STATUSES.has(status)) {
+    throw new PlatformValidationError("status is not supported");
+  }
+
+  return {
+    name: requiredTrimmed(input.name, "name"),
+    registration: optionalTrimmed(input.registration, "registration"),
+    platformType: optionalTrimmed(input.platformType, "platformType"),
+    manufacturer: optionalTrimmed(input.manufacturer, "manufacturer"),
+    model: optionalTrimmed(input.model, "model"),
+    serialNumber: optionalTrimmed(input.serialNumber, "serialNumber"),
+    status,
+    totalFlightHours: optionalNonNegativeNumber(
+      input.totalFlightHours,
+      "totalFlightHours",
+    ) ?? 0,
+    notes: optionalTrimmed(input.notes, "notes"),
+  };
+}
+
+export function validateCreateMaintenanceScheduleInput(
+  input: CreateMaintenanceScheduleInput,
+) {
+  if (!input || typeof input !== "object") {
+    throw new PlatformValidationError("Request body must be an object");
+  }
+
+  const status = input.status ?? "active";
+
+  if (!SCHEDULE_STATUSES.has(status)) {
+    throw new PlatformValidationError("status is not supported");
+  }
+
+  return {
+    taskName: requiredTrimmed(input.taskName, "taskName"),
+    description: optionalTrimmed(input.description, "description"),
+    intervalDays: optionalPositiveInteger(input.intervalDays, "intervalDays"),
+    intervalFlightHours: optionalPositiveNumber(
+      input.intervalFlightHours,
+      "intervalFlightHours",
+    ),
+    nextDueAt: optionalDate(input.nextDueAt, "nextDueAt"),
+    nextDueFlightHours: optionalNonNegativeNumber(
+      input.nextDueFlightHours,
+      "nextDueFlightHours",
+    ),
+    status,
+  };
+}
+
+export function validateCreateMaintenanceRecordInput(
+  input: CreateMaintenanceRecordInput,
+) {
+  if (!input || typeof input !== "object") {
+    throw new PlatformValidationError("Request body must be an object");
+  }
+
+  const completedAt = optionalDate(input.completedAt, "completedAt");
+
+  if (!completedAt) {
+    throw new PlatformValidationError("completedAt is required");
+  }
+
+  return {
+    scheduleId: optionalTrimmed(input.scheduleId, "scheduleId"),
+    taskName: optionalTrimmed(input.taskName, "taskName"),
+    completedAt,
+    completedBy: requiredTrimmed(input.completedBy, "completedBy"),
+    completedFlightHours: optionalNonNegativeNumber(
+      input.completedFlightHours,
+      "completedFlightHours",
+    ),
+    notes: optionalTrimmed(input.notes, "notes"),
+    evidenceRef: optionalTrimmed(input.evidenceRef, "evidenceRef"),
+  };
+}

--- a/src/tests/platform-maintenance.test.ts
+++ b/src/tests/platform-maintenance.test.ts
@@ -1,0 +1,223 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import app, { pool } from "../app";
+import { runMigrations } from "../migrations/runMigrations";
+
+const clearPlatformTables = async () => {
+  await pool.query("delete from maintenance_records");
+  await pool.query("delete from maintenance_schedules");
+  await pool.query("delete from platforms");
+};
+
+describe("platform maintenance integration", () => {
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  beforeEach(async () => {
+    await clearPlatformTables();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("creates and reads a UAV platform with operational status", async () => {
+    const createResponse = await request(app)
+      .post("/platforms")
+      .send({
+        name: "UAV Alpha",
+        registration: "G-FSMS-001",
+        platformType: "multi-rotor",
+        manufacturer: "FSMS Test",
+        model: "Prototype X",
+        serialNumber: "SN-001",
+        status: "active",
+        totalFlightHours: 12.5,
+        notes: "Initial concept-test aircraft",
+      });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.platform).toMatchObject({
+      name: "UAV Alpha",
+      registration: "G-FSMS-001",
+      platformType: "multi-rotor",
+      manufacturer: "FSMS Test",
+      model: "Prototype X",
+      serialNumber: "SN-001",
+      status: "active",
+      totalFlightHours: 12.5,
+      notes: "Initial concept-test aircraft",
+    });
+
+    const platformId = createResponse.body.platform.id;
+
+    const readResponse = await request(app).get(`/platforms/${platformId}`);
+
+    expect(readResponse.status).toBe(200);
+    expect(readResponse.body.platform).toMatchObject({
+      id: platformId,
+      name: "UAV Alpha",
+      status: "active",
+    });
+  });
+
+  it("reports maintenance_due when an active platform has overdue maintenance", async () => {
+    const platformResponse = await request(app)
+      .post("/platforms")
+      .send({
+        name: "UAV Bravo",
+        status: "active",
+        totalFlightHours: 50,
+      });
+
+    const platformId = platformResponse.body.platform.id;
+
+    const scheduleResponse = await request(app)
+      .post(`/platforms/${platformId}/maintenance-schedules`)
+      .send({
+        taskName: "Airframe inspection",
+        description: "Routine airframe inspection",
+        intervalDays: 30,
+        intervalFlightHours: 25,
+        nextDueAt: "2026-01-01T00:00:00Z",
+        nextDueFlightHours: 40,
+      });
+
+    expect(scheduleResponse.status).toBe(201);
+    expect(scheduleResponse.body.schedule).toMatchObject({
+      platformId,
+      taskName: "Airframe inspection",
+      intervalDays: 30,
+      intervalFlightHours: 25,
+      nextDueAt: "2026-01-01T00:00:00.000Z",
+      nextDueFlightHours: 40,
+      status: "active",
+    });
+
+    const statusResponse = await request(app).get(
+      `/platforms/${platformId}/maintenance-status`,
+    );
+
+    expect(statusResponse.status).toBe(200);
+    expect(statusResponse.body.platform.id).toBe(platformId);
+    expect(statusResponse.body.platform.status).toBe("active");
+    expect(statusResponse.body.effectiveStatus).toBe("maintenance_due");
+    expect(statusResponse.body.dueSchedules).toHaveLength(1);
+    expect(statusResponse.body.dueSchedules[0]).toMatchObject({
+      taskName: "Airframe inspection",
+    });
+  });
+
+  it("records completed maintenance and updates the linked schedule due thresholds", async () => {
+    const platformResponse = await request(app)
+      .post("/platforms")
+      .send({
+        name: "UAV Charlie",
+        status: "active",
+        totalFlightHours: 10,
+      });
+
+    const platformId = platformResponse.body.platform.id;
+
+    const scheduleResponse = await request(app)
+      .post(`/platforms/${platformId}/maintenance-schedules`)
+      .send({
+        taskName: "Propeller replacement",
+        intervalDays: 30,
+        intervalFlightHours: 25,
+        nextDueAt: "2026-01-01T00:00:00Z",
+        nextDueFlightHours: 5,
+      });
+
+    const scheduleId = scheduleResponse.body.schedule.id;
+
+    const recordResponse = await request(app)
+      .post(`/platforms/${platformId}/maintenance-records`)
+      .send({
+        scheduleId,
+        completedAt: "2026-04-15T10:00:00Z",
+        completedBy: "engineer-1",
+        completedFlightHours: 12,
+        notes: "Props replaced and checked",
+        evidenceRef: "maint-2026-04-15-props",
+      });
+
+    expect(recordResponse.status).toBe(201);
+    expect(recordResponse.body.record).toMatchObject({
+      platformId,
+      scheduleId,
+      taskName: "Propeller replacement",
+      completedAt: "2026-04-15T10:00:00.000Z",
+      completedBy: "engineer-1",
+      completedFlightHours: 12,
+      notes: "Props replaced and checked",
+      evidenceRef: "maint-2026-04-15-props",
+    });
+
+    const statusResponse = await request(app).get(
+      `/platforms/${platformId}/maintenance-status`,
+    );
+
+    expect(statusResponse.status).toBe(200);
+    expect(statusResponse.body.effectiveStatus).toBe("active");
+    expect(statusResponse.body.dueSchedules).toEqual([]);
+    expect(statusResponse.body.upcomingSchedules).toHaveLength(1);
+    expect(statusResponse.body.upcomingSchedules[0]).toMatchObject({
+      id: scheduleId,
+      lastCompletedAt: "2026-04-15T10:00:00.000Z",
+      lastCompletedFlightHours: 12,
+      nextDueAt: "2026-05-15T10:00:00.000Z",
+      nextDueFlightHours: 37,
+    });
+    expect(statusResponse.body.latestRecords).toHaveLength(1);
+  });
+
+  it("rejects incomplete maintenance records without mutating stored records", async () => {
+    const platformResponse = await request(app)
+      .post("/platforms")
+      .send({
+        name: "UAV Delta",
+      });
+
+    const platformId = platformResponse.body.platform.id;
+
+    const invalidResponse = await request(app)
+      .post(`/platforms/${platformId}/maintenance-records`)
+      .send({
+        completedAt: "2026-04-15T10:00:00Z",
+        completedBy: "engineer-1",
+      });
+
+    expect(invalidResponse.status).toBe(400);
+    expect(invalidResponse.body).toMatchObject({
+      error: {
+        type: "platform_validation_error",
+        message: "taskName is required when scheduleId is not provided",
+      },
+    });
+
+    const statusResponse = await request(app).get(
+      `/platforms/${platformId}/maintenance-status`,
+    );
+
+    expect(statusResponse.status).toBe(200);
+    expect(statusResponse.body.latestRecords).toEqual([]);
+  });
+
+  it("rejects maintenance schedules for unknown platforms", async () => {
+    const response = await request(app)
+      .post("/platforms/7a2ed2c4-e238-4743-aa60-5bcd5a50d7b7/maintenance-schedules")
+      .send({
+        taskName: "Battery health check",
+        intervalDays: 7,
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "platform_not_found",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements issue #4 by adding the first platform and maintenance foundation for UAV readiness.

## What changed
- Added `platforms`, `maintenance_schedules`, and `maintenance_records` tables.
- Added platform domain types, validation, repository, service, controller, and routes.
- Added `/platforms` endpoints for:
  - creating a platform
  - reading a platform
  - adding maintenance schedules
  - recording completed maintenance
  - reading maintenance status
- Added maintenance status calculation that reports `maintenance_due` when an active platform has overdue maintenance.
- Added integration tests for platform creation, overdue maintenance, maintenance completion, validation, and unknown platform handling.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/platform-maintenance.test.ts` passed: 5 tests.
- `./node_modules/.bin/vitest.cmd run src/tests/mission-replay.test.ts src/tests/telemetry.test.ts` passed: 20 tests.

Closes #4.
