### PR TITLE
Add audit evidence snapshots #17

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add audit evidence snapshots so mission gates can preserve readiness decisions as reviewable records.",
+ "nextBuildStep": "Add audit evidence approval linkage migration so readiness snapshots can be tied to mission approval and dispatch decisions.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,6 +42,10 @@ import { AirspaceComplianceRepository } from "./airspace-compliance/airspace-com
 import { AirspaceComplianceService } from "./airspace-compliance/airspace-compliance.service";
 import { AirspaceComplianceController } from "./airspace-compliance/airspace-compliance.controller";
 import { createAirspaceComplianceRouter } from "./airspace-compliance/airspace-compliance.routes";
+import { AuditEvidenceRepository } from "./audit-evidence/audit-evidence.repository";
+import { AuditEvidenceService } from "./audit-evidence/audit-evidence.service";
+import { AuditEvidenceController } from "./audit-evidence/audit-evidence.controller";
+import { createAuditEvidenceRouter } from "./audit-evidence/audit-evidence.routes";
 
 dotenv.config({
   path: path.resolve(process.cwd(), ".env"),
@@ -130,10 +134,20 @@ const missionService = new MissionService(
   airspaceComplianceService,
 );
 const missionController = new MissionController(missionService);
+const auditEvidenceRepository = new AuditEvidenceRepository();
+const auditEvidenceService = new AuditEvidenceService(
+  pool,
+  auditEvidenceRepository,
+  missionService,
+);
+const auditEvidenceController = new AuditEvidenceController(
+  auditEvidenceService,
+);
 
 app.use("/missions", createMissionRouter(missionController));
 app.use("/missions", createMissionRiskRouter(missionRiskController));
 app.use("/missions", createAirspaceComplianceRouter(airspaceComplianceController));
+app.use("/missions", createAuditEvidenceRouter(auditEvidenceController));
 app.use("/missions", createMissionReplayRouter(missionReplayController));
 app.use("/missions", createMissionTelemetryRouter(missionTelemetryController));
 app.use("/missions", createAlertRouter(alertController));

--- a/src/audit-evidence/audit-evidence.controller.ts
+++ b/src/audit-evidence/audit-evidence.controller.ts
@@ -1,0 +1,43 @@
+import type { NextFunction, Request, Response } from "express";
+import { AuditEvidenceService } from "./audit-evidence.service";
+
+type MissionIdParams = {
+  missionId: string;
+};
+
+export class AuditEvidenceController {
+  constructor(private readonly auditEvidenceService: AuditEvidenceService) {}
+
+  createMissionReadinessSnapshot = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const snapshot =
+        await this.auditEvidenceService.createMissionReadinessSnapshot(
+          req.params.missionId,
+          req.body,
+        );
+      res.status(201).json({ snapshot });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listMissionReadinessSnapshots = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const snapshots =
+        await this.auditEvidenceService.listMissionReadinessSnapshots(
+          req.params.missionId,
+        );
+      res.status(200).json({ snapshots });
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/audit-evidence/audit-evidence.errors.ts
+++ b/src/audit-evidence/audit-evidence.errors.ts
@@ -1,0 +1,13 @@
+export class AuditEvidenceValidationError extends Error {
+  readonly statusCode = 400;
+  readonly code = "AUDIT_EVIDENCE_VALIDATION_FAILED";
+}
+
+export class AuditEvidenceMissionNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "MISSION_NOT_FOUND";
+
+  constructor(missionId: string) {
+    super(`Mission not found: ${missionId}`);
+  }
+}

--- a/src/audit-evidence/audit-evidence.repository.ts
+++ b/src/audit-evidence/audit-evidence.repository.ts
@@ -1,0 +1,111 @@
+import { randomUUID } from "crypto";
+import type { PoolClient, QueryResultRow } from "pg";
+import type { MissionReadinessCheck } from "../missions/mission-readiness.types";
+import type { AuditEvidenceSnapshot } from "./audit-evidence.types";
+
+interface AuditEvidenceSnapshotRow extends QueryResultRow {
+  id: string;
+  mission_id: string;
+  evidence_type: AuditEvidenceSnapshot["evidenceType"];
+  readiness_result: AuditEvidenceSnapshot["readinessResult"];
+  gate_result: AuditEvidenceSnapshot["gateResult"];
+  blocks_approval: boolean;
+  blocks_dispatch: boolean;
+  requires_review: boolean;
+  readiness_snapshot: MissionReadinessCheck;
+  created_by: string | null;
+  created_at: Date;
+}
+
+interface CreateAuditEvidenceSnapshotRow {
+  missionId: string;
+  readinessSnapshot: MissionReadinessCheck;
+  createdBy: string | null;
+}
+
+const toAuditEvidenceSnapshot = (
+  row: AuditEvidenceSnapshotRow,
+): AuditEvidenceSnapshot => ({
+  id: row.id,
+  missionId: row.mission_id,
+  evidenceType: row.evidence_type,
+  readinessResult: row.readiness_result,
+  gateResult: row.gate_result,
+  blocksApproval: row.blocks_approval,
+  blocksDispatch: row.blocks_dispatch,
+  requiresReview: row.requires_review,
+  readinessSnapshot: row.readiness_snapshot,
+  createdBy: row.created_by,
+  createdAt: row.created_at.toISOString(),
+});
+
+export class AuditEvidenceRepository {
+  async missionExists(tx: PoolClient, missionId: string): Promise<boolean> {
+    const result = await tx.query(
+      `
+      select 1
+      from missions
+      where id = $1
+      `,
+      [missionId],
+    );
+
+    return result.rowCount === 1;
+  }
+
+  async insertReadinessSnapshot(
+    tx: PoolClient,
+    input: CreateAuditEvidenceSnapshotRow,
+  ): Promise<AuditEvidenceSnapshot> {
+    const result = await tx.query<AuditEvidenceSnapshotRow>(
+      `
+      insert into audit_evidence_snapshots (
+        id,
+        mission_id,
+        evidence_type,
+        readiness_result,
+        gate_result,
+        blocks_approval,
+        blocks_dispatch,
+        requires_review,
+        readiness_snapshot,
+        created_by
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.missionId,
+        "mission_readiness_gate",
+        input.readinessSnapshot.result,
+        input.readinessSnapshot.gate.result,
+        input.readinessSnapshot.gate.blocksApproval,
+        input.readinessSnapshot.gate.blocksDispatch,
+        input.readinessSnapshot.gate.requiresReview,
+        JSON.stringify(input.readinessSnapshot),
+        input.createdBy,
+      ],
+    );
+
+    return toAuditEvidenceSnapshot(result.rows[0]);
+  }
+
+  async listReadinessSnapshots(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<AuditEvidenceSnapshot[]> {
+    const result = await tx.query<AuditEvidenceSnapshotRow>(
+      `
+      select *
+      from audit_evidence_snapshots
+      where mission_id = $1
+        and evidence_type = 'mission_readiness_gate'
+      order by created_at desc, id desc
+      `,
+      [missionId],
+    );
+
+    return result.rows.map(toAuditEvidenceSnapshot);
+  }
+}

--- a/src/audit-evidence/audit-evidence.routes.ts
+++ b/src/audit-evidence/audit-evidence.routes.ts
@@ -1,0 +1,19 @@
+import { Router } from "express";
+import { AuditEvidenceController } from "./audit-evidence.controller";
+
+export function createAuditEvidenceRouter(
+  controller: AuditEvidenceController,
+): Router {
+  const router = Router();
+
+  router.post(
+    "/:missionId/readiness/audit-snapshots",
+    controller.createMissionReadinessSnapshot,
+  );
+  router.get(
+    "/:missionId/readiness/audit-snapshots",
+    controller.listMissionReadinessSnapshots,
+  );
+
+  return router;
+}

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -1,0 +1,62 @@
+import type { Pool } from "pg";
+import { MissionService } from "../missions/mission.service";
+import { AuditEvidenceMissionNotFoundError } from "./audit-evidence.errors";
+import { AuditEvidenceRepository } from "./audit-evidence.repository";
+import type {
+  AuditEvidenceSnapshot,
+  CreateAuditEvidenceSnapshotInput,
+} from "./audit-evidence.types";
+import { validateCreateAuditEvidenceSnapshotInput } from "./audit-evidence.validators";
+
+export class AuditEvidenceService {
+  constructor(
+    private readonly pool: Pool,
+    private readonly auditEvidenceRepository: AuditEvidenceRepository,
+    private readonly missionService: MissionService,
+  ) {}
+
+  async createMissionReadinessSnapshot(
+    missionId: string,
+    input: CreateAuditEvidenceSnapshotInput | undefined,
+  ): Promise<AuditEvidenceSnapshot> {
+    const validated = validateCreateAuditEvidenceSnapshotInput(input);
+    const readinessSnapshot = await this.missionService.checkMissionReadiness({
+      missionId,
+    });
+    const client = await this.pool.connect();
+
+    try {
+      return await this.auditEvidenceRepository.insertReadinessSnapshot(client, {
+        missionId,
+        readinessSnapshot,
+        createdBy: validated.createdBy,
+      });
+    } finally {
+      client.release();
+    }
+  }
+
+  async listMissionReadinessSnapshots(
+    missionId: string,
+  ): Promise<AuditEvidenceSnapshot[]> {
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.auditEvidenceRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new AuditEvidenceMissionNotFoundError(missionId);
+      }
+
+      return await this.auditEvidenceRepository.listReadinessSnapshots(
+        client,
+        missionId,
+      );
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/src/audit-evidence/audit-evidence.types.ts
+++ b/src/audit-evidence/audit-evidence.types.ts
@@ -1,0 +1,21 @@
+import type { MissionReadinessCheck } from "../missions/mission-readiness.types";
+
+export type AuditEvidenceType = "mission_readiness_gate";
+
+export interface CreateAuditEvidenceSnapshotInput {
+  createdBy?: string | null;
+}
+
+export interface AuditEvidenceSnapshot {
+  id: string;
+  missionId: string;
+  evidenceType: AuditEvidenceType;
+  readinessResult: MissionReadinessCheck["result"];
+  gateResult: MissionReadinessCheck["gate"]["result"];
+  blocksApproval: boolean;
+  blocksDispatch: boolean;
+  requiresReview: boolean;
+  readinessSnapshot: MissionReadinessCheck;
+  createdBy: string | null;
+  createdAt: string;
+}

--- a/src/audit-evidence/audit-evidence.validators.ts
+++ b/src/audit-evidence/audit-evidence.validators.ts
@@ -1,0 +1,33 @@
+import { AuditEvidenceValidationError } from "./audit-evidence.errors";
+import type { CreateAuditEvidenceSnapshotInput } from "./audit-evidence.types";
+
+function optionalTrimmed(value: unknown, fieldName: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    throw new AuditEvidenceValidationError(`${fieldName} must be a string`);
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function validateCreateAuditEvidenceSnapshotInput(
+  input: CreateAuditEvidenceSnapshotInput | undefined,
+) {
+  if (input === undefined || input === null) {
+    return {
+      createdBy: null,
+    };
+  }
+
+  if (typeof input !== "object") {
+    throw new AuditEvidenceValidationError("Request body must be an object");
+  }
+
+  return {
+    createdBy: optionalTrimmed(input.createdBy, "createdBy"),
+  };
+}

--- a/src/migrations/013_create_audit_evidence_snapshots.sql
+++ b/src/migrations/013_create_audit_evidence_snapshots.sql
@@ -1,0 +1,22 @@
+create table if not exists audit_evidence_snapshots (
+  id uuid primary key,
+  mission_id uuid not null references missions(id) on delete cascade,
+  evidence_type text not null,
+  readiness_result text not null,
+  gate_result text not null,
+  blocks_approval boolean not null,
+  blocks_dispatch boolean not null,
+  requires_review boolean not null,
+  readiness_snapshot jsonb not null,
+  created_by text null,
+  created_at timestamptz not null default now(),
+  constraint audit_evidence_type_chk
+    check (evidence_type in ('mission_readiness_gate')),
+  constraint audit_readiness_result_chk
+    check (readiness_result in ('pass', 'warning', 'fail')),
+  constraint audit_gate_result_chk
+    check (gate_result in ('pass', 'warning', 'fail'))
+);
+
+create index if not exists idx_audit_evidence_snapshots_mission_created
+  on audit_evidence_snapshots (mission_id, created_at desc);

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -1,0 +1,365 @@
+import { randomUUID } from "crypto";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import app, { pool } from "../app";
+import { runMigrations } from "../migrations/runMigrations";
+
+const clearTables = async () => {
+  await pool.query("delete from audit_evidence_snapshots");
+  await pool.query("delete from airspace_compliance_inputs");
+  await pool.query("delete from mission_risk_inputs");
+  await pool.query("delete from mission_events");
+  await pool.query("delete from missions");
+  await pool.query("delete from pilot_readiness_evidence");
+  await pool.query("delete from pilots");
+  await pool.query("delete from maintenance_records");
+  await pool.query("delete from maintenance_schedules");
+  await pool.query("delete from platforms");
+};
+
+const createPlatform = async () => {
+  const response = await request(app).post("/platforms").send({
+    name: "Audit UAV",
+    status: "active",
+  });
+
+  expect(response.status).toBe(201);
+  return response.body.platform as { id: string };
+};
+
+const createReadyPilot = async () => {
+  const pilotResponse = await request(app).post("/pilots").send({
+    displayName: "Audit Pilot",
+    status: "active",
+  });
+
+  expect(pilotResponse.status).toBe(201);
+  const pilot = pilotResponse.body.pilot as { id: string };
+
+  const evidenceResponse = await request(app)
+    .post(`/pilots/${pilot.id}/readiness-evidence`)
+    .send({
+      evidenceType: "operator_authorisation",
+      title: "Current operator authorisation",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+    });
+
+  expect(evidenceResponse.status).toBe(201);
+  return pilot;
+};
+
+const insertMission = async (params: {
+  id?: string;
+  platformId?: string | null;
+  pilotId?: string | null;
+}) => {
+  const missionId = params.id ?? randomUUID();
+
+  await pool.query(
+    `
+    insert into missions (
+      id,
+      status,
+      mission_plan_id,
+      platform_id,
+      pilot_id,
+      last_event_sequence_no
+    )
+    values ($1, $2, $3, $4, $5, $6)
+    `,
+    [
+      missionId,
+      "submitted",
+      "plan-audit",
+      params.platformId ?? null,
+      params.pilotId ?? null,
+      0,
+    ],
+  );
+
+  return missionId;
+};
+
+const createLowRiskInput = async (missionId: string) => {
+  const response = await request(app)
+    .post(`/missions/${missionId}/risk-inputs`)
+    .send({
+      operatingCategory: "open",
+      missionComplexity: "low",
+      populationExposure: "low",
+      airspaceComplexity: "low",
+      weatherRisk: "low",
+      payloadRisk: "low",
+    });
+
+  expect(response.status).toBe(201);
+};
+
+const createHighRiskInput = async (missionId: string) => {
+  const response = await request(app)
+    .post(`/missions/${missionId}/risk-inputs`)
+    .send({
+      operatingCategory: "certified",
+      missionComplexity: "high",
+      populationExposure: "high",
+      airspaceComplexity: "high",
+      weatherRisk: "high",
+      payloadRisk: "high",
+    });
+
+  expect(response.status).toBe(201);
+};
+
+const createClearAirspaceInput = async (missionId: string) => {
+  const response = await request(app)
+    .post(`/missions/${missionId}/airspace-inputs`)
+    .send({
+      airspaceClass: "g",
+      maxAltitudeFt: 300,
+      restrictionStatus: "clear",
+      permissionStatus: "not_required",
+    });
+
+  expect(response.status).toBe(201);
+};
+
+const createFailingAirspaceInput = async (missionId: string) => {
+  const response = await request(app)
+    .post(`/missions/${missionId}/airspace-inputs`)
+    .send({
+      airspaceClass: "d",
+      maxAltitudeFt: 300,
+      restrictionStatus: "prohibited",
+      permissionStatus: "denied",
+    });
+
+  expect(response.status).toBe(201);
+};
+
+const createReadyMission = async () => {
+  const platform = await createPlatform();
+  const pilot = await createReadyPilot();
+  const missionId = await insertMission({
+    platformId: platform.id,
+    pilotId: pilot.id,
+  });
+
+  await createLowRiskInput(missionId);
+  await createClearAirspaceInput(missionId);
+
+  return {
+    missionId,
+    platformId: platform.id,
+    pilotId: pilot.id,
+  };
+};
+
+const countRows = async (missionId: string) => {
+  const result = await pool.query(
+    `
+    select
+      (select count(*)::int from audit_evidence_snapshots where mission_id = $1) as snapshot_count,
+      (select count(*)::int from mission_events where mission_id = $1) as mission_event_count,
+      (select count(*)::int from mission_risk_inputs where mission_id = $1) as risk_input_count,
+      (select count(*)::int from airspace_compliance_inputs where mission_id = $1) as airspace_input_count,
+      (select last_event_sequence_no from missions where id = $1) as mission_sequence
+    `,
+    [missionId],
+  );
+
+  return result.rows[0] as {
+    snapshot_count: number;
+    mission_event_count: number;
+    risk_input_count: number;
+    airspace_input_count: number;
+    mission_sequence: number;
+  };
+};
+
+describe("audit evidence snapshots", () => {
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  beforeEach(async () => {
+    await clearTables();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("captures the current mission readiness gate as reviewable evidence", async () => {
+    const { missionId, platformId, pilotId } = await createReadyMission();
+    const before = await countRows(missionId);
+
+    const response = await request(app)
+      .post(`/missions/${missionId}/readiness/audit-snapshots`)
+      .send({
+        createdBy: " safety-manager ",
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.snapshot).toMatchObject({
+      missionId,
+      evidenceType: "mission_readiness_gate",
+      readinessResult: "pass",
+      gateResult: "pass",
+      blocksApproval: false,
+      blocksDispatch: false,
+      requiresReview: false,
+      createdBy: "safety-manager",
+      readinessSnapshot: {
+        missionId,
+        platformId,
+        pilotId,
+        result: "pass",
+        gate: {
+          result: "pass",
+          blocksApproval: false,
+          blocksDispatch: false,
+          requiresReview: false,
+        },
+        reasons: [
+          { code: "MISSION_PLATFORM_READY", source: "platform" },
+          { code: "MISSION_PILOT_READY", source: "pilot" },
+          { code: "MISSION_RISK_READY", source: "risk" },
+        ],
+        missionRisk: {
+          result: "pass",
+          riskBand: "low",
+        },
+        airspaceCompliance: {
+          result: "pass",
+        },
+      },
+    });
+    expect(response.body.snapshot.id).toEqual(expect.any(String));
+    expect(response.body.snapshot.createdAt).toEqual(expect.any(String));
+
+    expect(await countRows(missionId)).toEqual({
+      ...before,
+      snapshot_count: before.snapshot_count + 1,
+    });
+  });
+
+  it("keeps snapshots immutable when later source inputs change", async () => {
+    const { missionId } = await createReadyMission();
+
+    const snapshotResponse = await request(app)
+      .post(`/missions/${missionId}/readiness/audit-snapshots`)
+      .send({});
+
+    expect(snapshotResponse.status).toBe(201);
+    const snapshotId = snapshotResponse.body.snapshot.id;
+
+    await createHighRiskInput(missionId);
+    await createFailingAirspaceInput(missionId);
+
+    const liveReadinessResponse = await request(app).get(
+      `/missions/${missionId}/readiness`,
+    );
+    expect(liveReadinessResponse.status).toBe(200);
+    expect(liveReadinessResponse.body.result).toBe("fail");
+    expect(liveReadinessResponse.body.reasons).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "MISSION_RISK_FAILED" }),
+        expect.objectContaining({ code: "MISSION_AIRSPACE_FAILED" }),
+      ]),
+    );
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/readiness/audit-snapshots`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.snapshots).toHaveLength(1);
+    expect(listResponse.body.snapshots[0]).toMatchObject({
+      id: snapshotId,
+      readinessResult: "pass",
+      gateResult: "pass",
+      readinessSnapshot: {
+        result: "pass",
+        missionRisk: {
+          result: "pass",
+          riskBand: "low",
+        },
+        airspaceCompliance: {
+          result: "pass",
+        },
+      },
+    });
+  });
+
+  it("lists snapshots only for the requested mission", async () => {
+    const first = await createReadyMission();
+    const second = await createReadyMission();
+
+    const firstSnapshot = await request(app)
+      .post(`/missions/${first.missionId}/readiness/audit-snapshots`)
+      .send({ createdBy: "reviewer-a" });
+    const secondSnapshot = await request(app)
+      .post(`/missions/${second.missionId}/readiness/audit-snapshots`)
+      .send({ createdBy: "reviewer-b" });
+
+    expect(firstSnapshot.status).toBe(201);
+    expect(secondSnapshot.status).toBe(201);
+
+    const response = await request(app).get(
+      `/missions/${first.missionId}/readiness/audit-snapshots`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.snapshots).toHaveLength(1);
+    expect(response.body.snapshots[0]).toMatchObject({
+      missionId: first.missionId,
+      createdBy: "reviewer-a",
+    });
+  });
+
+  it("does not mutate source inputs, mission state, or events when snapshotting", async () => {
+    const { missionId } = await createReadyMission();
+    const before = await countRows(missionId);
+
+    const response = await request(app)
+      .post(`/missions/${missionId}/readiness/audit-snapshots`)
+      .send({});
+
+    expect(response.status).toBe(201);
+    expect(await countRows(missionId)).toEqual({
+      ...before,
+      snapshot_count: before.snapshot_count + 1,
+    });
+  });
+
+  it("rejects invalid snapshot metadata", async () => {
+    const { missionId } = await createReadyMission();
+
+    const response = await request(app)
+      .post(`/missions/${missionId}/readiness/audit-snapshots`)
+      .send({
+        createdBy: 42,
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "audit_evidence_validation_failed",
+      },
+    });
+  });
+
+  it("returns 404 for unknown missions", async () => {
+    const missingMissionId = randomUUID();
+
+    const createResponse = await request(app)
+      .post(`/missions/${missingMissionId}/readiness/audit-snapshots`)
+      .send({});
+    const listResponse = await request(app).get(
+      `/missions/${missingMissionId}/readiness/audit-snapshots`,
+    );
+
+    expect(createResponse.status).toBe(404);
+    expect(listResponse.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
Implements issue #17 by adding audit evidence snapshots for mission readiness gate decisions.

## What changed
- Added `audit_evidence_snapshots` persistence linked to missions.
- Added `POST /missions/:missionId/readiness/audit-snapshots` to capture the current readiness gate as immutable review evidence.
- Added `GET /missions/:missionId/readiness/audit-snapshots` to list captured readiness evidence for a mission.
- Preserved the full readiness decision payload, including gate flags, mission reasons, platform readiness, pilot readiness, mission risk, and airspace compliance outputs.
- Added validation for snapshot metadata and a next build step for approval/dispatch linkage.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/audit-evidence.test.ts src/tests/mission-readiness.test.ts` passed: 21 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 150 tests.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #17.
