### PR TITLE
Add mission risk scoring inputs #13

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission risk scoring inputs so mission gates can combine platform, pilot, and operational risk.",
+ "nextBuildStep": "Add airspace compliance inputs so mission gates can combine readiness, risk, and operating constraints.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -34,6 +34,10 @@ import { PilotRepository } from "./pilots/pilot.repository";
 import { PilotService } from "./pilots/pilot.service";
 import { PilotController } from "./pilots/pilot.controller";
 import { createPilotRouter } from "./pilots/pilot.routes";
+import { MissionRiskRepository } from "./mission-risk/mission-risk.repository";
+import { MissionRiskService } from "./mission-risk/mission-risk.service";
+import { MissionRiskController } from "./mission-risk/mission-risk.controller";
+import { createMissionRiskRouter } from "./mission-risk/mission-risk.routes";
 
 dotenv.config({
   path: path.resolve(process.cwd(), ".env"),
@@ -101,16 +105,21 @@ const platformController = new PlatformController(platformService);
 const pilotRepository = new PilotRepository();
 const pilotService = new PilotService(pool, pilotRepository);
 const pilotController = new PilotController(pilotService);
+const missionRiskRepository = new MissionRiskRepository();
+const missionRiskService = new MissionRiskService(pool, missionRiskRepository);
+const missionRiskController = new MissionRiskController(missionRiskService);
 const missionService = new MissionService(
   db,
   missionRepo,
   missionEventRepo,
   platformService,
   pilotService,
+  missionRiskService,
 );
 const missionController = new MissionController(missionService);
 
 app.use("/missions", createMissionRouter(missionController));
+app.use("/missions", createMissionRiskRouter(missionRiskController));
 app.use("/missions", createMissionReplayRouter(missionReplayController));
 app.use("/missions", createMissionTelemetryRouter(missionTelemetryController));
 app.use("/missions", createAlertRouter(alertController));

--- a/src/migrations/011_create_mission_risk_inputs.sql
+++ b/src/migrations/011_create_mission_risk_inputs.sql
@@ -1,0 +1,28 @@
+create table if not exists mission_risk_inputs (
+  id uuid primary key,
+  mission_id uuid not null references missions(id) on delete cascade,
+  operating_category text not null,
+  mission_complexity text not null,
+  population_exposure text not null,
+  airspace_complexity text not null,
+  weather_risk text not null,
+  payload_risk text not null,
+  mitigation_summary text null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint mission_risk_operating_category_chk
+    check (operating_category in ('open', 'specific', 'certified')),
+  constraint mission_risk_complexity_chk
+    check (mission_complexity in ('low', 'medium', 'high')),
+  constraint mission_risk_population_exposure_chk
+    check (population_exposure in ('low', 'medium', 'high')),
+  constraint mission_risk_airspace_complexity_chk
+    check (airspace_complexity in ('low', 'medium', 'high')),
+  constraint mission_risk_weather_risk_chk
+    check (weather_risk in ('low', 'medium', 'high')),
+  constraint mission_risk_payload_risk_chk
+    check (payload_risk in ('low', 'medium', 'high'))
+);
+
+create index if not exists idx_mission_risk_inputs_mission_created
+  on mission_risk_inputs (mission_id, created_at desc);

--- a/src/mission-risk/mission-risk.controller.ts
+++ b/src/mission-risk/mission-risk.controller.ts
@@ -1,0 +1,41 @@
+import type { NextFunction, Request, Response } from "express";
+import { MissionRiskService } from "./mission-risk.service";
+
+type MissionIdParams = {
+  missionId: string;
+};
+
+export class MissionRiskController {
+  constructor(private readonly missionRiskService: MissionRiskService) {}
+
+  createMissionRiskInput = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const input = await this.missionRiskService.createMissionRiskInput(
+        req.params.missionId,
+        req.body,
+      );
+      res.status(201).json({ input });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getMissionRiskAssessment = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const assessment = await this.missionRiskService.assessMissionRisk(
+        req.params.missionId,
+      );
+      res.status(200).json(assessment);
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/mission-risk/mission-risk.errors.ts
+++ b/src/mission-risk/mission-risk.errors.ts
@@ -1,0 +1,13 @@
+export class MissionRiskValidationError extends Error {
+  readonly statusCode = 400;
+  readonly code = "MISSION_RISK_VALIDATION_FAILED";
+}
+
+export class MissionRiskMissionNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "MISSION_NOT_FOUND";
+
+  constructor(missionId: string) {
+    super(`Mission not found: ${missionId}`);
+  }
+}

--- a/src/mission-risk/mission-risk.repository.ts
+++ b/src/mission-risk/mission-risk.repository.ts
@@ -1,0 +1,105 @@
+import { randomUUID } from "crypto";
+import type { PoolClient, QueryResultRow } from "pg";
+import type { MissionRiskInput } from "./mission-risk.types";
+
+interface MissionRiskInputRow extends QueryResultRow {
+  id: string;
+  mission_id: string;
+  operating_category: MissionRiskInput["operatingCategory"];
+  mission_complexity: MissionRiskInput["missionComplexity"];
+  population_exposure: MissionRiskInput["populationExposure"];
+  airspace_complexity: MissionRiskInput["airspaceComplexity"];
+  weather_risk: MissionRiskInput["weatherRisk"];
+  payload_risk: MissionRiskInput["payloadRisk"];
+  mitigation_summary: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+type CreateMissionRiskInputRow = Omit<
+  MissionRiskInput,
+  "id" | "createdAt" | "updatedAt"
+>;
+
+const toMissionRiskInput = (row: MissionRiskInputRow): MissionRiskInput => ({
+  id: row.id,
+  missionId: row.mission_id,
+  operatingCategory: row.operating_category,
+  missionComplexity: row.mission_complexity,
+  populationExposure: row.population_exposure,
+  airspaceComplexity: row.airspace_complexity,
+  weatherRisk: row.weather_risk,
+  payloadRisk: row.payload_risk,
+  mitigationSummary: row.mitigation_summary,
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
+});
+
+export class MissionRiskRepository {
+  async missionExists(tx: PoolClient, missionId: string): Promise<boolean> {
+    const result = await tx.query(
+      `
+      select 1
+      from missions
+      where id = $1
+      `,
+      [missionId],
+    );
+
+    return result.rowCount === 1;
+  }
+
+  async insertMissionRiskInput(
+    tx: PoolClient,
+    input: CreateMissionRiskInputRow,
+  ): Promise<MissionRiskInput> {
+    const result = await tx.query<MissionRiskInputRow>(
+      `
+      insert into mission_risk_inputs (
+        id,
+        mission_id,
+        operating_category,
+        mission_complexity,
+        population_exposure,
+        airspace_complexity,
+        weather_risk,
+        payload_risk,
+        mitigation_summary
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.missionId,
+        input.operatingCategory,
+        input.missionComplexity,
+        input.populationExposure,
+        input.airspaceComplexity,
+        input.weatherRisk,
+        input.payloadRisk,
+        input.mitigationSummary,
+      ],
+    );
+
+    return toMissionRiskInput(result.rows[0]);
+  }
+
+  async getLatestMissionRiskInput(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<MissionRiskInput | null> {
+    const result = await tx.query<MissionRiskInputRow>(
+      `
+      select *
+      from mission_risk_inputs
+      where mission_id = $1
+      order by created_at desc, id desc
+      limit 1
+      `,
+      [missionId],
+    );
+
+    return result.rows[0] ? toMissionRiskInput(result.rows[0]) : null;
+  }
+}

--- a/src/mission-risk/mission-risk.routes.ts
+++ b/src/mission-risk/mission-risk.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { MissionRiskController } from "./mission-risk.controller";
+
+export function createMissionRiskRouter(
+  controller: MissionRiskController,
+): Router {
+  const router = Router();
+
+  router.post("/:missionId/risk-inputs", controller.createMissionRiskInput);
+  router.get("/:missionId/risk", controller.getMissionRiskAssessment);
+
+  return router;
+}

--- a/src/mission-risk/mission-risk.service.ts
+++ b/src/mission-risk/mission-risk.service.ts
@@ -1,0 +1,179 @@
+import type { Pool } from "pg";
+import { MissionRiskMissionNotFoundError } from "./mission-risk.errors";
+import { MissionRiskRepository } from "./mission-risk.repository";
+import type {
+  CreateMissionRiskInput,
+  MissionRiskAssessment,
+  MissionRiskBand,
+  MissionRiskInput,
+  MissionRiskReason,
+  MissionRiskResult,
+  OperatingCategory,
+  RiskLevel,
+} from "./mission-risk.types";
+import { validateCreateMissionRiskInput } from "./mission-risk.validators";
+
+const CATEGORY_SCORE: Record<OperatingCategory, number> = {
+  open: 0,
+  specific: 2,
+  certified: 4,
+};
+
+const LEVEL_SCORE: Record<RiskLevel, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+};
+
+export class MissionRiskService {
+  constructor(
+    private readonly pool: Pool,
+    private readonly missionRiskRepository: MissionRiskRepository,
+  ) {}
+
+  async createMissionRiskInput(
+    missionId: string,
+    input: CreateMissionRiskInput,
+  ): Promise<MissionRiskInput> {
+    const validated = validateCreateMissionRiskInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.missionRiskRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new MissionRiskMissionNotFoundError(missionId);
+      }
+
+      return await this.missionRiskRepository.insertMissionRiskInput(client, {
+        missionId,
+        ...validated,
+      });
+    } finally {
+      client.release();
+    }
+  }
+
+  async assessMissionRisk(missionId: string): Promise<MissionRiskAssessment> {
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.missionRiskRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new MissionRiskMissionNotFoundError(missionId);
+      }
+
+      const input = await this.missionRiskRepository.getLatestMissionRiskInput(
+        client,
+        missionId,
+      );
+
+      if (!input) {
+        return {
+          missionId,
+          result: "fail",
+          score: null,
+          riskBand: null,
+          reasons: [
+            {
+              code: "MISSION_RISK_MISSING",
+              severity: "fail",
+              message: "Mission has no risk scoring inputs",
+            },
+          ],
+          input: null,
+        };
+      }
+
+      const score = this.scoreMissionRisk(input);
+      const riskBand = this.getRiskBand(score);
+      const reasons = this.buildRiskReasons(score, riskBand);
+
+      return {
+        missionId,
+        result: this.getRiskResult(reasons),
+        score,
+        riskBand,
+        reasons,
+        input,
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  private scoreMissionRisk(input: MissionRiskInput): number {
+    return (
+      CATEGORY_SCORE[input.operatingCategory] +
+      LEVEL_SCORE[input.missionComplexity] +
+      LEVEL_SCORE[input.populationExposure] +
+      LEVEL_SCORE[input.airspaceComplexity] +
+      LEVEL_SCORE[input.weatherRisk] +
+      LEVEL_SCORE[input.payloadRisk]
+    );
+  }
+
+  private getRiskBand(score: number): MissionRiskBand {
+    if (score > 12) {
+      return "high";
+    }
+
+    if (score > 8) {
+      return "moderate";
+    }
+
+    return "low";
+  }
+
+  private buildRiskReasons(
+    score: number,
+    riskBand: MissionRiskBand,
+  ): MissionRiskReason[] {
+    if (riskBand === "high") {
+      return [
+        {
+          code: "MISSION_RISK_HIGH",
+          severity: "fail",
+          message: `Mission risk score ${score} is high and blocks approval or dispatch`,
+        },
+      ];
+    }
+
+    if (riskBand === "moderate") {
+      return [
+        {
+          code: "MISSION_RISK_ELEVATED",
+          severity: "warning",
+          message: `Mission risk score ${score} requires explicit review`,
+        },
+      ];
+    }
+
+    return [
+      {
+        code: "MISSION_RISK_ACCEPTABLE",
+        severity: "pass",
+        message: `Mission risk score ${score} is acceptable for planning`,
+      },
+    ];
+  }
+
+  private getRiskResult(reasons: MissionRiskReason[]): MissionRiskResult {
+    if (reasons.some((reason) => reason.severity === "fail")) {
+      return "fail";
+    }
+
+    if (reasons.some((reason) => reason.severity === "warning")) {
+      return "warning";
+    }
+
+    return "pass";
+  }
+}

--- a/src/mission-risk/mission-risk.types.ts
+++ b/src/mission-risk/mission-risk.types.ts
@@ -1,0 +1,52 @@
+export type OperatingCategory = "open" | "specific" | "certified";
+
+export type RiskLevel = "low" | "medium" | "high";
+
+export interface CreateMissionRiskInput {
+  operatingCategory?: OperatingCategory;
+  missionComplexity?: RiskLevel;
+  populationExposure?: RiskLevel;
+  airspaceComplexity?: RiskLevel;
+  weatherRisk?: RiskLevel;
+  payloadRisk?: RiskLevel;
+  mitigationSummary?: string | null;
+}
+
+export interface MissionRiskInput {
+  id: string;
+  missionId: string;
+  operatingCategory: OperatingCategory;
+  missionComplexity: RiskLevel;
+  populationExposure: RiskLevel;
+  airspaceComplexity: RiskLevel;
+  weatherRisk: RiskLevel;
+  payloadRisk: RiskLevel;
+  mitigationSummary: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type MissionRiskResult = "pass" | "warning" | "fail";
+
+export type MissionRiskBand = "low" | "moderate" | "high";
+
+export type MissionRiskReasonCode =
+  | "MISSION_RISK_ACCEPTABLE"
+  | "MISSION_RISK_ELEVATED"
+  | "MISSION_RISK_HIGH"
+  | "MISSION_RISK_MISSING";
+
+export interface MissionRiskReason {
+  code: MissionRiskReasonCode;
+  severity: MissionRiskResult;
+  message: string;
+}
+
+export interface MissionRiskAssessment {
+  missionId: string;
+  result: MissionRiskResult;
+  score: number | null;
+  riskBand: MissionRiskBand | null;
+  reasons: MissionRiskReason[];
+  input: MissionRiskInput | null;
+}

--- a/src/mission-risk/mission-risk.validators.ts
+++ b/src/mission-risk/mission-risk.validators.ts
@@ -1,0 +1,74 @@
+import { MissionRiskValidationError } from "./mission-risk.errors";
+import type {
+  CreateMissionRiskInput,
+  OperatingCategory,
+  RiskLevel,
+} from "./mission-risk.types";
+
+const OPERATING_CATEGORIES = new Set<OperatingCategory>([
+  "open",
+  "specific",
+  "certified",
+]);
+
+const RISK_LEVELS = new Set<RiskLevel>(["low", "medium", "high"]);
+
+function requiredEnum<T extends string>(
+  value: unknown,
+  fieldName: string,
+  allowed: Set<T>,
+): T {
+  if (typeof value !== "string" || !allowed.has(value as T)) {
+    throw new MissionRiskValidationError(`${fieldName} is not supported`);
+  }
+
+  return value as T;
+}
+
+function optionalTrimmed(value: unknown, fieldName: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    throw new MissionRiskValidationError(`${fieldName} must be a string`);
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function validateCreateMissionRiskInput(input: CreateMissionRiskInput) {
+  if (!input || typeof input !== "object") {
+    throw new MissionRiskValidationError("Request body must be an object");
+  }
+
+  return {
+    operatingCategory: requiredEnum(
+      input.operatingCategory,
+      "operatingCategory",
+      OPERATING_CATEGORIES,
+    ),
+    missionComplexity: requiredEnum(
+      input.missionComplexity,
+      "missionComplexity",
+      RISK_LEVELS,
+    ),
+    populationExposure: requiredEnum(
+      input.populationExposure,
+      "populationExposure",
+      RISK_LEVELS,
+    ),
+    airspaceComplexity: requiredEnum(
+      input.airspaceComplexity,
+      "airspaceComplexity",
+      RISK_LEVELS,
+    ),
+    weatherRisk: requiredEnum(input.weatherRisk, "weatherRisk", RISK_LEVELS),
+    payloadRisk: requiredEnum(input.payloadRisk, "payloadRisk", RISK_LEVELS),
+    mitigationSummary: optionalTrimmed(
+      input.mitigationSummary,
+      "mitigationSummary",
+    ),
+  };
+}

--- a/src/missions/mission-readiness.types.ts
+++ b/src/missions/mission-readiness.types.ts
@@ -1,5 +1,6 @@
 import type { PlatformReadinessCheck } from "../platforms/platform.types";
 import type { PilotReadinessCheck } from "../pilots/pilot.types";
+import type { MissionRiskAssessment } from "../mission-risk/mission-risk.types";
 
 export type MissionReadinessResult = "pass" | "warning" | "fail";
 
@@ -13,17 +14,21 @@ export type MissionReadinessReasonCode =
   | "MISSION_PILOT_WARNING"
   | "MISSION_PILOT_FAILED"
   | "MISSION_PILOT_NOT_ASSIGNED"
-  | "MISSION_PILOT_NOT_FOUND";
+  | "MISSION_PILOT_NOT_FOUND"
+  | "MISSION_RISK_READY"
+  | "MISSION_RISK_WARNING"
+  | "MISSION_RISK_FAILED";
 
 export interface MissionReadinessReason {
   code: MissionReadinessReasonCode;
   severity: MissionReadinessResult;
   message: string;
-  source: "mission" | "platform" | "pilot";
+  source: "mission" | "platform" | "pilot" | "risk";
   relatedPlatformId?: string;
   relatedPlatformReasonCodes?: string[];
   relatedPilotId?: string;
   relatedPilotReasonCodes?: string[];
+  relatedRiskReasonCodes?: string[];
 }
 
 export interface MissionReadinessGate {
@@ -42,4 +47,5 @@ export interface MissionReadinessCheck {
   reasons: MissionReadinessReason[];
   platformReadiness: PlatformReadinessCheck | null;
   pilotReadiness: PilotReadinessCheck | null;
+  missionRisk: MissionRiskAssessment | null;
 }

--- a/src/missions/mission.service.ts
+++ b/src/missions/mission.service.ts
@@ -10,12 +10,14 @@ import { PlatformNotFoundError } from "../platforms/platform.errors";
 import { PlatformService } from "../platforms/platform.service";
 import { PilotNotFoundError } from "../pilots/pilot.errors";
 import { PilotService } from "../pilots/pilot.service";
+import { MissionRiskService } from "../mission-risk/mission-risk.service";
 import type {
   MissionReadinessCheck,
   MissionReadinessReason,
   MissionReadinessResult,
 } from "./mission-readiness.types";
 import type { PilotReadinessResult } from "../pilots/pilot.types";
+import type { MissionRiskResult } from "../mission-risk/mission-risk.types";
 
 export interface GetMissionEventsFilters {
   safety?: boolean;
@@ -54,6 +56,7 @@ export class MissionService {
     private readonly missionEventRepo: MissionEventRepository,
     private readonly platformService?: PlatformService,
     private readonly pilotService?: PilotService,
+    private readonly missionRiskService?: MissionRiskService,
   ) {}
 
   async submitMission(params: {
@@ -250,6 +253,7 @@ export class MissionService {
     const reasons: MissionReadinessReason[] = [];
     let platformReadiness: MissionReadinessCheck["platformReadiness"] = null;
     let pilotReadiness: MissionReadinessCheck["pilotReadiness"] = null;
+    let missionRisk: MissionReadinessCheck["missionRisk"] = null;
 
     if (!platformId) {
       reasons.push({
@@ -332,6 +336,23 @@ export class MissionService {
       }
     }
 
+    if (!this.missionRiskService) {
+      reasons.push({
+        code: "MISSION_RISK_FAILED",
+        severity: "fail",
+        message: "Mission risk assessment service is not available",
+        source: "mission",
+      });
+    } else {
+      missionRisk = await this.missionRiskService.assessMissionRisk(mission.id);
+      reasons.push(
+        this.mapMissionRiskReason(
+          missionRisk.result,
+          missionRisk.reasons.map((reason) => reason.code),
+        ),
+      );
+    }
+
     return this.buildMissionReadiness({
       missionId: mission.id,
       platformId,
@@ -339,6 +360,7 @@ export class MissionService {
       reasons,
       platformReadiness,
       pilotReadiness,
+      missionRisk,
     });
   }
 
@@ -450,6 +472,39 @@ export class MissionService {
     };
   }
 
+  private mapMissionRiskReason(
+    result: MissionRiskResult,
+    riskReasonCodes: string[],
+  ): MissionReadinessReason {
+    if (result === "fail") {
+      return {
+        code: "MISSION_RISK_FAILED",
+        severity: "fail",
+        message: "Mission risk assessment fails and blocks approval or dispatch",
+        source: "risk",
+        relatedRiskReasonCodes: riskReasonCodes,
+      };
+    }
+
+    if (result === "warning") {
+      return {
+        code: "MISSION_RISK_WARNING",
+        severity: "warning",
+        message: "Mission risk assessment requires explicit review before approval or dispatch",
+        source: "risk",
+        relatedRiskReasonCodes: riskReasonCodes,
+      };
+    }
+
+    return {
+      code: "MISSION_RISK_READY",
+      severity: "pass",
+      message: "Mission risk assessment passes for planning",
+      source: "risk",
+      relatedRiskReasonCodes: riskReasonCodes,
+    };
+  }
+
   private buildMissionReadiness(params: {
     missionId: string;
     platformId: string | null;
@@ -457,6 +512,7 @@ export class MissionService {
     reasons: MissionReadinessReason[];
     platformReadiness: MissionReadinessCheck["platformReadiness"];
     pilotReadiness: MissionReadinessCheck["pilotReadiness"];
+    missionRisk: MissionReadinessCheck["missionRisk"];
   }): MissionReadinessCheck {
     const result = this.getMissionReadinessResult(params.reasons);
 
@@ -474,6 +530,7 @@ export class MissionService {
       reasons: params.reasons,
       platformReadiness: params.platformReadiness,
       pilotReadiness: params.pilotReadiness,
+      missionRisk: params.missionRisk,
     };
   }
 

--- a/src/tests/mission-readiness.test.ts
+++ b/src/tests/mission-readiness.test.ts
@@ -5,6 +5,7 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from mission_risk_inputs");
   await pool.query("delete from mission_events");
   await pool.query("delete from missions");
   await pool.query("delete from pilot_readiness_evidence");
@@ -78,6 +79,54 @@ const insertMission = async (params: {
   return missionId;
 };
 
+const createLowRiskInput = async (missionId: string) => {
+  const response = await request(app)
+    .post(`/missions/${missionId}/risk-inputs`)
+    .send({
+      operatingCategory: "open",
+      missionComplexity: "low",
+      populationExposure: "low",
+      airspaceComplexity: "low",
+      weatherRisk: "low",
+      payloadRisk: "low",
+    });
+
+  expect(response.status).toBe(201);
+  return response.body.input as { id: string };
+};
+
+const createModerateRiskInput = async (missionId: string) => {
+  const response = await request(app)
+    .post(`/missions/${missionId}/risk-inputs`)
+    .send({
+      operatingCategory: "specific",
+      missionComplexity: "medium",
+      populationExposure: "medium",
+      airspaceComplexity: "medium",
+      weatherRisk: "medium",
+      payloadRisk: "low",
+    });
+
+  expect(response.status).toBe(201);
+  return response.body.input as { id: string };
+};
+
+const createHighRiskInput = async (missionId: string) => {
+  const response = await request(app)
+    .post(`/missions/${missionId}/risk-inputs`)
+    .send({
+      operatingCategory: "certified",
+      missionComplexity: "high",
+      populationExposure: "high",
+      airspaceComplexity: "high",
+      weatherRisk: "high",
+      payloadRisk: "high",
+    });
+
+  expect(response.status).toBe(201);
+  return response.body.input as { id: string };
+};
+
 const countRows = async (params: {
   missionId: string;
   platformId?: string;
@@ -93,7 +142,8 @@ const countRows = async (params: {
       (select count(*)::int from maintenance_schedules where platform_id = $2) as schedule_count,
       (select count(*)::int from maintenance_records where platform_id = $2) as record_count,
       (select count(*)::int from pilots where id = $3) as pilot_count,
-      (select count(*)::int from pilot_readiness_evidence where pilot_id = $3) as pilot_evidence_count
+      (select count(*)::int from pilot_readiness_evidence where pilot_id = $3) as pilot_evidence_count,
+      (select count(*)::int from mission_risk_inputs where mission_id = $1) as risk_input_count
     `,
     [params.missionId, params.platformId ?? null, params.pilotId ?? null],
   );
@@ -107,6 +157,7 @@ const countRows = async (params: {
     record_count: number;
     pilot_count: number;
     pilot_evidence_count: number;
+    risk_input_count: number;
   };
 };
 
@@ -133,6 +184,7 @@ describe("mission readiness platform gate integration", () => {
       platformId: platform.id,
       pilotId: pilot.id,
     });
+    await createLowRiskInput(missionId);
     const before = await countRows({
       missionId,
       platformId: platform.id,
@@ -168,6 +220,12 @@ describe("mission readiness platform gate integration", () => {
           relatedPilotId: pilot.id,
           relatedPilotReasonCodes: ["PILOT_ACTIVE"],
         },
+        {
+          code: "MISSION_RISK_READY",
+          severity: "pass",
+          source: "risk",
+          relatedRiskReasonCodes: ["MISSION_RISK_ACCEPTABLE"],
+        },
       ],
       platformReadiness: {
         platformId: platform.id,
@@ -176,6 +234,12 @@ describe("mission readiness platform gate integration", () => {
       pilotReadiness: {
         pilotId: pilot.id,
         result: "pass",
+      },
+      missionRisk: {
+        missionId,
+        result: "pass",
+        score: 5,
+        riskBand: "low",
       },
     });
     expect(await countRows({
@@ -196,6 +260,7 @@ describe("mission readiness platform gate integration", () => {
       platformId: platform.id,
       pilotId: pilot.id,
     });
+    await createLowRiskInput(missionId);
 
     const scheduleResponse = await request(app)
       .post(`/platforms/${platform.id}/maintenance-schedules`)
@@ -240,6 +305,12 @@ describe("mission readiness platform gate integration", () => {
           relatedPilotId: pilot.id,
           relatedPilotReasonCodes: ["PILOT_ACTIVE"],
         },
+        {
+          code: "MISSION_RISK_READY",
+          severity: "pass",
+          source: "risk",
+          relatedRiskReasonCodes: ["MISSION_RISK_ACCEPTABLE"],
+        },
       ],
       platformReadiness: {
         platformId: platform.id,
@@ -247,6 +318,10 @@ describe("mission readiness platform gate integration", () => {
       },
       pilotReadiness: {
         pilotId: pilot.id,
+        result: "pass",
+      },
+      missionRisk: {
+        missionId,
         result: "pass",
       },
     });
@@ -276,6 +351,7 @@ describe("mission readiness platform gate integration", () => {
       platformId: platform.id,
       pilotId: pilot.id,
     });
+    await createLowRiskInput(missionId);
     const before = await countRows({
       missionId,
       platformId: platform.id,
@@ -311,6 +387,12 @@ describe("mission readiness platform gate integration", () => {
           relatedPilotId: pilot.id,
           relatedPilotReasonCodes: ["PILOT_ACTIVE"],
         },
+        {
+          code: "MISSION_RISK_READY",
+          severity: "pass",
+          source: "risk",
+          relatedRiskReasonCodes: ["MISSION_RISK_ACCEPTABLE"],
+        },
       ],
       platformReadiness: {
         platformId: platform.id,
@@ -318,6 +400,10 @@ describe("mission readiness platform gate integration", () => {
       },
       pilotReadiness: {
         pilotId: pilot.id,
+        result: "pass",
+      },
+      missionRisk: {
+        missionId,
         result: "pass",
       },
     });
@@ -334,6 +420,7 @@ describe("mission readiness platform gate integration", () => {
       platformId: null,
       pilotId: pilot.id,
     });
+    await createLowRiskInput(missionId);
     const before = await countRows({ missionId, pilotId: pilot.id });
 
     const response = await request(app).get(`/missions/${missionId}/readiness`);
@@ -363,10 +450,20 @@ describe("mission readiness platform gate integration", () => {
           relatedPilotId: pilot.id,
           relatedPilotReasonCodes: ["PILOT_ACTIVE"],
         },
+        {
+          code: "MISSION_RISK_READY",
+          severity: "pass",
+          source: "risk",
+          relatedRiskReasonCodes: ["MISSION_RISK_ACCEPTABLE"],
+        },
       ],
       platformReadiness: null,
       pilotReadiness: {
         pilotId: pilot.id,
+        result: "pass",
+      },
+      missionRisk: {
+        missionId,
         result: "pass",
       },
     });
@@ -384,6 +481,7 @@ describe("mission readiness platform gate integration", () => {
       platformId: platform.id,
       pilotId: pilot.id,
     });
+    await createLowRiskInput(missionId);
     const before = await countRows({
       missionId,
       platformId: platform.id,
@@ -420,10 +518,20 @@ describe("mission readiness platform gate integration", () => {
           relatedPilotId: pilot.id,
           relatedPilotReasonCodes: ["PILOT_ACTIVE"],
         },
+        {
+          code: "MISSION_RISK_READY",
+          severity: "pass",
+          source: "risk",
+          relatedRiskReasonCodes: ["MISSION_RISK_ACCEPTABLE"],
+        },
       ],
       platformReadiness: null,
       pilotReadiness: {
         pilotId: pilot.id,
+        result: "pass",
+      },
+      missionRisk: {
+        missionId,
         result: "pass",
       },
     });
@@ -458,6 +566,7 @@ describe("mission readiness platform gate integration", () => {
       platformId: platform.id,
       pilotId: pilot.id,
     });
+    await createLowRiskInput(missionId);
     const before = await countRows({
       missionId,
       platformId: platform.id,
@@ -494,6 +603,12 @@ describe("mission readiness platform gate integration", () => {
             "PILOT_EVIDENCE_EXPIRED",
           ],
         },
+        {
+          code: "MISSION_RISK_READY",
+          severity: "pass",
+          source: "risk",
+          relatedRiskReasonCodes: ["MISSION_RISK_ACCEPTABLE"],
+        },
       ],
       platformReadiness: {
         result: "pass",
@@ -501,6 +616,10 @@ describe("mission readiness platform gate integration", () => {
       pilotReadiness: {
         pilotId: pilot.id,
         result: "fail",
+      },
+      missionRisk: {
+        missionId,
+        result: "pass",
       },
     });
     expect(await countRows({
@@ -519,6 +638,7 @@ describe("mission readiness platform gate integration", () => {
       platformId: platform.id,
       pilotId: null,
     });
+    await createLowRiskInput(missionId);
     const before = await countRows({ missionId, platformId: platform.id });
 
     const response = await request(app).get(`/missions/${missionId}/readiness`);
@@ -540,8 +660,18 @@ describe("mission readiness platform gate integration", () => {
           severity: "fail",
           source: "mission",
         },
+        {
+          code: "MISSION_RISK_READY",
+          severity: "pass",
+          source: "risk",
+          relatedRiskReasonCodes: ["MISSION_RISK_ACCEPTABLE"],
+        },
       ],
       pilotReadiness: null,
+      missionRisk: {
+        missionId,
+        result: "pass",
+      },
     });
     expect(await countRows({ missionId, platformId: platform.id })).toEqual(before);
   });
@@ -557,6 +687,7 @@ describe("mission readiness platform gate integration", () => {
       platformId: platform.id,
       pilotId: pilot.id,
     });
+    await createLowRiskInput(missionId);
     const before = await countRows({
       missionId,
       platformId: platform.id,
@@ -585,8 +716,201 @@ describe("mission readiness platform gate integration", () => {
           source: "mission",
           relatedPilotId: missingPilotId,
         },
+        {
+          code: "MISSION_RISK_READY",
+          severity: "pass",
+          source: "risk",
+          relatedRiskReasonCodes: ["MISSION_RISK_ACCEPTABLE"],
+        },
       ],
       pilotReadiness: null,
+      missionRisk: {
+        missionId,
+        result: "pass",
+      },
+    });
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    })).toEqual(before);
+  });
+
+  it("surfaces mission risk warnings in the combined readiness gate", async () => {
+    const platform = await createPlatform({
+      name: "Ready UAV",
+      status: "active",
+    });
+    const pilot = await createReadyPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    await createModerateRiskInput(missionId);
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+
+    const response = await request(app).get(`/missions/${missionId}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      result: "warning",
+      gate: {
+        result: "warning",
+        blocksApproval: false,
+        blocksDispatch: false,
+        requiresReview: true,
+      },
+      reasons: [
+        {
+          code: "MISSION_PLATFORM_READY",
+          severity: "pass",
+          source: "platform",
+        },
+        {
+          code: "MISSION_PILOT_READY",
+          severity: "pass",
+          source: "pilot",
+        },
+        {
+          code: "MISSION_RISK_WARNING",
+          severity: "warning",
+          source: "risk",
+          relatedRiskReasonCodes: ["MISSION_RISK_ELEVATED"],
+        },
+      ],
+      missionRisk: {
+        missionId,
+        result: "warning",
+        score: 11,
+        riskBand: "moderate",
+      },
+    });
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    })).toEqual(before);
+  });
+
+  it("fails the combined readiness gate for high mission risk", async () => {
+    const platform = await createPlatform({
+      name: "Ready UAV",
+      status: "active",
+    });
+    const pilot = await createReadyPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    await createHighRiskInput(missionId);
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+
+    const response = await request(app).get(`/missions/${missionId}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      result: "fail",
+      gate: {
+        result: "fail",
+        blocksApproval: true,
+        blocksDispatch: true,
+        requiresReview: false,
+      },
+      reasons: [
+        {
+          code: "MISSION_PLATFORM_READY",
+          severity: "pass",
+          source: "platform",
+        },
+        {
+          code: "MISSION_PILOT_READY",
+          severity: "pass",
+          source: "pilot",
+        },
+        {
+          code: "MISSION_RISK_FAILED",
+          severity: "fail",
+          source: "risk",
+          relatedRiskReasonCodes: ["MISSION_RISK_HIGH"],
+        },
+      ],
+      missionRisk: {
+        missionId,
+        result: "fail",
+        score: 19,
+        riskBand: "high",
+      },
+    });
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    })).toEqual(before);
+  });
+
+  it("fails explicitly when mission risk inputs are missing", async () => {
+    const platform = await createPlatform({
+      name: "Ready UAV",
+      status: "active",
+    });
+    const pilot = await createReadyPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+
+    const response = await request(app).get(`/missions/${missionId}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      result: "fail",
+      reasons: [
+        {
+          code: "MISSION_PLATFORM_READY",
+          severity: "pass",
+          source: "platform",
+        },
+        {
+          code: "MISSION_PILOT_READY",
+          severity: "pass",
+          source: "pilot",
+        },
+        {
+          code: "MISSION_RISK_FAILED",
+          severity: "fail",
+          source: "risk",
+          relatedRiskReasonCodes: ["MISSION_RISK_MISSING"],
+        },
+      ],
+      missionRisk: {
+        missionId,
+        result: "fail",
+        score: null,
+        riskBand: null,
+        input: null,
+      },
     });
     expect(await countRows({
       missionId,

--- a/src/tests/mission-risk.test.ts
+++ b/src/tests/mission-risk.test.ts
@@ -1,0 +1,197 @@
+import { randomUUID } from "crypto";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import app, { pool } from "../app";
+import { runMigrations } from "../migrations/runMigrations";
+
+const clearTables = async () => {
+  await pool.query("delete from mission_risk_inputs");
+  await pool.query("delete from mission_events");
+  await pool.query("delete from missions");
+};
+
+const insertMission = async (missionId = randomUUID()) => {
+  await pool.query(
+    `
+    insert into missions (
+      id,
+      status,
+      mission_plan_id,
+      last_event_sequence_no
+    )
+    values ($1, $2, $3, $4)
+    `,
+    [missionId, "submitted", "plan-1", 0],
+  );
+
+  return missionId;
+};
+
+const countRows = async (missionId: string) => {
+  const result = await pool.query(
+    `
+    select
+      (select status from missions where id = $1) as mission_status,
+      (select last_event_sequence_no from missions where id = $1) as mission_sequence,
+      (select count(*)::int from mission_events where mission_id = $1) as mission_event_count,
+      (select count(*)::int from mission_risk_inputs where mission_id = $1) as risk_input_count
+    `,
+    [missionId],
+  );
+
+  return result.rows[0] as {
+    mission_status: string;
+    mission_sequence: number;
+    mission_event_count: number;
+    risk_input_count: number;
+  };
+};
+
+describe("mission risk integration", () => {
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  beforeEach(async () => {
+    await clearTables();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("passes risk assessment for low mission risk inputs", async () => {
+    const missionId = await insertMission();
+
+    const createResponse = await request(app)
+      .post(`/missions/${missionId}/risk-inputs`)
+      .send({
+        operatingCategory: "open",
+        missionComplexity: "low",
+        populationExposure: "low",
+        airspaceComplexity: "low",
+        weatherRisk: "low",
+        payloadRisk: "low",
+        mitigationSummary: "Standard mitigations in place",
+      });
+
+    expect(createResponse.status).toBe(201);
+    const before = await countRows(missionId);
+
+    const response = await request(app).get(`/missions/${missionId}/risk`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      result: "pass",
+      score: 5,
+      riskBand: "low",
+      reasons: [
+        {
+          code: "MISSION_RISK_ACCEPTABLE",
+          severity: "pass",
+        },
+      ],
+      input: {
+        missionId,
+        operatingCategory: "open",
+        missionComplexity: "low",
+      },
+    });
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("warns risk assessment for moderate mission risk inputs", async () => {
+    const missionId = await insertMission();
+
+    await request(app).post(`/missions/${missionId}/risk-inputs`).send({
+      operatingCategory: "specific",
+      missionComplexity: "medium",
+      populationExposure: "medium",
+      airspaceComplexity: "medium",
+      weatherRisk: "medium",
+      payloadRisk: "low",
+    });
+
+    const response = await request(app).get(`/missions/${missionId}/risk`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      result: "warning",
+      score: 11,
+      riskBand: "moderate",
+      reasons: [
+        {
+          code: "MISSION_RISK_ELEVATED",
+          severity: "warning",
+        },
+      ],
+    });
+  });
+
+  it("fails risk assessment for high mission risk inputs", async () => {
+    const missionId = await insertMission();
+
+    await request(app).post(`/missions/${missionId}/risk-inputs`).send({
+      operatingCategory: "certified",
+      missionComplexity: "high",
+      populationExposure: "high",
+      airspaceComplexity: "high",
+      weatherRisk: "high",
+      payloadRisk: "high",
+    });
+
+    const response = await request(app).get(`/missions/${missionId}/risk`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      result: "fail",
+      score: 19,
+      riskBand: "high",
+      reasons: [
+        {
+          code: "MISSION_RISK_HIGH",
+          severity: "fail",
+        },
+      ],
+    });
+  });
+
+  it("fails explicitly when mission risk inputs are missing", async () => {
+    const missionId = await insertMission();
+    const before = await countRows(missionId);
+
+    const response = await request(app).get(`/missions/${missionId}/risk`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      result: "fail",
+      score: null,
+      riskBand: null,
+      reasons: [
+        {
+          code: "MISSION_RISK_MISSING",
+          severity: "fail",
+        },
+      ],
+      input: null,
+    });
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("returns not found for unknown missions", async () => {
+    const response = await request(app).get(
+      "/missions/7a2ed2c4-e238-4743-aa60-5bcd5a50d7b7/risk",
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "mission_not_found",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements issue #13 by adding mission risk inputs and combining operational risk with platform and pilot readiness in the mission gate.

## What changed
- Added `mission_risk_inputs` persistence linked to missions.
- Added `POST /missions/:missionId/risk-inputs` and `GET /missions/:missionId/risk`.
- Added deterministic mission risk scoring with low/moderate/high bands and pass/warning/fail results.
- Added machine-readable mission risk reasons for acceptable, elevated, high, and missing risk inputs.
- Extended `GET /missions/:missionId/readiness` to combine platform readiness, pilot readiness, and mission risk.
- Updated the next build step toward airspace compliance inputs.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/mission-risk.test.ts src/tests/mission-readiness.test.ts` passed: 17 tests.
- `./node_modules/.bin/vitest.cmd run src/tests/pilot-readiness.test.ts src/tests/platform-readiness.test.ts` passed: 13 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 136 tests.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #13.
