### PR TITLE
Add airspace compliance inputs #15

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add airspace compliance inputs so mission gates can combine readiness, risk, and operating constraints.",
+ "nextBuildStep": "Add audit evidence snapshots so mission gates can preserve readiness decisions as reviewable records.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/airspace-compliance/airspace-compliance.controller.ts
+++ b/src/airspace-compliance/airspace-compliance.controller.ts
@@ -1,0 +1,45 @@
+import type { NextFunction, Request, Response } from "express";
+import { AirspaceComplianceService } from "./airspace-compliance.service";
+
+type MissionIdParams = {
+  missionId: string;
+};
+
+export class AirspaceComplianceController {
+  constructor(
+    private readonly airspaceComplianceService: AirspaceComplianceService,
+  ) {}
+
+  createAirspaceComplianceInput = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const input =
+        await this.airspaceComplianceService.createAirspaceComplianceInput(
+          req.params.missionId,
+          req.body,
+        );
+      res.status(201).json({ input });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getAirspaceComplianceAssessment = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const assessment =
+        await this.airspaceComplianceService.assessAirspaceCompliance(
+          req.params.missionId,
+        );
+      res.status(200).json(assessment);
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/airspace-compliance/airspace-compliance.errors.ts
+++ b/src/airspace-compliance/airspace-compliance.errors.ts
@@ -1,0 +1,13 @@
+export class AirspaceComplianceValidationError extends Error {
+  readonly statusCode = 400;
+  readonly code = "AIRSPACE_COMPLIANCE_VALIDATION_FAILED";
+}
+
+export class AirspaceComplianceMissionNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "MISSION_NOT_FOUND";
+
+  constructor(missionId: string) {
+    super(`Mission not found: ${missionId}`);
+  }
+}

--- a/src/airspace-compliance/airspace-compliance.repository.ts
+++ b/src/airspace-compliance/airspace-compliance.repository.ts
@@ -1,0 +1,111 @@
+import { randomUUID } from "crypto";
+import type { PoolClient, QueryResultRow } from "pg";
+import type { AirspaceComplianceInput } from "./airspace-compliance.types";
+
+interface AirspaceComplianceInputRow extends QueryResultRow {
+  id: string;
+  mission_id: string;
+  airspace_class: AirspaceComplianceInput["airspaceClass"];
+  max_altitude_ft: number;
+  restriction_status: AirspaceComplianceInput["restrictionStatus"];
+  permission_status: AirspaceComplianceInput["permissionStatus"];
+  controlled_airspace: boolean;
+  nearby_aerodrome: boolean;
+  evidence_ref: string | null;
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+type CreateAirspaceComplianceInputRow = Omit<
+  AirspaceComplianceInput,
+  "id" | "createdAt" | "updatedAt"
+>;
+
+const toAirspaceComplianceInput = (
+  row: AirspaceComplianceInputRow,
+): AirspaceComplianceInput => ({
+  id: row.id,
+  missionId: row.mission_id,
+  airspaceClass: row.airspace_class,
+  maxAltitudeFt: Number(row.max_altitude_ft),
+  restrictionStatus: row.restriction_status,
+  permissionStatus: row.permission_status,
+  controlledAirspace: row.controlled_airspace,
+  nearbyAerodrome: row.nearby_aerodrome,
+  evidenceRef: row.evidence_ref,
+  notes: row.notes,
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
+});
+
+export class AirspaceComplianceRepository {
+  async missionExists(tx: PoolClient, missionId: string): Promise<boolean> {
+    const result = await tx.query(
+      `
+      select 1
+      from missions
+      where id = $1
+      `,
+      [missionId],
+    );
+
+    return result.rowCount === 1;
+  }
+
+  async insertAirspaceComplianceInput(
+    tx: PoolClient,
+    input: CreateAirspaceComplianceInputRow,
+  ): Promise<AirspaceComplianceInput> {
+    const result = await tx.query<AirspaceComplianceInputRow>(
+      `
+      insert into airspace_compliance_inputs (
+        id,
+        mission_id,
+        airspace_class,
+        max_altitude_ft,
+        restriction_status,
+        permission_status,
+        controlled_airspace,
+        nearby_aerodrome,
+        evidence_ref,
+        notes
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.missionId,
+        input.airspaceClass,
+        input.maxAltitudeFt,
+        input.restrictionStatus,
+        input.permissionStatus,
+        input.controlledAirspace,
+        input.nearbyAerodrome,
+        input.evidenceRef,
+        input.notes,
+      ],
+    );
+
+    return toAirspaceComplianceInput(result.rows[0]);
+  }
+
+  async getLatestAirspaceComplianceInput(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<AirspaceComplianceInput | null> {
+    const result = await tx.query<AirspaceComplianceInputRow>(
+      `
+      select *
+      from airspace_compliance_inputs
+      where mission_id = $1
+      order by created_at desc, id desc
+      limit 1
+      `,
+      [missionId],
+    );
+
+    return result.rows[0] ? toAirspaceComplianceInput(result.rows[0]) : null;
+  }
+}

--- a/src/airspace-compliance/airspace-compliance.routes.ts
+++ b/src/airspace-compliance/airspace-compliance.routes.ts
@@ -1,0 +1,16 @@
+import { Router } from "express";
+import { AirspaceComplianceController } from "./airspace-compliance.controller";
+
+export function createAirspaceComplianceRouter(
+  controller: AirspaceComplianceController,
+): Router {
+  const router = Router();
+
+  router.post(
+    "/:missionId/airspace-inputs",
+    controller.createAirspaceComplianceInput,
+  );
+  router.get("/:missionId/airspace", controller.getAirspaceComplianceAssessment);
+
+  return router;
+}

--- a/src/airspace-compliance/airspace-compliance.service.ts
+++ b/src/airspace-compliance/airspace-compliance.service.ts
@@ -1,0 +1,195 @@
+import type { Pool } from "pg";
+import {
+  AirspaceComplianceMissionNotFoundError,
+} from "./airspace-compliance.errors";
+import { AirspaceComplianceRepository } from "./airspace-compliance.repository";
+import type {
+  AirspaceComplianceAssessment,
+  AirspaceComplianceInput,
+  AirspaceComplianceReason,
+  AirspaceComplianceResult,
+  CreateAirspaceComplianceInput,
+} from "./airspace-compliance.types";
+import { validateCreateAirspaceComplianceInput } from "./airspace-compliance.validators";
+
+export class AirspaceComplianceService {
+  constructor(
+    private readonly pool: Pool,
+    private readonly airspaceRepository: AirspaceComplianceRepository,
+  ) {}
+
+  async createAirspaceComplianceInput(
+    missionId: string,
+    input: CreateAirspaceComplianceInput,
+  ): Promise<AirspaceComplianceInput> {
+    const validated = validateCreateAirspaceComplianceInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.airspaceRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new AirspaceComplianceMissionNotFoundError(missionId);
+      }
+
+      return await this.airspaceRepository.insertAirspaceComplianceInput(
+        client,
+        {
+          missionId,
+          ...validated,
+        },
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  async assessAirspaceCompliance(
+    missionId: string,
+  ): Promise<AirspaceComplianceAssessment> {
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.airspaceRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new AirspaceComplianceMissionNotFoundError(missionId);
+      }
+
+      const input =
+        await this.airspaceRepository.getLatestAirspaceComplianceInput(
+          client,
+          missionId,
+        );
+
+      if (!input) {
+        return {
+          missionId,
+          result: "fail",
+          reasons: [
+            {
+              code: "AIRSPACE_INPUT_MISSING",
+              severity: "fail",
+              message: "Mission has no airspace compliance inputs",
+            },
+          ],
+          input: null,
+        };
+      }
+
+      const reasons = this.buildComplianceReasons(input);
+
+      return {
+        missionId,
+        result: this.getComplianceResult(reasons),
+        reasons,
+        input,
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  private buildComplianceReasons(
+    input: AirspaceComplianceInput,
+  ): AirspaceComplianceReason[] {
+    const reasons: AirspaceComplianceReason[] = [];
+
+    if (input.restrictionStatus === "prohibited") {
+      reasons.push({
+        code: "AIRSPACE_PROHIBITED",
+        severity: "fail",
+        message: "Mission intersects prohibited airspace",
+      });
+    }
+
+    if (input.permissionStatus === "denied") {
+      reasons.push({
+        code: "AIRSPACE_PERMISSION_DENIED",
+        severity: "fail",
+        message: "Required airspace permission has been denied",
+      });
+    }
+
+    if (
+      input.restrictionStatus === "restricted" &&
+      input.permissionStatus !== "granted"
+    ) {
+      reasons.push({
+        code: "AIRSPACE_RESTRICTED",
+        severity: "fail",
+        message: "Restricted airspace requires granted permission before dispatch",
+      });
+    }
+
+    if (input.permissionStatus === "pending") {
+      reasons.push({
+        code: "AIRSPACE_PERMISSION_PENDING",
+        severity: "warning",
+        message: "Airspace permission is pending and requires review",
+      });
+    }
+
+    if (input.restrictionStatus === "permission_required") {
+      reasons.push({
+        code: "AIRSPACE_PERMISSION_REQUIRED",
+        severity: input.permissionStatus === "granted" ? "pass" : "warning",
+        message: "Mission requires airspace permission evidence",
+      });
+    }
+
+    if (input.controlledAirspace) {
+      reasons.push({
+        code: "AIRSPACE_CONTROLLED",
+        severity: input.permissionStatus === "granted" ? "pass" : "warning",
+        message: "Mission includes controlled airspace",
+      });
+    }
+
+    if (input.nearbyAerodrome) {
+      reasons.push({
+        code: "AIRSPACE_NEAR_AERODROME",
+        severity: "warning",
+        message: "Mission is near an aerodrome and requires explicit review",
+      });
+    }
+
+    if (input.maxAltitudeFt > 400 && input.permissionStatus !== "granted") {
+      reasons.push({
+        code: "AIRSPACE_ALTITUDE_REVIEW",
+        severity: "warning",
+        message: "Mission altitude exceeds 400 ft and requires permission review",
+      });
+    }
+
+    if (reasons.length === 0) {
+      reasons.push({
+        code: "AIRSPACE_CLEAR",
+        severity: "pass",
+        message: "Airspace compliance inputs are clear for planning",
+      });
+    }
+
+    return reasons;
+  }
+
+  private getComplianceResult(
+    reasons: AirspaceComplianceReason[],
+  ): AirspaceComplianceResult {
+    if (reasons.some((reason) => reason.severity === "fail")) {
+      return "fail";
+    }
+
+    if (reasons.some((reason) => reason.severity === "warning")) {
+      return "warning";
+    }
+
+    return "pass";
+  }
+}

--- a/src/airspace-compliance/airspace-compliance.types.ts
+++ b/src/airspace-compliance/airspace-compliance.types.ts
@@ -1,0 +1,62 @@
+export type AirspaceClass = "a" | "b" | "c" | "d" | "e" | "f" | "g";
+
+export type RestrictionStatus =
+  | "clear"
+  | "permission_required"
+  | "restricted"
+  | "prohibited";
+
+export type PermissionStatus = "not_required" | "pending" | "granted" | "denied";
+
+export interface CreateAirspaceComplianceInput {
+  airspaceClass?: AirspaceClass;
+  maxAltitudeFt?: number;
+  restrictionStatus?: RestrictionStatus;
+  permissionStatus?: PermissionStatus;
+  controlledAirspace?: boolean;
+  nearbyAerodrome?: boolean;
+  evidenceRef?: string | null;
+  notes?: string | null;
+}
+
+export interface AirspaceComplianceInput {
+  id: string;
+  missionId: string;
+  airspaceClass: AirspaceClass;
+  maxAltitudeFt: number;
+  restrictionStatus: RestrictionStatus;
+  permissionStatus: PermissionStatus;
+  controlledAirspace: boolean;
+  nearbyAerodrome: boolean;
+  evidenceRef: string | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type AirspaceComplianceResult = "pass" | "warning" | "fail";
+
+export type AirspaceComplianceReasonCode =
+  | "AIRSPACE_CLEAR"
+  | "AIRSPACE_INPUT_MISSING"
+  | "AIRSPACE_PERMISSION_PENDING"
+  | "AIRSPACE_PERMISSION_DENIED"
+  | "AIRSPACE_PERMISSION_REQUIRED"
+  | "AIRSPACE_RESTRICTED"
+  | "AIRSPACE_PROHIBITED"
+  | "AIRSPACE_CONTROLLED"
+  | "AIRSPACE_NEAR_AERODROME"
+  | "AIRSPACE_ALTITUDE_REVIEW";
+
+export interface AirspaceComplianceReason {
+  code: AirspaceComplianceReasonCode;
+  severity: AirspaceComplianceResult;
+  message: string;
+}
+
+export interface AirspaceComplianceAssessment {
+  missionId: string;
+  result: AirspaceComplianceResult;
+  reasons: AirspaceComplianceReason[];
+  input: AirspaceComplianceInput | null;
+}

--- a/src/airspace-compliance/airspace-compliance.validators.ts
+++ b/src/airspace-compliance/airspace-compliance.validators.ts
@@ -1,0 +1,105 @@
+import { AirspaceComplianceValidationError } from "./airspace-compliance.errors";
+import type {
+  AirspaceClass,
+  CreateAirspaceComplianceInput,
+  PermissionStatus,
+  RestrictionStatus,
+} from "./airspace-compliance.types";
+
+const AIRSPACE_CLASSES = new Set<AirspaceClass>(["a", "b", "c", "d", "e", "f", "g"]);
+const RESTRICTION_STATUSES = new Set<RestrictionStatus>([
+  "clear",
+  "permission_required",
+  "restricted",
+  "prohibited",
+]);
+const PERMISSION_STATUSES = new Set<PermissionStatus>([
+  "not_required",
+  "pending",
+  "granted",
+  "denied",
+]);
+
+function requiredEnum<T extends string>(
+  value: unknown,
+  fieldName: string,
+  allowed: Set<T>,
+): T {
+  if (typeof value !== "string" || !allowed.has(value as T)) {
+    throw new AirspaceComplianceValidationError(`${fieldName} is not supported`);
+  }
+
+  return value as T;
+}
+
+function requiredNonNegativeInteger(value: unknown, fieldName: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new AirspaceComplianceValidationError(
+      `${fieldName} must be a non-negative integer`,
+    );
+  }
+
+  return value;
+}
+
+function optionalBoolean(value: unknown, fieldName: string): boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+
+  if (typeof value !== "boolean") {
+    throw new AirspaceComplianceValidationError(`${fieldName} must be a boolean`);
+  }
+
+  return value;
+}
+
+function optionalTrimmed(value: unknown, fieldName: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    throw new AirspaceComplianceValidationError(`${fieldName} must be a string`);
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function validateCreateAirspaceComplianceInput(
+  input: CreateAirspaceComplianceInput,
+) {
+  if (!input || typeof input !== "object") {
+    throw new AirspaceComplianceValidationError("Request body must be an object");
+  }
+
+  return {
+    airspaceClass: requiredEnum(
+      input.airspaceClass,
+      "airspaceClass",
+      AIRSPACE_CLASSES,
+    ),
+    maxAltitudeFt: requiredNonNegativeInteger(
+      input.maxAltitudeFt,
+      "maxAltitudeFt",
+    ),
+    restrictionStatus: requiredEnum(
+      input.restrictionStatus,
+      "restrictionStatus",
+      RESTRICTION_STATUSES,
+    ),
+    permissionStatus: requiredEnum(
+      input.permissionStatus,
+      "permissionStatus",
+      PERMISSION_STATUSES,
+    ),
+    controlledAirspace: optionalBoolean(
+      input.controlledAirspace,
+      "controlledAirspace",
+    ),
+    nearbyAerodrome: optionalBoolean(input.nearbyAerodrome, "nearbyAerodrome"),
+    evidenceRef: optionalTrimmed(input.evidenceRef, "evidenceRef"),
+    notes: optionalTrimmed(input.notes, "notes"),
+  };
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -38,6 +38,10 @@ import { MissionRiskRepository } from "./mission-risk/mission-risk.repository";
 import { MissionRiskService } from "./mission-risk/mission-risk.service";
 import { MissionRiskController } from "./mission-risk/mission-risk.controller";
 import { createMissionRiskRouter } from "./mission-risk/mission-risk.routes";
+import { AirspaceComplianceRepository } from "./airspace-compliance/airspace-compliance.repository";
+import { AirspaceComplianceService } from "./airspace-compliance/airspace-compliance.service";
+import { AirspaceComplianceController } from "./airspace-compliance/airspace-compliance.controller";
+import { createAirspaceComplianceRouter } from "./airspace-compliance/airspace-compliance.routes";
 
 dotenv.config({
   path: path.resolve(process.cwd(), ".env"),
@@ -108,6 +112,14 @@ const pilotController = new PilotController(pilotService);
 const missionRiskRepository = new MissionRiskRepository();
 const missionRiskService = new MissionRiskService(pool, missionRiskRepository);
 const missionRiskController = new MissionRiskController(missionRiskService);
+const airspaceComplianceRepository = new AirspaceComplianceRepository();
+const airspaceComplianceService = new AirspaceComplianceService(
+  pool,
+  airspaceComplianceRepository,
+);
+const airspaceComplianceController = new AirspaceComplianceController(
+  airspaceComplianceService,
+);
 const missionService = new MissionService(
   db,
   missionRepo,
@@ -115,11 +127,13 @@ const missionService = new MissionService(
   platformService,
   pilotService,
   missionRiskService,
+  airspaceComplianceService,
 );
 const missionController = new MissionController(missionService);
 
 app.use("/missions", createMissionRouter(missionController));
 app.use("/missions", createMissionRiskRouter(missionRiskController));
+app.use("/missions", createAirspaceComplianceRouter(airspaceComplianceController));
 app.use("/missions", createMissionReplayRouter(missionReplayController));
 app.use("/missions", createMissionTelemetryRouter(missionTelemetryController));
 app.use("/missions", createAlertRouter(alertController));

--- a/src/migrations/012_create_airspace_compliance_inputs.sql
+++ b/src/migrations/012_create_airspace_compliance_inputs.sql
@@ -1,0 +1,25 @@
+create table if not exists airspace_compliance_inputs (
+  id uuid primary key,
+  mission_id uuid not null references missions(id) on delete cascade,
+  airspace_class text not null,
+  max_altitude_ft integer not null,
+  restriction_status text not null,
+  permission_status text not null,
+  controlled_airspace boolean not null default false,
+  nearby_aerodrome boolean not null default false,
+  evidence_ref text null,
+  notes text null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint airspace_class_chk
+    check (airspace_class in ('a', 'b', 'c', 'd', 'e', 'f', 'g')),
+  constraint airspace_max_altitude_chk
+    check (max_altitude_ft >= 0),
+  constraint airspace_restriction_status_chk
+    check (restriction_status in ('clear', 'permission_required', 'restricted', 'prohibited')),
+  constraint airspace_permission_status_chk
+    check (permission_status in ('not_required', 'pending', 'granted', 'denied'))
+);
+
+create index if not exists idx_airspace_compliance_inputs_mission_created
+  on airspace_compliance_inputs (mission_id, created_at desc);

--- a/src/missions/mission-readiness.types.ts
+++ b/src/missions/mission-readiness.types.ts
@@ -1,6 +1,7 @@
 import type { PlatformReadinessCheck } from "../platforms/platform.types";
 import type { PilotReadinessCheck } from "../pilots/pilot.types";
 import type { MissionRiskAssessment } from "../mission-risk/mission-risk.types";
+import type { AirspaceComplianceAssessment } from "../airspace-compliance/airspace-compliance.types";
 
 export type MissionReadinessResult = "pass" | "warning" | "fail";
 
@@ -17,18 +18,22 @@ export type MissionReadinessReasonCode =
   | "MISSION_PILOT_NOT_FOUND"
   | "MISSION_RISK_READY"
   | "MISSION_RISK_WARNING"
-  | "MISSION_RISK_FAILED";
+  | "MISSION_RISK_FAILED"
+  | "MISSION_AIRSPACE_READY"
+  | "MISSION_AIRSPACE_WARNING"
+  | "MISSION_AIRSPACE_FAILED";
 
 export interface MissionReadinessReason {
   code: MissionReadinessReasonCode;
   severity: MissionReadinessResult;
   message: string;
-  source: "mission" | "platform" | "pilot" | "risk";
+  source: "mission" | "platform" | "pilot" | "risk" | "airspace";
   relatedPlatformId?: string;
   relatedPlatformReasonCodes?: string[];
   relatedPilotId?: string;
   relatedPilotReasonCodes?: string[];
   relatedRiskReasonCodes?: string[];
+  relatedAirspaceReasonCodes?: string[];
 }
 
 export interface MissionReadinessGate {
@@ -48,4 +53,5 @@ export interface MissionReadinessCheck {
   platformReadiness: PlatformReadinessCheck | null;
   pilotReadiness: PilotReadinessCheck | null;
   missionRisk: MissionRiskAssessment | null;
+  airspaceCompliance: AirspaceComplianceAssessment | null;
 }

--- a/src/missions/mission.service.ts
+++ b/src/missions/mission.service.ts
@@ -11,6 +11,7 @@ import { PlatformService } from "../platforms/platform.service";
 import { PilotNotFoundError } from "../pilots/pilot.errors";
 import { PilotService } from "../pilots/pilot.service";
 import { MissionRiskService } from "../mission-risk/mission-risk.service";
+import { AirspaceComplianceService } from "../airspace-compliance/airspace-compliance.service";
 import type {
   MissionReadinessCheck,
   MissionReadinessReason,
@@ -18,6 +19,7 @@ import type {
 } from "./mission-readiness.types";
 import type { PilotReadinessResult } from "../pilots/pilot.types";
 import type { MissionRiskResult } from "../mission-risk/mission-risk.types";
+import type { AirspaceComplianceResult } from "../airspace-compliance/airspace-compliance.types";
 
 export interface GetMissionEventsFilters {
   safety?: boolean;
@@ -57,6 +59,7 @@ export class MissionService {
     private readonly platformService?: PlatformService,
     private readonly pilotService?: PilotService,
     private readonly missionRiskService?: MissionRiskService,
+    private readonly airspaceComplianceService?: AirspaceComplianceService,
   ) {}
 
   async submitMission(params: {
@@ -254,6 +257,7 @@ export class MissionService {
     let platformReadiness: MissionReadinessCheck["platformReadiness"] = null;
     let pilotReadiness: MissionReadinessCheck["pilotReadiness"] = null;
     let missionRisk: MissionReadinessCheck["missionRisk"] = null;
+    let airspaceCompliance: MissionReadinessCheck["airspaceCompliance"] = null;
 
     if (!platformId) {
       reasons.push({
@@ -353,6 +357,28 @@ export class MissionService {
       );
     }
 
+    if (!this.airspaceComplianceService) {
+      reasons.push({
+        code: "MISSION_AIRSPACE_FAILED",
+        severity: "fail",
+        message: "Airspace compliance assessment service is not available",
+        source: "mission",
+      });
+    } else {
+      airspaceCompliance =
+        await this.airspaceComplianceService.assessAirspaceCompliance(
+          mission.id,
+        );
+      if (airspaceCompliance.result !== "pass") {
+        reasons.push(
+          this.mapAirspaceComplianceReason(
+            airspaceCompliance.result,
+            airspaceCompliance.reasons.map((reason) => reason.code),
+          ),
+        );
+      }
+    }
+
     return this.buildMissionReadiness({
       missionId: mission.id,
       platformId,
@@ -361,6 +387,7 @@ export class MissionService {
       platformReadiness,
       pilotReadiness,
       missionRisk,
+      airspaceCompliance,
     });
   }
 
@@ -505,6 +532,39 @@ export class MissionService {
     };
   }
 
+  private mapAirspaceComplianceReason(
+    result: AirspaceComplianceResult,
+    airspaceReasonCodes: string[],
+  ): MissionReadinessReason {
+    if (result === "fail") {
+      return {
+        code: "MISSION_AIRSPACE_FAILED",
+        severity: "fail",
+        message: "Airspace compliance assessment fails and blocks approval or dispatch",
+        source: "airspace",
+        relatedAirspaceReasonCodes: airspaceReasonCodes,
+      };
+    }
+
+    if (result === "warning") {
+      return {
+        code: "MISSION_AIRSPACE_WARNING",
+        severity: "warning",
+        message: "Airspace compliance assessment requires explicit review before approval or dispatch",
+        source: "airspace",
+        relatedAirspaceReasonCodes: airspaceReasonCodes,
+      };
+    }
+
+    return {
+      code: "MISSION_AIRSPACE_READY",
+      severity: "pass",
+      message: "Airspace compliance assessment passes for planning",
+      source: "airspace",
+      relatedAirspaceReasonCodes: airspaceReasonCodes,
+    };
+  }
+
   private buildMissionReadiness(params: {
     missionId: string;
     platformId: string | null;
@@ -513,6 +573,7 @@ export class MissionService {
     platformReadiness: MissionReadinessCheck["platformReadiness"];
     pilotReadiness: MissionReadinessCheck["pilotReadiness"];
     missionRisk: MissionReadinessCheck["missionRisk"];
+    airspaceCompliance: MissionReadinessCheck["airspaceCompliance"];
   }): MissionReadinessCheck {
     const result = this.getMissionReadinessResult(params.reasons);
 
@@ -531,6 +592,7 @@ export class MissionService {
       platformReadiness: params.platformReadiness,
       pilotReadiness: params.pilotReadiness,
       missionRisk: params.missionRisk,
+      airspaceCompliance: params.airspaceCompliance,
     };
   }
 

--- a/src/tests/airspace-compliance.test.ts
+++ b/src/tests/airspace-compliance.test.ts
@@ -1,0 +1,193 @@
+import { randomUUID } from "crypto";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import app, { pool } from "../app";
+import { runMigrations } from "../migrations/runMigrations";
+
+const clearTables = async () => {
+  await pool.query("delete from airspace_compliance_inputs");
+  await pool.query("delete from mission_events");
+  await pool.query("delete from missions");
+};
+
+const insertMission = async (missionId = randomUUID()) => {
+  await pool.query(
+    `
+    insert into missions (
+      id,
+      status,
+      mission_plan_id,
+      last_event_sequence_no
+    )
+    values ($1, $2, $3, $4)
+    `,
+    [missionId, "submitted", "plan-1", 0],
+  );
+
+  return missionId;
+};
+
+const countRows = async (missionId: string) => {
+  const result = await pool.query(
+    `
+    select
+      (select status from missions where id = $1) as mission_status,
+      (select last_event_sequence_no from missions where id = $1) as mission_sequence,
+      (select count(*)::int from mission_events where mission_id = $1) as mission_event_count,
+      (select count(*)::int from airspace_compliance_inputs where mission_id = $1) as airspace_input_count
+    `,
+    [missionId],
+  );
+
+  return result.rows[0] as {
+    mission_status: string;
+    mission_sequence: number;
+    mission_event_count: number;
+    airspace_input_count: number;
+  };
+};
+
+describe("airspace compliance integration", () => {
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  beforeEach(async () => {
+    await clearTables();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("passes compliance for clear airspace inputs", async () => {
+    const missionId = await insertMission();
+
+    const createResponse = await request(app)
+      .post(`/missions/${missionId}/airspace-inputs`)
+      .send({
+        airspaceClass: "g",
+        maxAltitudeFt: 300,
+        restrictionStatus: "clear",
+        permissionStatus: "not_required",
+      });
+
+    expect(createResponse.status).toBe(201);
+    const before = await countRows(missionId);
+
+    const response = await request(app).get(`/missions/${missionId}/airspace`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      result: "pass",
+      reasons: [
+        {
+          code: "AIRSPACE_CLEAR",
+          severity: "pass",
+        },
+      ],
+      input: {
+        missionId,
+        airspaceClass: "g",
+        maxAltitudeFt: 300,
+      },
+    });
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("warns compliance for pending permission and controlled airspace", async () => {
+    const missionId = await insertMission();
+
+    await request(app).post(`/missions/${missionId}/airspace-inputs`).send({
+      airspaceClass: "d",
+      maxAltitudeFt: 350,
+      restrictionStatus: "permission_required",
+      permissionStatus: "pending",
+      controlledAirspace: true,
+    });
+
+    const response = await request(app).get(`/missions/${missionId}/airspace`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.result).toBe("warning");
+    expect(response.body.reasons).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "AIRSPACE_PERMISSION_PENDING",
+          severity: "warning",
+        }),
+        expect.objectContaining({
+          code: "AIRSPACE_PERMISSION_REQUIRED",
+          severity: "warning",
+        }),
+        expect.objectContaining({
+          code: "AIRSPACE_CONTROLLED",
+          severity: "warning",
+        }),
+      ]),
+    );
+  });
+
+  it("fails compliance for prohibited airspace", async () => {
+    const missionId = await insertMission();
+
+    await request(app).post(`/missions/${missionId}/airspace-inputs`).send({
+      airspaceClass: "d",
+      maxAltitudeFt: 300,
+      restrictionStatus: "prohibited",
+      permissionStatus: "denied",
+    });
+
+    const response = await request(app).get(`/missions/${missionId}/airspace`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.result).toBe("fail");
+    expect(response.body.reasons).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "AIRSPACE_PROHIBITED",
+          severity: "fail",
+        }),
+        expect.objectContaining({
+          code: "AIRSPACE_PERMISSION_DENIED",
+          severity: "fail",
+        }),
+      ]),
+    );
+  });
+
+  it("fails explicitly when airspace compliance inputs are missing", async () => {
+    const missionId = await insertMission();
+    const before = await countRows(missionId);
+
+    const response = await request(app).get(`/missions/${missionId}/airspace`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      result: "fail",
+      reasons: [
+        {
+          code: "AIRSPACE_INPUT_MISSING",
+          severity: "fail",
+        },
+      ],
+      input: null,
+    });
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("returns not found for unknown missions", async () => {
+    const response = await request(app).get(
+      "/missions/7a2ed2c4-e238-4743-aa60-5bcd5a50d7b7/airspace",
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "mission_not_found",
+      },
+    });
+  });
+});

--- a/src/tests/mission-readiness.test.ts
+++ b/src/tests/mission-readiness.test.ts
@@ -5,6 +5,7 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from airspace_compliance_inputs");
   await pool.query("delete from mission_risk_inputs");
   await pool.query("delete from mission_events");
   await pool.query("delete from missions");
@@ -127,6 +128,49 @@ const createHighRiskInput = async (missionId: string) => {
   return response.body.input as { id: string };
 };
 
+const createClearAirspaceInput = async (missionId: string) => {
+  const response = await request(app)
+    .post(`/missions/${missionId}/airspace-inputs`)
+    .send({
+      airspaceClass: "g",
+      maxAltitudeFt: 300,
+      restrictionStatus: "clear",
+      permissionStatus: "not_required",
+    });
+
+  expect(response.status).toBe(201);
+  return response.body.input as { id: string };
+};
+
+const createWarningAirspaceInput = async (missionId: string) => {
+  const response = await request(app)
+    .post(`/missions/${missionId}/airspace-inputs`)
+    .send({
+      airspaceClass: "d",
+      maxAltitudeFt: 350,
+      restrictionStatus: "permission_required",
+      permissionStatus: "pending",
+      controlledAirspace: true,
+    });
+
+  expect(response.status).toBe(201);
+  return response.body.input as { id: string };
+};
+
+const createFailingAirspaceInput = async (missionId: string) => {
+  const response = await request(app)
+    .post(`/missions/${missionId}/airspace-inputs`)
+    .send({
+      airspaceClass: "d",
+      maxAltitudeFt: 300,
+      restrictionStatus: "prohibited",
+      permissionStatus: "denied",
+    });
+
+  expect(response.status).toBe(201);
+  return response.body.input as { id: string };
+};
+
 const countRows = async (params: {
   missionId: string;
   platformId?: string;
@@ -143,7 +187,8 @@ const countRows = async (params: {
       (select count(*)::int from maintenance_records where platform_id = $2) as record_count,
       (select count(*)::int from pilots where id = $3) as pilot_count,
       (select count(*)::int from pilot_readiness_evidence where pilot_id = $3) as pilot_evidence_count,
-      (select count(*)::int from mission_risk_inputs where mission_id = $1) as risk_input_count
+      (select count(*)::int from mission_risk_inputs where mission_id = $1) as risk_input_count,
+      (select count(*)::int from airspace_compliance_inputs where mission_id = $1) as airspace_input_count
     `,
     [params.missionId, params.platformId ?? null, params.pilotId ?? null],
   );
@@ -158,6 +203,7 @@ const countRows = async (params: {
     pilot_count: number;
     pilot_evidence_count: number;
     risk_input_count: number;
+    airspace_input_count: number;
   };
 };
 
@@ -185,6 +231,7 @@ describe("mission readiness platform gate integration", () => {
       pilotId: pilot.id,
     });
     await createLowRiskInput(missionId);
+    await createClearAirspaceInput(missionId);
     const before = await countRows({
       missionId,
       platformId: platform.id,
@@ -261,6 +308,7 @@ describe("mission readiness platform gate integration", () => {
       pilotId: pilot.id,
     });
     await createLowRiskInput(missionId);
+    await createClearAirspaceInput(missionId);
 
     const scheduleResponse = await request(app)
       .post(`/platforms/${platform.id}/maintenance-schedules`)
@@ -352,6 +400,7 @@ describe("mission readiness platform gate integration", () => {
       pilotId: pilot.id,
     });
     await createLowRiskInput(missionId);
+    await createClearAirspaceInput(missionId);
     const before = await countRows({
       missionId,
       platformId: platform.id,
@@ -421,6 +470,7 @@ describe("mission readiness platform gate integration", () => {
       pilotId: pilot.id,
     });
     await createLowRiskInput(missionId);
+    await createClearAirspaceInput(missionId);
     const before = await countRows({ missionId, pilotId: pilot.id });
 
     const response = await request(app).get(`/missions/${missionId}/readiness`);
@@ -482,6 +532,7 @@ describe("mission readiness platform gate integration", () => {
       pilotId: pilot.id,
     });
     await createLowRiskInput(missionId);
+    await createClearAirspaceInput(missionId);
     const before = await countRows({
       missionId,
       platformId: platform.id,
@@ -567,6 +618,7 @@ describe("mission readiness platform gate integration", () => {
       pilotId: pilot.id,
     });
     await createLowRiskInput(missionId);
+    await createClearAirspaceInput(missionId);
     const before = await countRows({
       missionId,
       platformId: platform.id,
@@ -639,6 +691,7 @@ describe("mission readiness platform gate integration", () => {
       pilotId: null,
     });
     await createLowRiskInput(missionId);
+    await createClearAirspaceInput(missionId);
     const before = await countRows({ missionId, platformId: platform.id });
 
     const response = await request(app).get(`/missions/${missionId}/readiness`);
@@ -688,6 +741,7 @@ describe("mission readiness platform gate integration", () => {
       pilotId: pilot.id,
     });
     await createLowRiskInput(missionId);
+    await createClearAirspaceInput(missionId);
     const before = await countRows({
       missionId,
       platformId: platform.id,
@@ -747,6 +801,7 @@ describe("mission readiness platform gate integration", () => {
       pilotId: pilot.id,
     });
     await createModerateRiskInput(missionId);
+    await createClearAirspaceInput(missionId);
     const before = await countRows({
       missionId,
       platformId: platform.id,
@@ -810,6 +865,7 @@ describe("mission readiness platform gate integration", () => {
       pilotId: pilot.id,
     });
     await createHighRiskInput(missionId);
+    await createClearAirspaceInput(missionId);
     const before = await countRows({
       missionId,
       platformId: platform.id,
@@ -872,6 +928,7 @@ describe("mission readiness platform gate integration", () => {
       platformId: platform.id,
       pilotId: pilot.id,
     });
+    await createClearAirspaceInput(missionId);
     const before = await countRows({
       missionId,
       platformId: platform.id,
@@ -909,6 +966,208 @@ describe("mission readiness platform gate integration", () => {
         result: "fail",
         score: null,
         riskBand: null,
+        input: null,
+      },
+    });
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    })).toEqual(before);
+  });
+
+  it("surfaces airspace compliance warnings in the combined readiness gate", async () => {
+    const platform = await createPlatform({
+      name: "Ready UAV",
+      status: "active",
+    });
+    const pilot = await createReadyPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    await createLowRiskInput(missionId);
+    await createWarningAirspaceInput(missionId);
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+
+    const response = await request(app).get(`/missions/${missionId}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      result: "warning",
+      gate: {
+        result: "warning",
+        blocksApproval: false,
+        blocksDispatch: false,
+        requiresReview: true,
+      },
+      reasons: [
+        {
+          code: "MISSION_PLATFORM_READY",
+          severity: "pass",
+          source: "platform",
+        },
+        {
+          code: "MISSION_PILOT_READY",
+          severity: "pass",
+          source: "pilot",
+        },
+        {
+          code: "MISSION_RISK_READY",
+          severity: "pass",
+          source: "risk",
+        },
+        {
+          code: "MISSION_AIRSPACE_WARNING",
+          severity: "warning",
+          source: "airspace",
+          relatedAirspaceReasonCodes: [
+            "AIRSPACE_PERMISSION_PENDING",
+            "AIRSPACE_PERMISSION_REQUIRED",
+            "AIRSPACE_CONTROLLED",
+          ],
+        },
+      ],
+      airspaceCompliance: {
+        missionId,
+        result: "warning",
+      },
+    });
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    })).toEqual(before);
+  });
+
+  it("fails the combined readiness gate for prohibited airspace", async () => {
+    const platform = await createPlatform({
+      name: "Ready UAV",
+      status: "active",
+    });
+    const pilot = await createReadyPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    await createLowRiskInput(missionId);
+    await createFailingAirspaceInput(missionId);
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+
+    const response = await request(app).get(`/missions/${missionId}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      result: "fail",
+      gate: {
+        result: "fail",
+        blocksApproval: true,
+        blocksDispatch: true,
+        requiresReview: false,
+      },
+      reasons: [
+        {
+          code: "MISSION_PLATFORM_READY",
+          severity: "pass",
+          source: "platform",
+        },
+        {
+          code: "MISSION_PILOT_READY",
+          severity: "pass",
+          source: "pilot",
+        },
+        {
+          code: "MISSION_RISK_READY",
+          severity: "pass",
+          source: "risk",
+        },
+        {
+          code: "MISSION_AIRSPACE_FAILED",
+          severity: "fail",
+          source: "airspace",
+          relatedAirspaceReasonCodes: [
+            "AIRSPACE_PROHIBITED",
+            "AIRSPACE_PERMISSION_DENIED",
+          ],
+        },
+      ],
+      airspaceCompliance: {
+        missionId,
+        result: "fail",
+      },
+    });
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    })).toEqual(before);
+  });
+
+  it("fails explicitly when airspace compliance inputs are missing", async () => {
+    const platform = await createPlatform({
+      name: "Ready UAV",
+      status: "active",
+    });
+    const pilot = await createReadyPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    await createLowRiskInput(missionId);
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+
+    const response = await request(app).get(`/missions/${missionId}/readiness`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      result: "fail",
+      reasons: [
+        {
+          code: "MISSION_PLATFORM_READY",
+          severity: "pass",
+          source: "platform",
+        },
+        {
+          code: "MISSION_PILOT_READY",
+          severity: "pass",
+          source: "pilot",
+        },
+        {
+          code: "MISSION_RISK_READY",
+          severity: "pass",
+          source: "risk",
+        },
+        {
+          code: "MISSION_AIRSPACE_FAILED",
+          severity: "fail",
+          source: "airspace",
+          relatedAirspaceReasonCodes: ["AIRSPACE_INPUT_MISSING"],
+        },
+      ],
+      airspaceCompliance: {
+        missionId,
+        result: "fail",
         input: null,
       },
     });


### PR DESCRIPTION
## Summary
Implements issue #15 by adding airspace compliance inputs and combining operating constraints with platform readiness, pilot readiness, and mission risk in the mission gate.

## What changed
- Added `airspace_compliance_inputs` persistence linked to missions.
- Added `POST /missions/:missionId/airspace-inputs` and `GET /missions/:missionId/airspace`.
- Added deterministic airspace compliance assessment with pass/warning/fail results.
- Extended `GET /missions/:missionId/readiness` to combine platform readiness, pilot readiness, mission risk, and airspace compliance.
- Updated the next build step toward audit evidence snapshots.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/airspace-compliance.test.ts src/tests/mission-readiness.test.ts` passed: 20 tests.
- `./node_modules/.bin/vitest.cmd run src/tests/mission-risk.test.ts src/tests/pilot-readiness.test.ts src/tests/platform-readiness.test.ts` passed: 18 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 144 tests.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #15.
