### PR TITLE
Add platform readiness assurance checks #7

### DIFF
--- a/src/platforms/platform.controller.ts
+++ b/src/platforms/platform.controller.ts
@@ -78,4 +78,19 @@ export class PlatformController {
       next(error);
     }
   };
+
+  getReadiness = async (
+    req: Request<PlatformIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const readiness = await this.platformService.checkPlatformReadiness(
+        req.params.id,
+      );
+      res.status(200).json(readiness);
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/platforms/platform.routes.ts
+++ b/src/platforms/platform.routes.ts
@@ -9,6 +9,7 @@ export function createPlatformRouter(controller: PlatformController): Router {
   router.post("/:id/maintenance-schedules", controller.createMaintenanceSchedule);
   router.post("/:id/maintenance-records", controller.createMaintenanceRecord);
   router.get("/:id/maintenance-status", controller.getMaintenanceStatus);
+  router.get("/:id/readiness", controller.getReadiness);
 
   return router;
 }

--- a/src/platforms/platform.service.ts
+++ b/src/platforms/platform.service.ts
@@ -11,6 +11,9 @@ import type {
   CreatePlatformInput,
   MaintenanceSchedule,
   PlatformMaintenanceStatus,
+  PlatformReadinessCheck,
+  PlatformReadinessReason,
+  PlatformReadinessResult,
 } from "./platform.types";
 import {
   validateCreateMaintenanceRecordInput,
@@ -204,6 +207,20 @@ export class PlatformService {
     }
   }
 
+  async checkPlatformReadiness(
+    platformId: string,
+  ): Promise<PlatformReadinessCheck> {
+    const maintenanceStatus = await this.getMaintenanceStatus(platformId);
+    const reasons = this.buildReadinessReasons(maintenanceStatus);
+
+    return {
+      platformId,
+      result: this.getReadinessResult(reasons),
+      reasons,
+      maintenanceStatus,
+    };
+  }
+
   private computeNextDueAt(
     schedule: MaintenanceSchedule,
     completedAt: Date,
@@ -246,5 +263,74 @@ export class PlatformService {
       schedule.nextDueFlightHours <= platformTotalFlightHours;
 
     return dueByDate || dueByHours;
+  }
+
+  private buildReadinessReasons(
+    maintenanceStatus: PlatformMaintenanceStatus,
+  ): PlatformReadinessReason[] {
+    const { platform, dueSchedules } = maintenanceStatus;
+
+    if (platform.status === "grounded") {
+      return [
+        {
+          code: "PLATFORM_GROUNDED",
+          severity: "fail",
+          message: "Platform is grounded and is not fit for mission use",
+        },
+      ];
+    }
+
+    if (platform.status === "retired") {
+      return [
+        {
+          code: "PLATFORM_RETIRED",
+          severity: "fail",
+          message: "Platform is retired and is not fit for mission use",
+        },
+      ];
+    }
+
+    const reasons: PlatformReadinessReason[] = [];
+
+    if (platform.status === "inactive") {
+      reasons.push({
+        code: "PLATFORM_INACTIVE",
+        severity: "warning",
+        message: "Platform is inactive and requires review before mission use",
+      });
+    }
+
+    if (platform.status === "maintenance_due" || dueSchedules.length > 0) {
+      reasons.push({
+        code: "PLATFORM_MAINTENANCE_DUE",
+        severity: "warning",
+        message: "Platform has overdue maintenance requiring review before mission use",
+        relatedScheduleIds: dueSchedules.map((schedule) => schedule.id),
+      });
+    }
+
+    if (reasons.length === 0) {
+      reasons.push({
+        code: "PLATFORM_ACTIVE",
+        severity: "pass",
+        message: "Platform is active with no overdue maintenance",
+      });
+    }
+
+    return reasons;
+  }
+
+  private getReadinessResult(
+    reasons: PlatformReadinessReason[],
+  ): PlatformReadinessResult {
+    if (reasons.some((reason) => reason.severity === "fail")) {
+      return "fail";
+    }
+
+    if (reasons.some((reason) => reason.severity === "warning")) {
+      return "warning";
+    }
+
+    return "pass";
   }
 }

--- a/src/platforms/platform.types.ts
+++ b/src/platforms/platform.types.ts
@@ -90,3 +90,26 @@ export interface PlatformMaintenanceStatus {
   upcomingSchedules: MaintenanceSchedule[];
   latestRecords: MaintenanceRecord[];
 }
+
+export type PlatformReadinessResult = "pass" | "warning" | "fail";
+
+export type PlatformReadinessReasonCode =
+  | "PLATFORM_ACTIVE"
+  | "PLATFORM_INACTIVE"
+  | "PLATFORM_MAINTENANCE_DUE"
+  | "PLATFORM_GROUNDED"
+  | "PLATFORM_RETIRED";
+
+export interface PlatformReadinessReason {
+  code: PlatformReadinessReasonCode;
+  severity: PlatformReadinessResult;
+  message: string;
+  relatedScheduleIds?: string[];
+}
+
+export interface PlatformReadinessCheck {
+  platformId: string;
+  result: PlatformReadinessResult;
+  reasons: PlatformReadinessReason[];
+  maintenanceStatus: PlatformMaintenanceStatus;
+}

--- a/src/tests/platform-readiness.test.ts
+++ b/src/tests/platform-readiness.test.ts
@@ -1,0 +1,179 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import app, { pool } from "../app";
+import { runMigrations } from "../migrations/runMigrations";
+
+const clearPlatformTables = async () => {
+  await pool.query("delete from maintenance_records");
+  await pool.query("delete from maintenance_schedules");
+  await pool.query("delete from platforms");
+};
+
+const createPlatform = async (params: {
+  name: string;
+  status?: string;
+  totalFlightHours?: number;
+}) => {
+  const response = await request(app).post("/platforms").send(params);
+  expect(response.status).toBe(201);
+  return response.body.platform as { id: string };
+};
+
+const countPlatformRows = async (platformId: string) => {
+  const result = await pool.query(
+    `
+    select
+      (select count(*)::int from platforms where id = $1) as platform_count,
+      (select count(*)::int from maintenance_schedules where platform_id = $1) as schedule_count,
+      (select count(*)::int from maintenance_records where platform_id = $1) as record_count
+    `,
+    [platformId],
+  );
+
+  return result.rows[0] as {
+    platform_count: number;
+    schedule_count: number;
+    record_count: number;
+  };
+};
+
+describe("platform readiness integration", () => {
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  beforeEach(async () => {
+    await clearPlatformTables();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("passes readiness for an active platform with no overdue maintenance", async () => {
+    const platform = await createPlatform({
+      name: "Ready UAV",
+      status: "active",
+      totalFlightHours: 10,
+    });
+
+    const before = await countPlatformRows(platform.id);
+    const response = await request(app).get(`/platforms/${platform.id}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      platformId: platform.id,
+      result: "pass",
+      reasons: [
+        {
+          code: "PLATFORM_ACTIVE",
+          severity: "pass",
+          message: "Platform is active with no overdue maintenance",
+        },
+      ],
+    });
+    expect(response.body.maintenanceStatus.effectiveStatus).toBe("active");
+    expect(await countPlatformRows(platform.id)).toEqual(before);
+  });
+
+  it("warns readiness for an active platform with overdue maintenance", async () => {
+    const platform = await createPlatform({
+      name: "Due UAV",
+      status: "active",
+      totalFlightHours: 50,
+    });
+
+    const scheduleResponse = await request(app)
+      .post(`/platforms/${platform.id}/maintenance-schedules`)
+      .send({
+        taskName: "Airframe inspection",
+        nextDueFlightHours: 40,
+      });
+
+    expect(scheduleResponse.status).toBe(201);
+    const scheduleId = scheduleResponse.body.schedule.id;
+    const before = await countPlatformRows(platform.id);
+
+    const response = await request(app).get(`/platforms/${platform.id}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.result).toBe("warning");
+    expect(response.body.reasons).toContainEqual({
+      code: "PLATFORM_MAINTENANCE_DUE",
+      severity: "warning",
+      message: "Platform has overdue maintenance requiring review before mission use",
+      relatedScheduleIds: [scheduleId],
+    });
+    expect(response.body.maintenanceStatus.effectiveStatus).toBe("maintenance_due");
+    expect(response.body.maintenanceStatus.dueSchedules).toHaveLength(1);
+    expect(await countPlatformRows(platform.id)).toEqual(before);
+  });
+
+  it("warns readiness for an inactive platform", async () => {
+    const platform = await createPlatform({
+      name: "Inactive UAV",
+      status: "inactive",
+    });
+
+    const response = await request(app).get(`/platforms/${platform.id}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      platformId: platform.id,
+      result: "warning",
+      reasons: [
+        {
+          code: "PLATFORM_INACTIVE",
+          severity: "warning",
+          message: "Platform is inactive and requires review before mission use",
+        },
+      ],
+    });
+  });
+
+  it.each([
+    {
+      status: "grounded",
+      code: "PLATFORM_GROUNDED",
+      message: "Platform is grounded and is not fit for mission use",
+    },
+    {
+      status: "retired",
+      code: "PLATFORM_RETIRED",
+      message: "Platform is retired and is not fit for mission use",
+    },
+  ])("fails readiness for a $status platform", async ({ status, code, message }) => {
+    const platform = await createPlatform({
+      name: `${status} UAV`,
+      status,
+    });
+
+    const response = await request(app).get(`/platforms/${platform.id}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      platformId: platform.id,
+      result: "fail",
+      reasons: [
+        {
+          code,
+          severity: "fail",
+          message,
+        },
+      ],
+    });
+  });
+
+  it("returns not found for unknown platforms", async () => {
+    const response = await request(app).get(
+      "/platforms/7a2ed2c4-e238-4743-aa60-5bcd5a50d7b7/readiness",
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "platform_not_found",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements issue #7 by adding a read-only platform readiness check on top of platform maintenance status.

## What changed
- Added platform readiness result and reason types.
- Added `GET /platforms/:id/readiness`.
- Added readiness logic for active, inactive, overdue maintenance, grounded, and retired platforms.
- Returned machine-readable reasons, including related overdue maintenance schedule IDs.
- Added integration tests covering pass, overdue maintenance warning, inactive warning, grounded/retired fail, unknown platform, and read-only behaviour.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/platform-readiness.test.ts src/tests/platform-maintenance.test.ts` passed: 11 tests.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #7.
