### PR TITLE
Add pilot readiness assurance checks #11

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add pilot readiness assurance checks so mission gates can combine platform and operator fitness.",
+ "nextBuildStep": "Add mission risk scoring inputs so mission gates can combine platform, pilot, and operational risk.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,6 +30,10 @@ import { PlatformRepository } from "./platforms/platform.repository";
 import { PlatformService } from "./platforms/platform.service";
 import { PlatformController } from "./platforms/platform.controller";
 import { createPlatformRouter } from "./platforms/platform.routes";
+import { PilotRepository } from "./pilots/pilot.repository";
+import { PilotService } from "./pilots/pilot.service";
+import { PilotController } from "./pilots/pilot.controller";
+import { createPilotRouter } from "./pilots/pilot.routes";
 
 dotenv.config({
   path: path.resolve(process.cwd(), ".env"),
@@ -94,11 +98,15 @@ const timelineService = new TimelineService(pool);
 const platformRepository = new PlatformRepository();
 const platformService = new PlatformService(pool, platformRepository);
 const platformController = new PlatformController(platformService);
+const pilotRepository = new PilotRepository();
+const pilotService = new PilotService(pool, pilotRepository);
+const pilotController = new PilotController(pilotService);
 const missionService = new MissionService(
   db,
   missionRepo,
   missionEventRepo,
   platformService,
+  pilotService,
 );
 const missionController = new MissionController(missionService);
 
@@ -107,6 +115,7 @@ app.use("/missions", createMissionReplayRouter(missionReplayController));
 app.use("/missions", createMissionTelemetryRouter(missionTelemetryController));
 app.use("/missions", createAlertRouter(alertController));
 app.use("/platforms", createPlatformRouter(platformController));
+app.use("/pilots", createPilotRouter(pilotController));
 app.use("/timeline", createTimelineRouter(timelineService));
 app.get("/", (_req, res) => {
   res.status(200).send("FSMS backend is running");

--- a/src/migrations/010_create_pilots_readiness.sql
+++ b/src/migrations/010_create_pilots_readiness.sql
@@ -1,0 +1,43 @@
+create table if not exists pilots (
+  id uuid primary key,
+  display_name text not null,
+  caa_reference text null,
+  status text not null default 'active',
+  notes text null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint pilots_status_chk
+    check (status in ('active', 'inactive', 'suspended', 'retired'))
+);
+
+create unique index if not exists idx_pilots_caa_reference_unique
+  on pilots (caa_reference)
+  where caa_reference is not null;
+
+create index if not exists idx_pilots_status
+  on pilots (status);
+
+create table if not exists pilot_readiness_evidence (
+  id uuid primary key,
+  pilot_id uuid not null references pilots(id) on delete cascade,
+  evidence_type text not null,
+  title text not null,
+  issued_at timestamptz null,
+  expires_at timestamptz null,
+  status text not null default 'active',
+  evidence_ref text null,
+  notes text null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint pilot_readiness_evidence_status_chk
+    check (status in ('active', 'inactive', 'revoked'))
+);
+
+create index if not exists idx_pilot_readiness_evidence_pilot
+  on pilot_readiness_evidence (pilot_id);
+
+alter table missions
+add column if not exists pilot_id uuid null references pilots(id) on delete set null;
+
+create index if not exists idx_missions_pilot_id
+  on missions (pilot_id);

--- a/src/missions/mission-readiness.types.ts
+++ b/src/missions/mission-readiness.types.ts
@@ -1,4 +1,5 @@
 import type { PlatformReadinessCheck } from "../platforms/platform.types";
+import type { PilotReadinessCheck } from "../pilots/pilot.types";
 
 export type MissionReadinessResult = "pass" | "warning" | "fail";
 
@@ -7,15 +8,22 @@ export type MissionReadinessReasonCode =
   | "MISSION_PLATFORM_WARNING"
   | "MISSION_PLATFORM_FAILED"
   | "MISSION_PLATFORM_NOT_ASSIGNED"
-  | "MISSION_PLATFORM_NOT_FOUND";
+  | "MISSION_PLATFORM_NOT_FOUND"
+  | "MISSION_PILOT_READY"
+  | "MISSION_PILOT_WARNING"
+  | "MISSION_PILOT_FAILED"
+  | "MISSION_PILOT_NOT_ASSIGNED"
+  | "MISSION_PILOT_NOT_FOUND";
 
 export interface MissionReadinessReason {
   code: MissionReadinessReasonCode;
   severity: MissionReadinessResult;
   message: string;
-  source: "mission" | "platform";
+  source: "mission" | "platform" | "pilot";
   relatedPlatformId?: string;
   relatedPlatformReasonCodes?: string[];
+  relatedPilotId?: string;
+  relatedPilotReasonCodes?: string[];
 }
 
 export interface MissionReadinessGate {
@@ -28,8 +36,10 @@ export interface MissionReadinessGate {
 export interface MissionReadinessCheck {
   missionId: string;
   platformId: string | null;
+  pilotId: string | null;
   result: MissionReadinessResult;
   gate: MissionReadinessGate;
   reasons: MissionReadinessReason[];
   platformReadiness: PlatformReadinessCheck | null;
+  pilotReadiness: PilotReadinessCheck | null;
 }

--- a/src/missions/mission.controller.ts
+++ b/src/missions/mission.controller.ts
@@ -75,10 +75,12 @@ export class MissionController {
     try {
       const missionId = this.requireString(req.params.missionId, "missionId");
       const platformId = this.optionalString(req.query.platformId);
+      const pilotId = this.optionalString(req.query.pilotId);
 
       const result = await this.missionService.checkMissionReadiness({
         missionId,
         platformId,
+        pilotId,
       });
 
       res.status(200).json(result);

--- a/src/missions/mission.repository.ts
+++ b/src/missions/mission.repository.ts
@@ -9,6 +9,7 @@ export interface MissionRow {
   status: MissionStatus;
   mission_plan_id: string | null;
   platform_id: string | null;
+  pilot_id: string | null;
   last_event_sequence_no: number;
 }
 
@@ -37,6 +38,7 @@ export class MissionRepository implements MissionSequenceAllocator {
         status,
         mission_plan_id,
         platform_id,
+        pilot_id,
         last_event_sequence_no
       from missions
       where id = $1
@@ -90,6 +92,7 @@ export class MissionRepository implements MissionSequenceAllocator {
         status,
         mission_plan_id,
         platform_id,
+        pilot_id,
         last_event_sequence_no
       from missions
       where id = $1

--- a/src/missions/mission.service.ts
+++ b/src/missions/mission.service.ts
@@ -8,11 +8,14 @@ import {
 } from "../modules/missions/domain/missionLifecycle";
 import { PlatformNotFoundError } from "../platforms/platform.errors";
 import { PlatformService } from "../platforms/platform.service";
+import { PilotNotFoundError } from "../pilots/pilot.errors";
+import { PilotService } from "../pilots/pilot.service";
 import type {
   MissionReadinessCheck,
   MissionReadinessReason,
   MissionReadinessResult,
 } from "./mission-readiness.types";
+import type { PilotReadinessResult } from "../pilots/pilot.types";
 
 export interface GetMissionEventsFilters {
   safety?: boolean;
@@ -50,6 +53,7 @@ export class MissionService {
     private readonly missionRepo: MissionRepository,
     private readonly missionEventRepo: MissionEventRepository,
     private readonly platformService?: PlatformService,
+    private readonly pilotService?: PilotService,
   ) {}
 
   async submitMission(params: {
@@ -236,83 +240,106 @@ export class MissionService {
   async checkMissionReadiness(params: {
     missionId: string;
     platformId?: string;
+    pilotId?: string;
   }): Promise<MissionReadinessCheck> {
     const mission = await this.db.transaction(async (tx) =>
       this.missionRepo.getById(tx, params.missionId),
     );
     const platformId = params.platformId ?? mission.platform_id;
+    const pilotId = params.pilotId ?? mission.pilot_id;
+    const reasons: MissionReadinessReason[] = [];
+    let platformReadiness: MissionReadinessCheck["platformReadiness"] = null;
+    let pilotReadiness: MissionReadinessCheck["pilotReadiness"] = null;
 
     if (!platformId) {
-      return this.buildMissionReadiness({
-        missionId: mission.id,
-        platformId: null,
-        reasons: [
-          {
-            code: "MISSION_PLATFORM_NOT_ASSIGNED",
-            severity: "fail",
-            message: "Mission has no assigned platform for readiness evaluation",
-            source: "mission",
-          },
-        ],
-        platformReadiness: null,
+      reasons.push({
+        code: "MISSION_PLATFORM_NOT_ASSIGNED",
+        severity: "fail",
+        message: "Mission has no assigned platform for readiness evaluation",
+        source: "mission",
       });
-    }
-
-    if (!this.platformService) {
-      return this.buildMissionReadiness({
-        missionId: mission.id,
-        platformId,
-        reasons: [
-          {
+    } else if (!this.platformService) {
+      reasons.push({
             code: "MISSION_PLATFORM_NOT_FOUND",
             severity: "fail",
             message: "Platform readiness service is not available",
             source: "mission",
             relatedPlatformId: platformId,
-          },
-        ],
-        platformReadiness: null,
       });
-    }
+    } else {
+      try {
+        platformReadiness =
+          await this.platformService.checkPlatformReadiness(platformId);
+        reasons.push(
+          this.mapPlatformReadinessReason(
+            platformReadiness.result,
+            platformId,
+            platformReadiness.reasons.map((reason) => reason.code),
+          ),
+        );
+      } catch (error) {
+        if (!(error instanceof PlatformNotFoundError)) {
+          throw error;
+        }
 
-    try {
-      const platformReadiness =
-        await this.platformService.checkPlatformReadiness(platformId);
-      const platformReasonCodes = platformReadiness.reasons.map(
-        (reason) => reason.code,
-      );
-      const reason = this.mapPlatformReadinessReason(
-        platformReadiness.result,
-        platformId,
-        platformReasonCodes,
-      );
-
-      return this.buildMissionReadiness({
-        missionId: mission.id,
-        platformId,
-        reasons: [reason],
-        platformReadiness,
-      });
-    } catch (error) {
-      if (error instanceof PlatformNotFoundError) {
-        return this.buildMissionReadiness({
-          missionId: mission.id,
-          platformId,
-          reasons: [
-            {
+        reasons.push({
               code: "MISSION_PLATFORM_NOT_FOUND",
               severity: "fail",
               message: `Assigned platform was not found: ${platformId}`,
               source: "mission",
               relatedPlatformId: platformId,
-            },
-          ],
-          platformReadiness: null,
         });
       }
-
-      throw error;
     }
+
+    if (!pilotId) {
+      reasons.push({
+        code: "MISSION_PILOT_NOT_ASSIGNED",
+        severity: "fail",
+        message: "Mission has no assigned pilot for readiness evaluation",
+        source: "mission",
+      });
+    } else if (!this.pilotService) {
+      reasons.push({
+        code: "MISSION_PILOT_NOT_FOUND",
+        severity: "fail",
+        message: "Pilot readiness service is not available",
+        source: "mission",
+        relatedPilotId: pilotId,
+      });
+    } else {
+      try {
+        pilotReadiness = await this.pilotService.checkPilotReadiness(pilotId);
+        reasons.push(
+          this.mapPilotReadinessReason(
+            pilotReadiness.result,
+            pilotId,
+            pilotReadiness.reasons.map((reason) => reason.code),
+          ),
+        );
+      } catch (error) {
+        if (!(error instanceof PilotNotFoundError)) {
+          throw error;
+        }
+
+        reasons.push({
+          code: "MISSION_PILOT_NOT_FOUND",
+          severity: "fail",
+          message: `Assigned pilot was not found: ${pilotId}`,
+          source: "mission",
+          relatedPilotId: pilotId,
+        });
+      }
+    }
+
+    return this.buildMissionReadiness({
+      missionId: mission.id,
+      platformId,
+      pilotId,
+      reasons,
+      platformReadiness,
+      pilotReadiness,
+    });
   }
 
   async getMissionEvents(
@@ -386,17 +413,57 @@ export class MissionService {
     };
   }
 
+  private mapPilotReadinessReason(
+    result: PilotReadinessResult,
+    pilotId: string,
+    pilotReasonCodes: string[],
+  ): MissionReadinessReason {
+    if (result === "fail") {
+      return {
+        code: "MISSION_PILOT_FAILED",
+        severity: "fail",
+        message: "Assigned pilot fails readiness and blocks mission approval or dispatch",
+        source: "pilot",
+        relatedPilotId: pilotId,
+        relatedPilotReasonCodes: pilotReasonCodes,
+      };
+    }
+
+    if (result === "warning") {
+      return {
+        code: "MISSION_PILOT_WARNING",
+        severity: "warning",
+        message: "Assigned pilot has readiness warnings requiring review before approval or dispatch",
+        source: "pilot",
+        relatedPilotId: pilotId,
+        relatedPilotReasonCodes: pilotReasonCodes,
+      };
+    }
+
+    return {
+      code: "MISSION_PILOT_READY",
+      severity: "pass",
+      message: "Assigned pilot passes readiness for mission approval and dispatch",
+      source: "pilot",
+      relatedPilotId: pilotId,
+      relatedPilotReasonCodes: pilotReasonCodes,
+    };
+  }
+
   private buildMissionReadiness(params: {
     missionId: string;
     platformId: string | null;
+    pilotId: string | null;
     reasons: MissionReadinessReason[];
     platformReadiness: MissionReadinessCheck["platformReadiness"];
+    pilotReadiness: MissionReadinessCheck["pilotReadiness"];
   }): MissionReadinessCheck {
     const result = this.getMissionReadinessResult(params.reasons);
 
     return {
       missionId: params.missionId,
       platformId: params.platformId,
+      pilotId: params.pilotId,
       result,
       gate: {
         result,
@@ -406,6 +473,7 @@ export class MissionService {
       },
       reasons: params.reasons,
       platformReadiness: params.platformReadiness,
+      pilotReadiness: params.pilotReadiness,
     };
   }
 

--- a/src/pilots/pilot.controller.ts
+++ b/src/pilots/pilot.controller.ts
@@ -1,0 +1,67 @@
+import type { NextFunction, Request, Response } from "express";
+import { PilotService } from "./pilot.service";
+
+type PilotIdParams = {
+  id: string;
+};
+
+export class PilotController {
+  constructor(private readonly pilotService: PilotService) {}
+
+  createPilot = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const pilot = await this.pilotService.createPilot(req.body);
+      res.status(201).json({ pilot });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getPilot = async (
+    req: Request<PilotIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const pilot = await this.pilotService.getPilot(req.params.id);
+      res.status(200).json({ pilot });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  createReadinessEvidence = async (
+    req: Request<PilotIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const evidence = await this.pilotService.createReadinessEvidence(
+        req.params.id,
+        req.body,
+      );
+      res.status(201).json({ evidence });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getReadiness = async (
+    req: Request<PilotIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const readiness = await this.pilotService.checkPilotReadiness(
+        req.params.id,
+      );
+      res.status(200).json(readiness);
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/pilots/pilot.errors.ts
+++ b/src/pilots/pilot.errors.ts
@@ -1,0 +1,13 @@
+export class PilotValidationError extends Error {
+  readonly statusCode = 400;
+  readonly code = "PILOT_VALIDATION_FAILED";
+}
+
+export class PilotNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "PILOT_NOT_FOUND";
+
+  constructor(pilotId: string) {
+    super(`Pilot not found: ${pilotId}`);
+  }
+}

--- a/src/pilots/pilot.repository.ts
+++ b/src/pilots/pilot.repository.ts
@@ -1,0 +1,154 @@
+import { randomUUID } from "crypto";
+import type { PoolClient, QueryResultRow } from "pg";
+import type { Pilot, PilotEvidence } from "./pilot.types";
+
+interface PilotRow extends QueryResultRow {
+  id: string;
+  display_name: string;
+  caa_reference: string | null;
+  status: Pilot["status"];
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface PilotEvidenceRow extends QueryResultRow {
+  id: string;
+  pilot_id: string;
+  evidence_type: string;
+  title: string;
+  issued_at: Date | null;
+  expires_at: Date | null;
+  status: PilotEvidence["status"];
+  evidence_ref: string | null;
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+type CreatePilotRow = Omit<Pilot, "id" | "createdAt" | "updatedAt">;
+
+type CreatePilotEvidenceRow = {
+  pilotId: string;
+  evidenceType: string;
+  title: string;
+  issuedAt: Date | null;
+  expiresAt: Date | null;
+  status: PilotEvidence["status"];
+  evidenceRef: string | null;
+  notes: string | null;
+};
+
+const toPilot = (row: PilotRow): Pilot => ({
+  id: row.id,
+  displayName: row.display_name,
+  caaReference: row.caa_reference,
+  status: row.status,
+  notes: row.notes,
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
+});
+
+const toEvidence = (row: PilotEvidenceRow): PilotEvidence => ({
+  id: row.id,
+  pilotId: row.pilot_id,
+  evidenceType: row.evidence_type,
+  title: row.title,
+  issuedAt: row.issued_at?.toISOString() ?? null,
+  expiresAt: row.expires_at?.toISOString() ?? null,
+  status: row.status,
+  evidenceRef: row.evidence_ref,
+  notes: row.notes,
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
+});
+
+export class PilotRepository {
+  async insertPilot(tx: PoolClient, input: CreatePilotRow): Promise<Pilot> {
+    const result = await tx.query<PilotRow>(
+      `
+      insert into pilots (
+        id,
+        display_name,
+        caa_reference,
+        status,
+        notes
+      )
+      values ($1, $2, $3, $4, $5)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.displayName,
+        input.caaReference,
+        input.status,
+        input.notes,
+      ],
+    );
+
+    return toPilot(result.rows[0]);
+  }
+
+  async getPilotById(tx: PoolClient, pilotId: string): Promise<Pilot | null> {
+    const result = await tx.query<PilotRow>(
+      `
+      select *
+      from pilots
+      where id = $1
+      `,
+      [pilotId],
+    );
+
+    return result.rows[0] ? toPilot(result.rows[0]) : null;
+  }
+
+  async insertEvidence(
+    tx: PoolClient,
+    input: CreatePilotEvidenceRow,
+  ): Promise<PilotEvidence> {
+    const result = await tx.query<PilotEvidenceRow>(
+      `
+      insert into pilot_readiness_evidence (
+        id,
+        pilot_id,
+        evidence_type,
+        title,
+        issued_at,
+        expires_at,
+        status,
+        evidence_ref,
+        notes
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.pilotId,
+        input.evidenceType,
+        input.title,
+        input.issuedAt,
+        input.expiresAt,
+        input.status,
+        input.evidenceRef,
+        input.notes,
+      ],
+    );
+
+    return toEvidence(result.rows[0]);
+  }
+
+  async listEvidence(tx: PoolClient, pilotId: string): Promise<PilotEvidence[]> {
+    const result = await tx.query<PilotEvidenceRow>(
+      `
+      select *
+      from pilot_readiness_evidence
+      where pilot_id = $1
+      order by created_at asc, id asc
+      `,
+      [pilotId],
+    );
+
+    return result.rows.map(toEvidence);
+  }
+}

--- a/src/pilots/pilot.routes.ts
+++ b/src/pilots/pilot.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { PilotController } from "./pilot.controller";
+
+export function createPilotRouter(controller: PilotController): Router {
+  const router = Router();
+
+  router.post("/", controller.createPilot);
+  router.get("/:id", controller.getPilot);
+  router.post("/:id/readiness-evidence", controller.createReadinessEvidence);
+  router.get("/:id/readiness", controller.getReadiness);
+
+  return router;
+}

--- a/src/pilots/pilot.service.ts
+++ b/src/pilots/pilot.service.ts
@@ -1,0 +1,217 @@
+import type { Pool } from "pg";
+import { PilotNotFoundError } from "./pilot.errors";
+import { PilotRepository } from "./pilot.repository";
+import type {
+  CreatePilotEvidenceInput,
+  CreatePilotInput,
+  PilotEvidence,
+  PilotReadinessCheck,
+  PilotReadinessReason,
+  PilotReadinessResult,
+  PilotReadinessStatus,
+} from "./pilot.types";
+import {
+  validateCreatePilotEvidenceInput,
+  validateCreatePilotInput,
+} from "./pilot.validators";
+
+export class PilotService {
+  constructor(
+    private readonly pool: Pool,
+    private readonly pilotRepository: PilotRepository,
+  ) {}
+
+  async createPilot(input: CreatePilotInput) {
+    const validated = validateCreatePilotInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      return await this.pilotRepository.insertPilot(client, validated);
+    } finally {
+      client.release();
+    }
+  }
+
+  async getPilot(pilotId: string) {
+    const client = await this.pool.connect();
+
+    try {
+      const pilot = await this.pilotRepository.getPilotById(client, pilotId);
+
+      if (!pilot) {
+        throw new PilotNotFoundError(pilotId);
+      }
+
+      return pilot;
+    } finally {
+      client.release();
+    }
+  }
+
+  async createReadinessEvidence(
+    pilotId: string,
+    input: CreatePilotEvidenceInput,
+  ) {
+    const validated = validateCreatePilotEvidenceInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      const pilot = await this.pilotRepository.getPilotById(client, pilotId);
+
+      if (!pilot) {
+        throw new PilotNotFoundError(pilotId);
+      }
+
+      return await this.pilotRepository.insertEvidence(client, {
+        pilotId,
+        ...validated,
+      });
+    } finally {
+      client.release();
+    }
+  }
+
+  async checkPilotReadiness(pilotId: string): Promise<PilotReadinessCheck> {
+    const readinessStatus = await this.getReadinessStatus(pilotId);
+    const reasons = this.buildReadinessReasons(readinessStatus);
+
+    return {
+      pilotId,
+      result: this.getReadinessResult(reasons),
+      reasons,
+      readinessStatus,
+    };
+  }
+
+  private async getReadinessStatus(
+    pilotId: string,
+  ): Promise<PilotReadinessStatus> {
+    const client = await this.pool.connect();
+
+    try {
+      const pilot = await this.pilotRepository.getPilotById(client, pilotId);
+
+      if (!pilot) {
+        throw new PilotNotFoundError(pilotId);
+      }
+
+      const evidence = await this.pilotRepository.listEvidence(client, pilotId);
+      const now = new Date();
+      const expiredEvidence = evidence.filter((item) =>
+        this.isEvidenceExpired(item, now),
+      );
+      const inactiveEvidence = evidence.filter(
+        (item) => item.status !== "active" && !expiredEvidence.includes(item),
+      );
+      const currentEvidence = evidence.filter(
+        (item) =>
+          item.status === "active" && !expiredEvidence.some((expired) => expired.id === item.id),
+      );
+
+      return {
+        pilot,
+        currentEvidence,
+        expiredEvidence,
+        inactiveEvidence,
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  private isEvidenceExpired(evidence: PilotEvidence, now: Date): boolean {
+    return evidence.expiresAt !== null && new Date(evidence.expiresAt) <= now;
+  }
+
+  private buildReadinessReasons(
+    readinessStatus: PilotReadinessStatus,
+  ): PilotReadinessReason[] {
+    const { pilot, currentEvidence, expiredEvidence, inactiveEvidence } =
+      readinessStatus;
+
+    if (pilot.status === "suspended") {
+      return [
+        {
+          code: "PILOT_SUSPENDED",
+          severity: "fail",
+          message: "Pilot is suspended and is not fit for mission use",
+        },
+      ];
+    }
+
+    if (pilot.status === "retired") {
+      return [
+        {
+          code: "PILOT_RETIRED",
+          severity: "fail",
+          message: "Pilot is retired and is not fit for mission use",
+        },
+      ];
+    }
+
+    const reasons: PilotReadinessReason[] = [];
+
+    if (pilot.status === "inactive") {
+      reasons.push({
+        code: "PILOT_INACTIVE",
+        severity: "warning",
+        message: "Pilot is inactive and requires review before mission use",
+      });
+    }
+
+    if (currentEvidence.length === 0) {
+      reasons.push({
+        code: "PILOT_EVIDENCE_MISSING",
+        severity: "fail",
+        message: "Pilot has no current readiness evidence",
+      });
+    }
+
+    if (expiredEvidence.length > 0) {
+      reasons.push({
+        code: "PILOT_EVIDENCE_EXPIRED",
+        severity: "fail",
+        message: "Pilot has expired readiness evidence",
+        relatedEvidenceIds: expiredEvidence.map((item) => item.id),
+      });
+    }
+
+    const revokedEvidence = inactiveEvidence.filter(
+      (item) => item.status === "revoked",
+    );
+
+    if (revokedEvidence.length > 0) {
+      reasons.push({
+        code: "PILOT_EVIDENCE_REVOKED",
+        severity: "fail",
+        message: "Pilot has revoked readiness evidence",
+        relatedEvidenceIds: revokedEvidence.map((item) => item.id),
+      });
+    }
+
+    if (reasons.length === 0) {
+      reasons.push({
+        code: "PILOT_ACTIVE",
+        severity: "pass",
+        message: "Pilot is active with current readiness evidence",
+        relatedEvidenceIds: currentEvidence.map((item) => item.id),
+      });
+    }
+
+    return reasons;
+  }
+
+  private getReadinessResult(
+    reasons: PilotReadinessReason[],
+  ): PilotReadinessResult {
+    if (reasons.some((reason) => reason.severity === "fail")) {
+      return "fail";
+    }
+
+    if (reasons.some((reason) => reason.severity === "warning")) {
+      return "warning";
+    }
+
+    return "pass";
+  }
+}

--- a/src/pilots/pilot.types.ts
+++ b/src/pilots/pilot.types.ts
@@ -1,0 +1,76 @@
+export type PilotStatus = "active" | "inactive" | "suspended" | "retired";
+
+export type PilotEvidenceStatus = "active" | "inactive" | "revoked";
+
+export interface CreatePilotInput {
+  displayName?: string;
+  caaReference?: string | null;
+  status?: PilotStatus;
+  notes?: string | null;
+}
+
+export interface Pilot {
+  id: string;
+  displayName: string;
+  caaReference: string | null;
+  status: PilotStatus;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreatePilotEvidenceInput {
+  evidenceType?: string;
+  title?: string;
+  issuedAt?: string | null;
+  expiresAt?: string | null;
+  status?: PilotEvidenceStatus;
+  evidenceRef?: string | null;
+  notes?: string | null;
+}
+
+export interface PilotEvidence {
+  id: string;
+  pilotId: string;
+  evidenceType: string;
+  title: string;
+  issuedAt: string | null;
+  expiresAt: string | null;
+  status: PilotEvidenceStatus;
+  evidenceRef: string | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PilotReadinessStatus {
+  pilot: Pilot;
+  currentEvidence: PilotEvidence[];
+  expiredEvidence: PilotEvidence[];
+  inactiveEvidence: PilotEvidence[];
+}
+
+export type PilotReadinessResult = "pass" | "warning" | "fail";
+
+export type PilotReadinessReasonCode =
+  | "PILOT_ACTIVE"
+  | "PILOT_INACTIVE"
+  | "PILOT_SUSPENDED"
+  | "PILOT_RETIRED"
+  | "PILOT_EVIDENCE_MISSING"
+  | "PILOT_EVIDENCE_EXPIRED"
+  | "PILOT_EVIDENCE_REVOKED";
+
+export interface PilotReadinessReason {
+  code: PilotReadinessReasonCode;
+  severity: PilotReadinessResult;
+  message: string;
+  relatedEvidenceIds?: string[];
+}
+
+export interface PilotReadinessCheck {
+  pilotId: string;
+  result: PilotReadinessResult;
+  reasons: PilotReadinessReason[];
+  readinessStatus: PilotReadinessStatus;
+}

--- a/src/pilots/pilot.validators.ts
+++ b/src/pilots/pilot.validators.ts
@@ -1,0 +1,96 @@
+import { PilotValidationError } from "./pilot.errors";
+import type {
+  CreatePilotEvidenceInput,
+  CreatePilotInput,
+  PilotEvidenceStatus,
+  PilotStatus,
+} from "./pilot.types";
+
+const PILOT_STATUSES = new Set<PilotStatus>([
+  "active",
+  "inactive",
+  "suspended",
+  "retired",
+]);
+
+const EVIDENCE_STATUSES = new Set<PilotEvidenceStatus>([
+  "active",
+  "inactive",
+  "revoked",
+]);
+
+function optionalTrimmed(value: unknown, fieldName: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    throw new PilotValidationError(`${fieldName} must be a string`);
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function requiredTrimmed(value: unknown, fieldName: string): string {
+  const normalized = optionalTrimmed(value, fieldName);
+
+  if (!normalized) {
+    throw new PilotValidationError(`${fieldName} is required`);
+  }
+
+  return normalized;
+}
+
+function optionalDate(value: unknown, fieldName: string): Date | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    throw new PilotValidationError(`${fieldName} must be a valid ISO timestamp`);
+  }
+
+  return new Date(value);
+}
+
+export function validateCreatePilotInput(input: CreatePilotInput) {
+  if (!input || typeof input !== "object") {
+    throw new PilotValidationError("Request body must be an object");
+  }
+
+  const status = input.status ?? "active";
+
+  if (!PILOT_STATUSES.has(status)) {
+    throw new PilotValidationError("status is not supported");
+  }
+
+  return {
+    displayName: requiredTrimmed(input.displayName, "displayName"),
+    caaReference: optionalTrimmed(input.caaReference, "caaReference"),
+    status,
+    notes: optionalTrimmed(input.notes, "notes"),
+  };
+}
+
+export function validateCreatePilotEvidenceInput(input: CreatePilotEvidenceInput) {
+  if (!input || typeof input !== "object") {
+    throw new PilotValidationError("Request body must be an object");
+  }
+
+  const status = input.status ?? "active";
+
+  if (!EVIDENCE_STATUSES.has(status)) {
+    throw new PilotValidationError("status is not supported");
+  }
+
+  return {
+    evidenceType: requiredTrimmed(input.evidenceType, "evidenceType"),
+    title: requiredTrimmed(input.title, "title"),
+    issuedAt: optionalDate(input.issuedAt, "issuedAt"),
+    expiresAt: optionalDate(input.expiresAt, "expiresAt"),
+    status,
+    evidenceRef: optionalTrimmed(input.evidenceRef, "evidenceRef"),
+    notes: optionalTrimmed(input.notes, "notes"),
+  };
+}

--- a/src/tests/mission-readiness.test.ts
+++ b/src/tests/mission-readiness.test.ts
@@ -7,6 +7,8 @@ import { runMigrations } from "../migrations/runMigrations";
 const clearTables = async () => {
   await pool.query("delete from mission_events");
   await pool.query("delete from missions");
+  await pool.query("delete from pilot_readiness_evidence");
+  await pool.query("delete from pilots");
   await pool.query("delete from maintenance_records");
   await pool.query("delete from maintenance_schedules");
   await pool.query("delete from platforms");
@@ -22,10 +24,32 @@ const createPlatform = async (params: {
   return response.body.platform as { id: string };
 };
 
+const createReadyPilot = async () => {
+  const pilotResponse = await request(app).post("/pilots").send({
+    displayName: "Ready Pilot",
+    status: "active",
+  });
+
+  expect(pilotResponse.status).toBe(201);
+  const pilot = pilotResponse.body.pilot as { id: string };
+
+  const evidenceResponse = await request(app)
+    .post(`/pilots/${pilot.id}/readiness-evidence`)
+    .send({
+      evidenceType: "operator_authorisation",
+      title: "Current operator authorisation",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+    });
+
+  expect(evidenceResponse.status).toBe(201);
+  return pilot;
+};
+
 const insertMission = async (params: {
   id?: string;
   status?: string;
   platformId?: string | null;
+  pilotId?: string | null;
 }) => {
   const missionId = params.id ?? randomUUID();
 
@@ -36,15 +60,17 @@ const insertMission = async (params: {
       status,
       mission_plan_id,
       platform_id,
+      pilot_id,
       last_event_sequence_no
     )
-    values ($1, $2, $3, $4, $5)
+    values ($1, $2, $3, $4, $5, $6)
     `,
     [
       missionId,
       params.status ?? "submitted",
       "plan-1",
       params.platformId ?? null,
+      params.pilotId ?? null,
       0,
     ],
   );
@@ -52,7 +78,11 @@ const insertMission = async (params: {
   return missionId;
 };
 
-const countRows = async (params: { missionId: string; platformId?: string }) => {
+const countRows = async (params: {
+  missionId: string;
+  platformId?: string;
+  pilotId?: string;
+}) => {
   const result = await pool.query(
     `
     select
@@ -61,9 +91,11 @@ const countRows = async (params: { missionId: string; platformId?: string }) => 
       (select count(*)::int from mission_events where mission_id = $1) as mission_event_count,
       (select count(*)::int from platforms where id = $2) as platform_count,
       (select count(*)::int from maintenance_schedules where platform_id = $2) as schedule_count,
-      (select count(*)::int from maintenance_records where platform_id = $2) as record_count
+      (select count(*)::int from maintenance_records where platform_id = $2) as record_count,
+      (select count(*)::int from pilots where id = $3) as pilot_count,
+      (select count(*)::int from pilot_readiness_evidence where pilot_id = $3) as pilot_evidence_count
     `,
-    [params.missionId, params.platformId ?? null],
+    [params.missionId, params.platformId ?? null, params.pilotId ?? null],
   );
 
   return result.rows[0] as {
@@ -73,6 +105,8 @@ const countRows = async (params: { missionId: string; platformId?: string }) => 
     platform_count: number;
     schedule_count: number;
     record_count: number;
+    pilot_count: number;
+    pilot_evidence_count: number;
   };
 };
 
@@ -94,8 +128,16 @@ describe("mission readiness platform gate integration", () => {
       name: "Mission Ready UAV",
       status: "active",
     });
-    const missionId = await insertMission({ platformId: platform.id });
-    const before = await countRows({ missionId, platformId: platform.id });
+    const pilot = await createReadyPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
 
     const response = await request(app).get(`/missions/${missionId}/readiness`);
 
@@ -103,6 +145,7 @@ describe("mission readiness platform gate integration", () => {
     expect(response.body).toMatchObject({
       missionId,
       platformId: platform.id,
+      pilotId: pilot.id,
       result: "pass",
       gate: {
         result: "pass",
@@ -118,13 +161,28 @@ describe("mission readiness platform gate integration", () => {
           relatedPlatformId: platform.id,
           relatedPlatformReasonCodes: ["PLATFORM_ACTIVE"],
         },
+        {
+          code: "MISSION_PILOT_READY",
+          severity: "pass",
+          source: "pilot",
+          relatedPilotId: pilot.id,
+          relatedPilotReasonCodes: ["PILOT_ACTIVE"],
+        },
       ],
       platformReadiness: {
         platformId: platform.id,
         result: "pass",
       },
+      pilotReadiness: {
+        pilotId: pilot.id,
+        result: "pass",
+      },
     });
-    expect(await countRows({ missionId, platformId: platform.id })).toEqual(before);
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    })).toEqual(before);
   });
 
   it("surfaces a warning when the assigned platform has overdue maintenance", async () => {
@@ -133,7 +191,11 @@ describe("mission readiness platform gate integration", () => {
       status: "active",
       totalFlightHours: 55,
     });
-    const missionId = await insertMission({ platformId: platform.id });
+    const pilot = await createReadyPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
 
     const scheduleResponse = await request(app)
       .post(`/platforms/${platform.id}/maintenance-schedules`)
@@ -143,7 +205,11 @@ describe("mission readiness platform gate integration", () => {
       });
 
     expect(scheduleResponse.status).toBe(201);
-    const before = await countRows({ missionId, platformId: platform.id });
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
 
     const response = await request(app).get(`/missions/${missionId}/readiness`);
 
@@ -151,6 +217,7 @@ describe("mission readiness platform gate integration", () => {
     expect(response.body).toMatchObject({
       missionId,
       platformId: platform.id,
+      pilotId: pilot.id,
       result: "warning",
       gate: {
         result: "warning",
@@ -166,13 +233,28 @@ describe("mission readiness platform gate integration", () => {
           relatedPlatformId: platform.id,
           relatedPlatformReasonCodes: ["PLATFORM_MAINTENANCE_DUE"],
         },
+        {
+          code: "MISSION_PILOT_READY",
+          severity: "pass",
+          source: "pilot",
+          relatedPilotId: pilot.id,
+          relatedPilotReasonCodes: ["PILOT_ACTIVE"],
+        },
       ],
       platformReadiness: {
         platformId: platform.id,
         result: "warning",
       },
+      pilotReadiness: {
+        pilotId: pilot.id,
+        result: "pass",
+      },
     });
-    expect(await countRows({ missionId, platformId: platform.id })).toEqual(before);
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    })).toEqual(before);
   });
 
   it.each([
@@ -189,8 +271,16 @@ describe("mission readiness platform gate integration", () => {
       name: `${status} UAV`,
       status,
     });
-    const missionId = await insertMission({ platformId: platform.id });
-    const before = await countRows({ missionId, platformId: platform.id });
+    const pilot = await createReadyPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
 
     const response = await request(app).get(`/missions/${missionId}/readiness`);
 
@@ -198,6 +288,7 @@ describe("mission readiness platform gate integration", () => {
     expect(response.body).toMatchObject({
       missionId,
       platformId: platform.id,
+      pilotId: pilot.id,
       result: "fail",
       gate: {
         result: "fail",
@@ -213,18 +304,37 @@ describe("mission readiness platform gate integration", () => {
           relatedPlatformId: platform.id,
           relatedPlatformReasonCodes: [platformCode],
         },
+        {
+          code: "MISSION_PILOT_READY",
+          severity: "pass",
+          source: "pilot",
+          relatedPilotId: pilot.id,
+          relatedPilotReasonCodes: ["PILOT_ACTIVE"],
+        },
       ],
       platformReadiness: {
         platformId: platform.id,
         result: "fail",
       },
+      pilotReadiness: {
+        pilotId: pilot.id,
+        result: "pass",
+      },
     });
-    expect(await countRows({ missionId, platformId: platform.id })).toEqual(before);
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    })).toEqual(before);
   });
 
   it("fails explicitly when the mission has no assigned platform", async () => {
-    const missionId = await insertMission({ platformId: null });
-    const before = await countRows({ missionId });
+    const pilot = await createReadyPilot();
+    const missionId = await insertMission({
+      platformId: null,
+      pilotId: pilot.id,
+    });
+    const before = await countRows({ missionId, pilotId: pilot.id });
 
     const response = await request(app).get(`/missions/${missionId}/readiness`);
 
@@ -232,6 +342,7 @@ describe("mission readiness platform gate integration", () => {
     expect(response.body).toMatchObject({
       missionId,
       platformId: null,
+      pilotId: pilot.id,
       result: "fail",
       gate: {
         result: "fail",
@@ -245,10 +356,21 @@ describe("mission readiness platform gate integration", () => {
           severity: "fail",
           source: "mission",
         },
+        {
+          code: "MISSION_PILOT_READY",
+          severity: "pass",
+          source: "pilot",
+          relatedPilotId: pilot.id,
+          relatedPilotReasonCodes: ["PILOT_ACTIVE"],
+        },
       ],
       platformReadiness: null,
+      pilotReadiness: {
+        pilotId: pilot.id,
+        result: "pass",
+      },
     });
-    expect(await countRows({ missionId })).toEqual(before);
+    expect(await countRows({ missionId, pilotId: pilot.id })).toEqual(before);
   });
 
   it("fails explicitly when a candidate platform override is unknown", async () => {
@@ -256,9 +378,17 @@ describe("mission readiness platform gate integration", () => {
       name: "Assigned UAV",
       status: "active",
     });
+    const pilot = await createReadyPilot();
     const missingPlatformId = randomUUID();
-    const missionId = await insertMission({ platformId: platform.id });
-    const before = await countRows({ missionId, platformId: platform.id });
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
 
     const response = await request(app)
       .get(`/missions/${missionId}/readiness`)
@@ -268,6 +398,7 @@ describe("mission readiness platform gate integration", () => {
     expect(response.body).toMatchObject({
       missionId,
       platformId: missingPlatformId,
+      pilotId: pilot.id,
       result: "fail",
       gate: {
         result: "fail",
@@ -282,9 +413,185 @@ describe("mission readiness platform gate integration", () => {
           source: "mission",
           relatedPlatformId: missingPlatformId,
         },
+        {
+          code: "MISSION_PILOT_READY",
+          severity: "pass",
+          source: "pilot",
+          relatedPilotId: pilot.id,
+          relatedPilotReasonCodes: ["PILOT_ACTIVE"],
+        },
       ],
       platformReadiness: null,
+      pilotReadiness: {
+        pilotId: pilot.id,
+        result: "pass",
+      },
+    });
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    })).toEqual(before);
+  });
+
+  it("fails the combined mission gate when the assigned pilot has expired evidence", async () => {
+    const platform = await createPlatform({
+      name: "Ready UAV",
+      status: "active",
+    });
+    const pilotResponse = await request(app).post("/pilots").send({
+      displayName: "Expired Evidence Pilot",
+      status: "active",
+    });
+    expect(pilotResponse.status).toBe(201);
+    const pilot = pilotResponse.body.pilot as { id: string };
+
+    await request(app)
+      .post(`/pilots/${pilot.id}/readiness-evidence`)
+      .send({
+        evidenceType: "operator_authorisation",
+        title: "Expired operator authorisation",
+        expiresAt: "2020-01-01T00:00:00.000Z",
+      });
+
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+
+    const response = await request(app).get(`/missions/${missionId}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      result: "fail",
+      gate: {
+        result: "fail",
+        blocksApproval: true,
+        blocksDispatch: true,
+        requiresReview: false,
+      },
+      reasons: [
+        {
+          code: "MISSION_PLATFORM_READY",
+          severity: "pass",
+          source: "platform",
+        },
+        {
+          code: "MISSION_PILOT_FAILED",
+          severity: "fail",
+          source: "pilot",
+          relatedPilotId: pilot.id,
+          relatedPilotReasonCodes: [
+            "PILOT_EVIDENCE_MISSING",
+            "PILOT_EVIDENCE_EXPIRED",
+          ],
+        },
+      ],
+      platformReadiness: {
+        result: "pass",
+      },
+      pilotReadiness: {
+        pilotId: pilot.id,
+        result: "fail",
+      },
+    });
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    })).toEqual(before);
+  });
+
+  it("fails explicitly when the mission has no assigned pilot", async () => {
+    const platform = await createPlatform({
+      name: "Ready UAV",
+      status: "active",
+    });
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: null,
+    });
+    const before = await countRows({ missionId, platformId: platform.id });
+
+    const response = await request(app).get(`/missions/${missionId}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      platformId: platform.id,
+      pilotId: null,
+      result: "fail",
+      reasons: [
+        {
+          code: "MISSION_PLATFORM_READY",
+          severity: "pass",
+          source: "platform",
+        },
+        {
+          code: "MISSION_PILOT_NOT_ASSIGNED",
+          severity: "fail",
+          source: "mission",
+        },
+      ],
+      pilotReadiness: null,
     });
     expect(await countRows({ missionId, platformId: platform.id })).toEqual(before);
+  });
+
+  it("fails explicitly when a candidate pilot override is unknown", async () => {
+    const platform = await createPlatform({
+      name: "Ready UAV",
+      status: "active",
+    });
+    const pilot = await createReadyPilot();
+    const missingPilotId = randomUUID();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+
+    const response = await request(app)
+      .get(`/missions/${missionId}/readiness`)
+      .query({ pilotId: missingPilotId });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      platformId: platform.id,
+      pilotId: missingPilotId,
+      result: "fail",
+      reasons: [
+        {
+          code: "MISSION_PLATFORM_READY",
+          severity: "pass",
+          source: "platform",
+        },
+        {
+          code: "MISSION_PILOT_NOT_FOUND",
+          severity: "fail",
+          source: "mission",
+          relatedPilotId: missingPilotId,
+        },
+      ],
+      pilotReadiness: null,
+    });
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    })).toEqual(before);
   });
 });

--- a/src/tests/pilot-readiness.test.ts
+++ b/src/tests/pilot-readiness.test.ts
@@ -1,0 +1,214 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import app, { pool } from "../app";
+import { runMigrations } from "../migrations/runMigrations";
+
+const clearPilotTables = async () => {
+  await pool.query("delete from missions");
+  await pool.query("delete from pilot_readiness_evidence");
+  await pool.query("delete from pilots");
+};
+
+const createPilot = async (params: {
+  displayName: string;
+  status?: string;
+}) => {
+  const response = await request(app).post("/pilots").send(params);
+  expect(response.status).toBe(201);
+  return response.body.pilot as { id: string };
+};
+
+const countPilotRows = async (pilotId: string) => {
+  const result = await pool.query(
+    `
+    select
+      (select count(*)::int from pilots where id = $1) as pilot_count,
+      (select count(*)::int from pilot_readiness_evidence where pilot_id = $1) as evidence_count
+    `,
+    [pilotId],
+  );
+
+  return result.rows[0] as {
+    pilot_count: number;
+    evidence_count: number;
+  };
+};
+
+describe("pilot readiness integration", () => {
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  beforeEach(async () => {
+    await clearPilotTables();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("passes readiness for an active pilot with current evidence", async () => {
+    const pilot = await createPilot({
+      displayName: "Ready Pilot",
+      status: "active",
+    });
+
+    const evidenceResponse = await request(app)
+      .post(`/pilots/${pilot.id}/readiness-evidence`)
+      .send({
+        evidenceType: "operator_authorisation",
+        title: "Current operator authorisation",
+        expiresAt: "2099-01-01T00:00:00.000Z",
+      });
+
+    expect(evidenceResponse.status).toBe(201);
+    const evidenceId = evidenceResponse.body.evidence.id;
+    const before = await countPilotRows(pilot.id);
+
+    const response = await request(app).get(`/pilots/${pilot.id}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      pilotId: pilot.id,
+      result: "pass",
+      reasons: [
+        {
+          code: "PILOT_ACTIVE",
+          severity: "pass",
+          relatedEvidenceIds: [evidenceId],
+        },
+      ],
+    });
+    expect(response.body.readinessStatus.currentEvidence).toHaveLength(1);
+    expect(await countPilotRows(pilot.id)).toEqual(before);
+  });
+
+  it("fails readiness for an active pilot with no current evidence", async () => {
+    const pilot = await createPilot({
+      displayName: "No Evidence Pilot",
+      status: "active",
+    });
+    const before = await countPilotRows(pilot.id);
+
+    const response = await request(app).get(`/pilots/${pilot.id}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      pilotId: pilot.id,
+      result: "fail",
+      reasons: [
+        {
+          code: "PILOT_EVIDENCE_MISSING",
+          severity: "fail",
+        },
+      ],
+    });
+    expect(await countPilotRows(pilot.id)).toEqual(before);
+  });
+
+  it("fails readiness for expired pilot evidence", async () => {
+    const pilot = await createPilot({
+      displayName: "Expired Pilot",
+      status: "active",
+    });
+
+    const evidenceResponse = await request(app)
+      .post(`/pilots/${pilot.id}/readiness-evidence`)
+      .send({
+        evidenceType: "operator_authorisation",
+        title: "Expired operator authorisation",
+        expiresAt: "2020-01-01T00:00:00.000Z",
+      });
+
+    expect(evidenceResponse.status).toBe(201);
+    const evidenceId = evidenceResponse.body.evidence.id;
+
+    const response = await request(app).get(`/pilots/${pilot.id}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.result).toBe("fail");
+    expect(response.body.reasons).toContainEqual({
+      code: "PILOT_EVIDENCE_MISSING",
+      severity: "fail",
+      message: "Pilot has no current readiness evidence",
+    });
+    expect(response.body.reasons).toContainEqual({
+      code: "PILOT_EVIDENCE_EXPIRED",
+      severity: "fail",
+      message: "Pilot has expired readiness evidence",
+      relatedEvidenceIds: [evidenceId],
+    });
+  });
+
+  it("warns readiness for an inactive pilot with current evidence", async () => {
+    const pilot = await createPilot({
+      displayName: "Inactive Pilot",
+      status: "inactive",
+    });
+
+    await request(app)
+      .post(`/pilots/${pilot.id}/readiness-evidence`)
+      .send({
+        evidenceType: "operator_authorisation",
+        title: "Current operator authorisation",
+        expiresAt: "2099-01-01T00:00:00.000Z",
+      });
+
+    const response = await request(app).get(`/pilots/${pilot.id}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      pilotId: pilot.id,
+      result: "warning",
+      reasons: [
+        {
+          code: "PILOT_INACTIVE",
+          severity: "warning",
+        },
+      ],
+    });
+  });
+
+  it.each([
+    {
+      status: "suspended",
+      code: "PILOT_SUSPENDED",
+    },
+    {
+      status: "retired",
+      code: "PILOT_RETIRED",
+    },
+  ])("fails readiness for a $status pilot", async ({ status, code }) => {
+    const pilot = await createPilot({
+      displayName: `${status} Pilot`,
+      status,
+    });
+
+    const response = await request(app).get(`/pilots/${pilot.id}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      pilotId: pilot.id,
+      result: "fail",
+      reasons: [
+        {
+          code,
+          severity: "fail",
+        },
+      ],
+    });
+  });
+
+  it("returns not found for unknown pilots", async () => {
+    const response = await request(app).get(
+      "/pilots/7a2ed2c4-e238-4743-aa60-5bcd5a50d7b7/readiness",
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "pilot_not_found",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements issue #11 by adding pilot readiness checks and combining pilot fitness with platform readiness in the mission gate.

## What changed
- Added pilot and pilot readiness evidence persistence.
- Added `POST /pilots`, `GET /pilots/:id`, `POST /pilots/:id/readiness-evidence`, and `GET /pilots/:id/readiness`.
- Added pilot readiness logic returning `pass`, `warning`, or `fail` with machine-readable reasons.
- Added nullable `missions.pilot_id` assignment.
- Extended `GET /missions/:missionId/readiness` to combine platform readiness and pilot readiness.
- Added mission readiness reasons for ready/warning/failed/missing/unknown pilot cases.
- Updated the next build step toward mission risk scoring inputs.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/pilot-readiness.test.ts src/tests/mission-readiness.test.ts` passed: 16 tests.
- `./node_modules/.bin/vitest.cmd run src/tests/platform-readiness.test.ts src/tests/platform-maintenance.test.ts` passed: 11 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 128 tests.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #11.
