### PR TITLE
Connect platform readiness into mission planning gates #9

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add platform readiness assurance checks against the platform maintenance schema so mission gates can detect overdue maintenance.",
+ "nextBuildStep": "Add pilot readiness assurance checks so mission gates can combine platform and operator fitness.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -66,8 +66,6 @@ const pool = new Pool({
 const db = new Db(pool);
 const missionRepo = new MissionRepository();
 const missionEventRepo = new MissionEventRepository();
-const missionService = new MissionService(db, missionRepo, missionEventRepo);
-const missionController = new MissionController(missionService);
 
 const missionLifecyclePolicy = new MissionLifecyclePolicy();
 const missionTelemetryRepo = new MissionTelemetryRepository();
@@ -96,6 +94,13 @@ const timelineService = new TimelineService(pool);
 const platformRepository = new PlatformRepository();
 const platformService = new PlatformService(pool, platformRepository);
 const platformController = new PlatformController(platformService);
+const missionService = new MissionService(
+  db,
+  missionRepo,
+  missionEventRepo,
+  platformService,
+);
+const missionController = new MissionController(missionService);
 
 app.use("/missions", createMissionRouter(missionController));
 app.use("/missions", createMissionReplayRouter(missionReplayController));

--- a/src/migrations/009_add_mission_platform_assignment.sql
+++ b/src/migrations/009_add_mission_platform_assignment.sql
@@ -1,0 +1,5 @@
+alter table missions
+add column if not exists platform_id uuid null references platforms(id) on delete set null;
+
+create index if not exists idx_missions_platform_id
+  on missions (platform_id);

--- a/src/missions/mission-readiness.types.ts
+++ b/src/missions/mission-readiness.types.ts
@@ -1,0 +1,35 @@
+import type { PlatformReadinessCheck } from "../platforms/platform.types";
+
+export type MissionReadinessResult = "pass" | "warning" | "fail";
+
+export type MissionReadinessReasonCode =
+  | "MISSION_PLATFORM_READY"
+  | "MISSION_PLATFORM_WARNING"
+  | "MISSION_PLATFORM_FAILED"
+  | "MISSION_PLATFORM_NOT_ASSIGNED"
+  | "MISSION_PLATFORM_NOT_FOUND";
+
+export interface MissionReadinessReason {
+  code: MissionReadinessReasonCode;
+  severity: MissionReadinessResult;
+  message: string;
+  source: "mission" | "platform";
+  relatedPlatformId?: string;
+  relatedPlatformReasonCodes?: string[];
+}
+
+export interface MissionReadinessGate {
+  result: MissionReadinessResult;
+  blocksApproval: boolean;
+  blocksDispatch: boolean;
+  requiresReview: boolean;
+}
+
+export interface MissionReadinessCheck {
+  missionId: string;
+  platformId: string | null;
+  result: MissionReadinessResult;
+  gate: MissionReadinessGate;
+  reasons: MissionReadinessReason[];
+  platformReadiness: PlatformReadinessCheck | null;
+}

--- a/src/missions/mission.controller.ts
+++ b/src/missions/mission.controller.ts
@@ -67,6 +67,26 @@ export class MissionController {
     }
   };
 
+  checkReadiness = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const missionId = this.requireString(req.params.missionId, "missionId");
+      const platformId = this.optionalString(req.query.platformId);
+
+      const result = await this.missionService.checkMissionReadiness({
+        missionId,
+        platformId,
+      });
+
+      res.status(200).json(result);
+    } catch (error) {
+      next(error);
+    }
+  };
+
   submitMission = async (
     req: Request,
     res: Response,

--- a/src/missions/mission.repository.ts
+++ b/src/missions/mission.repository.ts
@@ -8,6 +8,7 @@ export interface MissionRow {
   id: string;
   status: MissionStatus;
   mission_plan_id: string | null;
+  platform_id: string | null;
   last_event_sequence_no: number;
 }
 
@@ -35,6 +36,7 @@ export class MissionRepository implements MissionSequenceAllocator {
         id,
         status,
         mission_plan_id,
+        platform_id,
         last_event_sequence_no
       from missions
       where id = $1
@@ -87,6 +89,7 @@ export class MissionRepository implements MissionSequenceAllocator {
         id,
         status,
         mission_plan_id,
+        platform_id,
         last_event_sequence_no
       from missions
       where id = $1

--- a/src/missions/mission.routes.ts
+++ b/src/missions/mission.routes.ts
@@ -13,6 +13,7 @@ export function createMissionRouter(
   router.post("/:missionId/abort", missionController.abortMission);
 
   router.get("/:missionId/events", missionController.getMissionEvents);
+  router.get("/:missionId/readiness", missionController.checkReadiness);
   router.get(
     "/:missionId/transitions/:action/check",
     missionController.checkTransition,

--- a/src/missions/mission.service.ts
+++ b/src/missions/mission.service.ts
@@ -6,6 +6,13 @@ import {
   checkMissionActionAllowed,
   MissionLifecycleAction,
 } from "../modules/missions/domain/missionLifecycle";
+import { PlatformNotFoundError } from "../platforms/platform.errors";
+import { PlatformService } from "../platforms/platform.service";
+import type {
+  MissionReadinessCheck,
+  MissionReadinessReason,
+  MissionReadinessResult,
+} from "./mission-readiness.types";
 
 export interface GetMissionEventsFilters {
   safety?: boolean;
@@ -42,6 +49,7 @@ export class MissionService {
     private readonly db: Db,
     private readonly missionRepo: MissionRepository,
     private readonly missionEventRepo: MissionEventRepository,
+    private readonly platformService?: PlatformService,
   ) {}
 
   async submitMission(params: {
@@ -225,6 +233,88 @@ export class MissionService {
   });
 }
 
+  async checkMissionReadiness(params: {
+    missionId: string;
+    platformId?: string;
+  }): Promise<MissionReadinessCheck> {
+    const mission = await this.db.transaction(async (tx) =>
+      this.missionRepo.getById(tx, params.missionId),
+    );
+    const platformId = params.platformId ?? mission.platform_id;
+
+    if (!platformId) {
+      return this.buildMissionReadiness({
+        missionId: mission.id,
+        platformId: null,
+        reasons: [
+          {
+            code: "MISSION_PLATFORM_NOT_ASSIGNED",
+            severity: "fail",
+            message: "Mission has no assigned platform for readiness evaluation",
+            source: "mission",
+          },
+        ],
+        platformReadiness: null,
+      });
+    }
+
+    if (!this.platformService) {
+      return this.buildMissionReadiness({
+        missionId: mission.id,
+        platformId,
+        reasons: [
+          {
+            code: "MISSION_PLATFORM_NOT_FOUND",
+            severity: "fail",
+            message: "Platform readiness service is not available",
+            source: "mission",
+            relatedPlatformId: platformId,
+          },
+        ],
+        platformReadiness: null,
+      });
+    }
+
+    try {
+      const platformReadiness =
+        await this.platformService.checkPlatformReadiness(platformId);
+      const platformReasonCodes = platformReadiness.reasons.map(
+        (reason) => reason.code,
+      );
+      const reason = this.mapPlatformReadinessReason(
+        platformReadiness.result,
+        platformId,
+        platformReasonCodes,
+      );
+
+      return this.buildMissionReadiness({
+        missionId: mission.id,
+        platformId,
+        reasons: [reason],
+        platformReadiness,
+      });
+    } catch (error) {
+      if (error instanceof PlatformNotFoundError) {
+        return this.buildMissionReadiness({
+          missionId: mission.id,
+          platformId,
+          reasons: [
+            {
+              code: "MISSION_PLATFORM_NOT_FOUND",
+              severity: "fail",
+              message: `Assigned platform was not found: ${platformId}`,
+              source: "mission",
+              relatedPlatformId: platformId,
+            },
+          ],
+          platformReadiness: null,
+        });
+      }
+
+      throw error;
+    }
+  }
+
   async getMissionEvents(
     missionId: string,
     filters: GetMissionEventsFilters = {},
@@ -257,5 +347,79 @@ export class MissionService {
         requestId: row.request_id,
       }));
     });
+  }
+
+  private mapPlatformReadinessReason(
+    result: MissionReadinessResult,
+    platformId: string,
+    platformReasonCodes: string[],
+  ): MissionReadinessReason {
+    if (result === "fail") {
+      return {
+        code: "MISSION_PLATFORM_FAILED",
+        severity: "fail",
+        message: "Assigned platform fails readiness and blocks mission approval or dispatch",
+        source: "platform",
+        relatedPlatformId: platformId,
+        relatedPlatformReasonCodes: platformReasonCodes,
+      };
+    }
+
+    if (result === "warning") {
+      return {
+        code: "MISSION_PLATFORM_WARNING",
+        severity: "warning",
+        message: "Assigned platform has readiness warnings requiring review before approval or dispatch",
+        source: "platform",
+        relatedPlatformId: platformId,
+        relatedPlatformReasonCodes: platformReasonCodes,
+      };
+    }
+
+    return {
+      code: "MISSION_PLATFORM_READY",
+      severity: "pass",
+      message: "Assigned platform passes readiness for mission approval and dispatch",
+      source: "platform",
+      relatedPlatformId: platformId,
+      relatedPlatformReasonCodes: platformReasonCodes,
+    };
+  }
+
+  private buildMissionReadiness(params: {
+    missionId: string;
+    platformId: string | null;
+    reasons: MissionReadinessReason[];
+    platformReadiness: MissionReadinessCheck["platformReadiness"];
+  }): MissionReadinessCheck {
+    const result = this.getMissionReadinessResult(params.reasons);
+
+    return {
+      missionId: params.missionId,
+      platformId: params.platformId,
+      result,
+      gate: {
+        result,
+        blocksApproval: result === "fail",
+        blocksDispatch: result === "fail",
+        requiresReview: result === "warning",
+      },
+      reasons: params.reasons,
+      platformReadiness: params.platformReadiness,
+    };
+  }
+
+  private getMissionReadinessResult(
+    reasons: MissionReadinessReason[],
+  ): MissionReadinessResult {
+    if (reasons.some((reason) => reason.severity === "fail")) {
+      return "fail";
+    }
+
+    if (reasons.some((reason) => reason.severity === "warning")) {
+      return "warning";
+    }
+
+    return "pass";
   }
 }

--- a/src/tests/mission-readiness.test.ts
+++ b/src/tests/mission-readiness.test.ts
@@ -1,0 +1,290 @@
+import { randomUUID } from "crypto";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import app, { pool } from "../app";
+import { runMigrations } from "../migrations/runMigrations";
+
+const clearTables = async () => {
+  await pool.query("delete from mission_events");
+  await pool.query("delete from missions");
+  await pool.query("delete from maintenance_records");
+  await pool.query("delete from maintenance_schedules");
+  await pool.query("delete from platforms");
+};
+
+const createPlatform = async (params: {
+  name: string;
+  status?: string;
+  totalFlightHours?: number;
+}) => {
+  const response = await request(app).post("/platforms").send(params);
+  expect(response.status).toBe(201);
+  return response.body.platform as { id: string };
+};
+
+const insertMission = async (params: {
+  id?: string;
+  status?: string;
+  platformId?: string | null;
+}) => {
+  const missionId = params.id ?? randomUUID();
+
+  await pool.query(
+    `
+    insert into missions (
+      id,
+      status,
+      mission_plan_id,
+      platform_id,
+      last_event_sequence_no
+    )
+    values ($1, $2, $3, $4, $5)
+    `,
+    [
+      missionId,
+      params.status ?? "submitted",
+      "plan-1",
+      params.platformId ?? null,
+      0,
+    ],
+  );
+
+  return missionId;
+};
+
+const countRows = async (params: { missionId: string; platformId?: string }) => {
+  const result = await pool.query(
+    `
+    select
+      (select status from missions where id = $1) as mission_status,
+      (select last_event_sequence_no from missions where id = $1) as mission_sequence,
+      (select count(*)::int from mission_events where mission_id = $1) as mission_event_count,
+      (select count(*)::int from platforms where id = $2) as platform_count,
+      (select count(*)::int from maintenance_schedules where platform_id = $2) as schedule_count,
+      (select count(*)::int from maintenance_records where platform_id = $2) as record_count
+    `,
+    [params.missionId, params.platformId ?? null],
+  );
+
+  return result.rows[0] as {
+    mission_status: string;
+    mission_sequence: number;
+    mission_event_count: number;
+    platform_count: number;
+    schedule_count: number;
+    record_count: number;
+  };
+};
+
+describe("mission readiness platform gate integration", () => {
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  beforeEach(async () => {
+    await clearTables();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("passes the mission platform gate when the assigned platform is ready", async () => {
+    const platform = await createPlatform({
+      name: "Mission Ready UAV",
+      status: "active",
+    });
+    const missionId = await insertMission({ platformId: platform.id });
+    const before = await countRows({ missionId, platformId: platform.id });
+
+    const response = await request(app).get(`/missions/${missionId}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      platformId: platform.id,
+      result: "pass",
+      gate: {
+        result: "pass",
+        blocksApproval: false,
+        blocksDispatch: false,
+        requiresReview: false,
+      },
+      reasons: [
+        {
+          code: "MISSION_PLATFORM_READY",
+          severity: "pass",
+          source: "platform",
+          relatedPlatformId: platform.id,
+          relatedPlatformReasonCodes: ["PLATFORM_ACTIVE"],
+        },
+      ],
+      platformReadiness: {
+        platformId: platform.id,
+        result: "pass",
+      },
+    });
+    expect(await countRows({ missionId, platformId: platform.id })).toEqual(before);
+  });
+
+  it("surfaces a warning when the assigned platform has overdue maintenance", async () => {
+    const platform = await createPlatform({
+      name: "Maintenance Due UAV",
+      status: "active",
+      totalFlightHours: 55,
+    });
+    const missionId = await insertMission({ platformId: platform.id });
+
+    const scheduleResponse = await request(app)
+      .post(`/platforms/${platform.id}/maintenance-schedules`)
+      .send({
+        taskName: "Propulsion inspection",
+        nextDueFlightHours: 50,
+      });
+
+    expect(scheduleResponse.status).toBe(201);
+    const before = await countRows({ missionId, platformId: platform.id });
+
+    const response = await request(app).get(`/missions/${missionId}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      platformId: platform.id,
+      result: "warning",
+      gate: {
+        result: "warning",
+        blocksApproval: false,
+        blocksDispatch: false,
+        requiresReview: true,
+      },
+      reasons: [
+        {
+          code: "MISSION_PLATFORM_WARNING",
+          severity: "warning",
+          source: "platform",
+          relatedPlatformId: platform.id,
+          relatedPlatformReasonCodes: ["PLATFORM_MAINTENANCE_DUE"],
+        },
+      ],
+      platformReadiness: {
+        platformId: platform.id,
+        result: "warning",
+      },
+    });
+    expect(await countRows({ missionId, platformId: platform.id })).toEqual(before);
+  });
+
+  it.each([
+    {
+      status: "grounded",
+      platformCode: "PLATFORM_GROUNDED",
+    },
+    {
+      status: "retired",
+      platformCode: "PLATFORM_RETIRED",
+    },
+  ])("fails the mission platform gate for a $status platform", async ({ status, platformCode }) => {
+    const platform = await createPlatform({
+      name: `${status} UAV`,
+      status,
+    });
+    const missionId = await insertMission({ platformId: platform.id });
+    const before = await countRows({ missionId, platformId: platform.id });
+
+    const response = await request(app).get(`/missions/${missionId}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      platformId: platform.id,
+      result: "fail",
+      gate: {
+        result: "fail",
+        blocksApproval: true,
+        blocksDispatch: true,
+        requiresReview: false,
+      },
+      reasons: [
+        {
+          code: "MISSION_PLATFORM_FAILED",
+          severity: "fail",
+          source: "platform",
+          relatedPlatformId: platform.id,
+          relatedPlatformReasonCodes: [platformCode],
+        },
+      ],
+      platformReadiness: {
+        platformId: platform.id,
+        result: "fail",
+      },
+    });
+    expect(await countRows({ missionId, platformId: platform.id })).toEqual(before);
+  });
+
+  it("fails explicitly when the mission has no assigned platform", async () => {
+    const missionId = await insertMission({ platformId: null });
+    const before = await countRows({ missionId });
+
+    const response = await request(app).get(`/missions/${missionId}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      platformId: null,
+      result: "fail",
+      gate: {
+        result: "fail",
+        blocksApproval: true,
+        blocksDispatch: true,
+        requiresReview: false,
+      },
+      reasons: [
+        {
+          code: "MISSION_PLATFORM_NOT_ASSIGNED",
+          severity: "fail",
+          source: "mission",
+        },
+      ],
+      platformReadiness: null,
+    });
+    expect(await countRows({ missionId })).toEqual(before);
+  });
+
+  it("fails explicitly when a candidate platform override is unknown", async () => {
+    const platform = await createPlatform({
+      name: "Assigned UAV",
+      status: "active",
+    });
+    const missingPlatformId = randomUUID();
+    const missionId = await insertMission({ platformId: platform.id });
+    const before = await countRows({ missionId, platformId: platform.id });
+
+    const response = await request(app)
+      .get(`/missions/${missionId}/readiness`)
+      .query({ platformId: missingPlatformId });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      platformId: missingPlatformId,
+      result: "fail",
+      gate: {
+        result: "fail",
+        blocksApproval: true,
+        blocksDispatch: true,
+        requiresReview: false,
+      },
+      reasons: [
+        {
+          code: "MISSION_PLATFORM_NOT_FOUND",
+          severity: "fail",
+          source: "mission",
+          relatedPlatformId: missingPlatformId,
+        },
+      ],
+      platformReadiness: null,
+    });
+    expect(await countRows({ missionId, platformId: platform.id })).toEqual(before);
+  });
+});


### PR DESCRIPTION
## Summary
Implements issue #9 by connecting platform readiness into a read-only mission planning gate.

## What changed
- Added nullable `missions.platform_id` assignment with a foreign key to `platforms`.
- Added `GET /missions/:missionId/readiness` for mission-level platform gate evaluation.
- Reused the existing TypeScript platform readiness service so mission gates do not duplicate maintenance/status rules.
- Added machine-readable mission readiness reasons for ready, warning, failed, missing assignment, and unknown candidate platform cases.
- Returned gate flags for approval/dispatch blocking and warning review requirements.
- Updated the next build step toward pilot readiness checks.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/mission-readiness.test.ts src/tests/platform-readiness.test.ts` passed: 12 tests.
- `./node_modules/.bin/vitest.cmd run src/tests/mission-lifecycle.test.ts src/tests/mission.transition-matrix.integration.test.ts` passed: 34 tests.
- `./node_modules/.bin/vitest.cmd run src/tests/mission-replay.test.ts src/tests/telemetry.test.ts` passed: 20 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 118 tests.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #9.
