### PR TITLE
Add decision evidence linkage #19

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add audit evidence approval linkage migration so readiness snapshots can be tied to mission approval and dispatch decisions.",
+ "nextBuildStep": "Add mission approval guard migration so approval decisions require linked readiness evidence snapshots.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.controller.ts
+++ b/src/audit-evidence/audit-evidence.controller.ts
@@ -40,4 +40,37 @@ export class AuditEvidenceController {
       next(error);
     }
   };
+
+  createMissionDecisionEvidenceLink = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const link =
+        await this.auditEvidenceService.createMissionDecisionEvidenceLink(
+          req.params.missionId,
+          req.body,
+        );
+      res.status(201).json({ link });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listMissionDecisionEvidenceLinks = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const links =
+        await this.auditEvidenceService.listMissionDecisionEvidenceLinks(
+          req.params.missionId,
+        );
+      res.status(200).json({ links });
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/audit-evidence/audit-evidence.errors.ts
+++ b/src/audit-evidence/audit-evidence.errors.ts
@@ -11,3 +11,12 @@ export class AuditEvidenceMissionNotFoundError extends Error {
     super(`Mission not found: ${missionId}`);
   }
 }
+
+export class AuditEvidenceSnapshotNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "AUDIT_EVIDENCE_SNAPSHOT_NOT_FOUND";
+
+  constructor(snapshotId: string) {
+    super(`Audit evidence snapshot not found for mission: ${snapshotId}`);
+  }
+}

--- a/src/audit-evidence/audit-evidence.repository.ts
+++ b/src/audit-evidence/audit-evidence.repository.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "crypto";
 import type { PoolClient, QueryResultRow } from "pg";
 import type { MissionReadinessCheck } from "../missions/mission-readiness.types";
-import type { AuditEvidenceSnapshot } from "./audit-evidence.types";
+import type {
+  AuditEvidenceSnapshot,
+  MissionDecisionEvidenceLink,
+} from "./audit-evidence.types";
 
 interface AuditEvidenceSnapshotRow extends QueryResultRow {
   id: string;
@@ -23,6 +26,22 @@ interface CreateAuditEvidenceSnapshotRow {
   createdBy: string | null;
 }
 
+interface MissionDecisionEvidenceLinkRow extends QueryResultRow {
+  id: string;
+  mission_id: string;
+  audit_evidence_snapshot_id: string;
+  decision_type: MissionDecisionEvidenceLink["decisionType"];
+  created_by: string | null;
+  created_at: Date;
+}
+
+interface CreateMissionDecisionEvidenceLinkRow {
+  missionId: string;
+  snapshotId: string;
+  decisionType: MissionDecisionEvidenceLink["decisionType"];
+  createdBy: string | null;
+}
+
 const toAuditEvidenceSnapshot = (
   row: AuditEvidenceSnapshotRow,
 ): AuditEvidenceSnapshot => ({
@@ -35,6 +54,17 @@ const toAuditEvidenceSnapshot = (
   blocksDispatch: row.blocks_dispatch,
   requiresReview: row.requires_review,
   readinessSnapshot: row.readiness_snapshot,
+  createdBy: row.created_by,
+  createdAt: row.created_at.toISOString(),
+});
+
+const toMissionDecisionEvidenceLink = (
+  row: MissionDecisionEvidenceLinkRow,
+): MissionDecisionEvidenceLink => ({
+  id: row.id,
+  missionId: row.mission_id,
+  auditEvidenceSnapshotId: row.audit_evidence_snapshot_id,
+  decisionType: row.decision_type,
   createdBy: row.created_by,
   createdAt: row.created_at.toISOString(),
 });
@@ -107,5 +137,68 @@ export class AuditEvidenceRepository {
     );
 
     return result.rows.map(toAuditEvidenceSnapshot);
+  }
+
+  async snapshotExistsForMission(
+    tx: PoolClient,
+    missionId: string,
+    snapshotId: string,
+  ): Promise<boolean> {
+    const result = await tx.query(
+      `
+      select 1
+      from audit_evidence_snapshots
+      where mission_id = $1
+        and id = $2
+      `,
+      [missionId, snapshotId],
+    );
+
+    return result.rowCount === 1;
+  }
+
+  async insertDecisionEvidenceLink(
+    tx: PoolClient,
+    input: CreateMissionDecisionEvidenceLinkRow,
+  ): Promise<MissionDecisionEvidenceLink> {
+    const result = await tx.query<MissionDecisionEvidenceLinkRow>(
+      `
+      insert into mission_decision_evidence_links (
+        id,
+        mission_id,
+        audit_evidence_snapshot_id,
+        decision_type,
+        created_by
+      )
+      values ($1, $2, $3, $4, $5)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.missionId,
+        input.snapshotId,
+        input.decisionType,
+        input.createdBy,
+      ],
+    );
+
+    return toMissionDecisionEvidenceLink(result.rows[0]);
+  }
+
+  async listDecisionEvidenceLinks(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<MissionDecisionEvidenceLink[]> {
+    const result = await tx.query<MissionDecisionEvidenceLinkRow>(
+      `
+      select *
+      from mission_decision_evidence_links
+      where mission_id = $1
+      order by created_at desc, id desc
+      `,
+      [missionId],
+    );
+
+    return result.rows.map(toMissionDecisionEvidenceLink);
   }
 }

--- a/src/audit-evidence/audit-evidence.routes.ts
+++ b/src/audit-evidence/audit-evidence.routes.ts
@@ -14,6 +14,14 @@ export function createAuditEvidenceRouter(
     "/:missionId/readiness/audit-snapshots",
     controller.listMissionReadinessSnapshots,
   );
+  router.post(
+    "/:missionId/decision-evidence-links",
+    controller.createMissionDecisionEvidenceLink,
+  );
+  router.get(
+    "/:missionId/decision-evidence-links",
+    controller.listMissionDecisionEvidenceLinks,
+  );
 
   return router;
 }

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -1,12 +1,20 @@
 import type { Pool } from "pg";
 import { MissionService } from "../missions/mission.service";
-import { AuditEvidenceMissionNotFoundError } from "./audit-evidence.errors";
+import {
+  AuditEvidenceMissionNotFoundError,
+  AuditEvidenceSnapshotNotFoundError,
+} from "./audit-evidence.errors";
 import { AuditEvidenceRepository } from "./audit-evidence.repository";
 import type {
   AuditEvidenceSnapshot,
   CreateAuditEvidenceSnapshotInput,
+  CreateMissionDecisionEvidenceLinkInput,
+  MissionDecisionEvidenceLink,
 } from "./audit-evidence.types";
-import { validateCreateAuditEvidenceSnapshotInput } from "./audit-evidence.validators";
+import {
+  validateCreateAuditEvidenceSnapshotInput,
+  validateCreateMissionDecisionEvidenceLinkInput,
+} from "./audit-evidence.validators";
 
 export class AuditEvidenceService {
   constructor(
@@ -52,6 +60,72 @@ export class AuditEvidenceService {
       }
 
       return await this.auditEvidenceRepository.listReadinessSnapshots(
+        client,
+        missionId,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  async createMissionDecisionEvidenceLink(
+    missionId: string,
+    input: CreateMissionDecisionEvidenceLinkInput | undefined,
+  ): Promise<MissionDecisionEvidenceLink> {
+    const validated = validateCreateMissionDecisionEvidenceLinkInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.auditEvidenceRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new AuditEvidenceMissionNotFoundError(missionId);
+      }
+
+      const snapshotExists =
+        await this.auditEvidenceRepository.snapshotExistsForMission(
+          client,
+          missionId,
+          validated.snapshotId,
+        );
+
+      if (!snapshotExists) {
+        throw new AuditEvidenceSnapshotNotFoundError(validated.snapshotId);
+      }
+
+      return await this.auditEvidenceRepository.insertDecisionEvidenceLink(
+        client,
+        {
+          missionId,
+          snapshotId: validated.snapshotId,
+          decisionType: validated.decisionType,
+          createdBy: validated.createdBy,
+        },
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  async listMissionDecisionEvidenceLinks(
+    missionId: string,
+  ): Promise<MissionDecisionEvidenceLink[]> {
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.auditEvidenceRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new AuditEvidenceMissionNotFoundError(missionId);
+      }
+
+      return await this.auditEvidenceRepository.listDecisionEvidenceLinks(
         client,
         missionId,
       );

--- a/src/audit-evidence/audit-evidence.types.ts
+++ b/src/audit-evidence/audit-evidence.types.ts
@@ -2,7 +2,15 @@ import type { MissionReadinessCheck } from "../missions/mission-readiness.types"
 
 export type AuditEvidenceType = "mission_readiness_gate";
 
+export type MissionDecisionType = "approval" | "dispatch";
+
 export interface CreateAuditEvidenceSnapshotInput {
+  createdBy?: string | null;
+}
+
+export interface CreateMissionDecisionEvidenceLinkInput {
+  snapshotId?: string;
+  decisionType?: MissionDecisionType;
   createdBy?: string | null;
 }
 
@@ -16,6 +24,15 @@ export interface AuditEvidenceSnapshot {
   blocksDispatch: boolean;
   requiresReview: boolean;
   readinessSnapshot: MissionReadinessCheck;
+  createdBy: string | null;
+  createdAt: string;
+}
+
+export interface MissionDecisionEvidenceLink {
+  id: string;
+  missionId: string;
+  auditEvidenceSnapshotId: string;
+  decisionType: MissionDecisionType;
   createdBy: string | null;
   createdAt: string;
 }

--- a/src/audit-evidence/audit-evidence.validators.ts
+++ b/src/audit-evidence/audit-evidence.validators.ts
@@ -1,5 +1,11 @@
 import { AuditEvidenceValidationError } from "./audit-evidence.errors";
-import type { CreateAuditEvidenceSnapshotInput } from "./audit-evidence.types";
+import type {
+  CreateAuditEvidenceSnapshotInput,
+  CreateMissionDecisionEvidenceLinkInput,
+  MissionDecisionType,
+} from "./audit-evidence.types";
+
+const DECISION_TYPES = new Set<MissionDecisionType>(["approval", "dispatch"]);
 
 function optionalTrimmed(value: unknown, fieldName: string): string | null {
   if (value === undefined || value === null) {
@@ -28,6 +34,36 @@ export function validateCreateAuditEvidenceSnapshotInput(
   }
 
   return {
+    createdBy: optionalTrimmed(input.createdBy, "createdBy"),
+  };
+}
+
+function requiredString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new AuditEvidenceValidationError(`${fieldName} is required`);
+  }
+
+  return value.trim();
+}
+
+function requiredDecisionType(value: unknown): MissionDecisionType {
+  if (typeof value !== "string" || !DECISION_TYPES.has(value as MissionDecisionType)) {
+    throw new AuditEvidenceValidationError("decisionType is not supported");
+  }
+
+  return value as MissionDecisionType;
+}
+
+export function validateCreateMissionDecisionEvidenceLinkInput(
+  input: CreateMissionDecisionEvidenceLinkInput | undefined,
+) {
+  if (!input || typeof input !== "object") {
+    throw new AuditEvidenceValidationError("Request body must be an object");
+  }
+
+  return {
+    snapshotId: requiredString(input.snapshotId, "snapshotId"),
+    decisionType: requiredDecisionType(input.decisionType),
     createdBy: optionalTrimmed(input.createdBy, "createdBy"),
   };
 }

--- a/src/migrations/014_create_mission_decision_evidence_links.sql
+++ b/src/migrations/014_create_mission_decision_evidence_links.sql
@@ -1,0 +1,33 @@
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'audit_evidence_snapshots_mission_id_id_uniq'
+  ) then
+    alter table audit_evidence_snapshots
+      add constraint audit_evidence_snapshots_mission_id_id_uniq
+      unique (mission_id, id);
+  end if;
+end $$;
+
+create table if not exists mission_decision_evidence_links (
+  id uuid primary key,
+  mission_id uuid not null references missions(id) on delete cascade,
+  audit_evidence_snapshot_id uuid not null,
+  decision_type text not null,
+  created_by text null,
+  created_at timestamptz not null default now(),
+  constraint mission_decision_type_chk
+    check (decision_type in ('approval', 'dispatch')),
+  constraint mission_decision_snapshot_fk
+    foreign key (mission_id, audit_evidence_snapshot_id)
+    references audit_evidence_snapshots (mission_id, id)
+    on delete restrict
+);
+
+create index if not exists idx_mission_decision_evidence_links_mission_created
+  on mission_decision_evidence_links (mission_id, created_at desc);
+
+create index if not exists idx_mission_decision_evidence_links_snapshot
+  on mission_decision_evidence_links (audit_evidence_snapshot_id);

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -5,6 +5,7 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from mission_decision_evidence_links");
   await pool.query("delete from audit_evidence_snapshots");
   await pool.query("delete from airspace_compliance_inputs");
   await pool.query("delete from mission_risk_inputs");
@@ -159,6 +160,7 @@ const countRows = async (missionId: string) => {
     `
     select
       (select count(*)::int from audit_evidence_snapshots where mission_id = $1) as snapshot_count,
+      (select count(*)::int from mission_decision_evidence_links where mission_id = $1) as decision_link_count,
       (select count(*)::int from mission_events where mission_id = $1) as mission_event_count,
       (select count(*)::int from mission_risk_inputs where mission_id = $1) as risk_input_count,
       (select count(*)::int from airspace_compliance_inputs where mission_id = $1) as airspace_input_count,
@@ -169,6 +171,7 @@ const countRows = async (missionId: string) => {
 
   return result.rows[0] as {
     snapshot_count: number;
+    decision_link_count: number;
     mission_event_count: number;
     risk_input_count: number;
     airspace_input_count: number;
@@ -361,5 +364,168 @@ describe("audit evidence snapshots", () => {
 
     expect(createResponse.status).toBe(404);
     expect(listResponse.status).toBe(404);
+  });
+
+  it("links approval and dispatch decisions to readiness snapshots", async () => {
+    const { missionId } = await createReadyMission();
+    const snapshotResponse = await request(app)
+      .post(`/missions/${missionId}/readiness/audit-snapshots`)
+      .send({ createdBy: "reviewer-a" });
+
+    expect(snapshotResponse.status).toBe(201);
+    const snapshotId = snapshotResponse.body.snapshot.id;
+    const before = await countRows(missionId);
+
+    const approvalResponse = await request(app)
+      .post(`/missions/${missionId}/decision-evidence-links`)
+      .send({
+        snapshotId,
+        decisionType: "approval",
+        createdBy: " approver ",
+      });
+    const dispatchResponse = await request(app)
+      .post(`/missions/${missionId}/decision-evidence-links`)
+      .send({
+        snapshotId,
+        decisionType: "dispatch",
+      });
+
+    expect(approvalResponse.status).toBe(201);
+    expect(approvalResponse.body.link).toMatchObject({
+      missionId,
+      auditEvidenceSnapshotId: snapshotId,
+      decisionType: "approval",
+      createdBy: "approver",
+    });
+    expect(dispatchResponse.status).toBe(201);
+    expect(dispatchResponse.body.link).toMatchObject({
+      missionId,
+      auditEvidenceSnapshotId: snapshotId,
+      decisionType: "dispatch",
+      createdBy: null,
+    });
+    expect(await countRows(missionId)).toEqual({
+      ...before,
+      decision_link_count: before.decision_link_count + 2,
+    });
+  });
+
+  it("lists decision evidence links only for the requested mission", async () => {
+    const first = await createReadyMission();
+    const second = await createReadyMission();
+    const firstSnapshot = await request(app)
+      .post(`/missions/${first.missionId}/readiness/audit-snapshots`)
+      .send({});
+    const secondSnapshot = await request(app)
+      .post(`/missions/${second.missionId}/readiness/audit-snapshots`)
+      .send({});
+
+    expect(firstSnapshot.status).toBe(201);
+    expect(secondSnapshot.status).toBe(201);
+
+    const firstLink = await request(app)
+      .post(`/missions/${first.missionId}/decision-evidence-links`)
+      .send({
+        snapshotId: firstSnapshot.body.snapshot.id,
+        decisionType: "approval",
+        createdBy: "reviewer-a",
+      });
+    const secondLink = await request(app)
+      .post(`/missions/${second.missionId}/decision-evidence-links`)
+      .send({
+        snapshotId: secondSnapshot.body.snapshot.id,
+        decisionType: "dispatch",
+        createdBy: "reviewer-b",
+      });
+
+    expect(firstLink.status).toBe(201);
+    expect(secondLink.status).toBe(201);
+
+    const response = await request(app).get(
+      `/missions/${first.missionId}/decision-evidence-links`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.links).toHaveLength(1);
+    expect(response.body.links[0]).toMatchObject({
+      missionId: first.missionId,
+      auditEvidenceSnapshotId: firstSnapshot.body.snapshot.id,
+      decisionType: "approval",
+      createdBy: "reviewer-a",
+    });
+  });
+
+  it("rejects snapshots from another mission", async () => {
+    const first = await createReadyMission();
+    const second = await createReadyMission();
+    const secondSnapshot = await request(app)
+      .post(`/missions/${second.missionId}/readiness/audit-snapshots`)
+      .send({});
+
+    expect(secondSnapshot.status).toBe(201);
+
+    const response = await request(app)
+      .post(`/missions/${first.missionId}/decision-evidence-links`)
+      .send({
+        snapshotId: secondSnapshot.body.snapshot.id,
+        decisionType: "approval",
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "audit_evidence_snapshot_not_found",
+      },
+    });
+  });
+
+  it("rejects invalid decision evidence link requests", async () => {
+    const { missionId } = await createReadyMission();
+    const snapshotResponse = await request(app)
+      .post(`/missions/${missionId}/readiness/audit-snapshots`)
+      .send({});
+
+    expect(snapshotResponse.status).toBe(201);
+
+    const missingSnapshotResponse = await request(app)
+      .post(`/missions/${missionId}/decision-evidence-links`)
+      .send({
+        decisionType: "approval",
+      });
+    const invalidDecisionResponse = await request(app)
+      .post(`/missions/${missionId}/decision-evidence-links`)
+      .send({
+        snapshotId: snapshotResponse.body.snapshot.id,
+        decisionType: "release",
+      });
+
+    expect(missingSnapshotResponse.status).toBe(400);
+    expect(invalidDecisionResponse.status).toBe(400);
+  });
+
+  it("does not mutate referenced snapshots when decision links are created", async () => {
+    const { missionId } = await createReadyMission();
+    const snapshotResponse = await request(app)
+      .post(`/missions/${missionId}/readiness/audit-snapshots`)
+      .send({});
+
+    expect(snapshotResponse.status).toBe(201);
+    const beforeSnapshot = snapshotResponse.body.snapshot;
+
+    const linkResponse = await request(app)
+      .post(`/missions/${missionId}/decision-evidence-links`)
+      .send({
+        snapshotId: beforeSnapshot.id,
+        decisionType: "approval",
+      });
+
+    expect(linkResponse.status).toBe(201);
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/readiness/audit-snapshots`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.snapshots[0]).toEqual(beforeSnapshot);
   });
 });


### PR DESCRIPTION
## Summary
Implements issue #19 by adding approval/dispatch evidence linkage for audit readiness snapshots.

## What changed
- Added `mission_decision_evidence_links` persistence for linking approval or dispatch decisions to audit evidence snapshots.
- Added same-mission foreign key protection so a mission cannot link to another mission's snapshot.
- Added `POST /missions/:missionId/decision-evidence-links` to create approval/dispatch evidence links.
- Added `GET /missions/:missionId/decision-evidence-links` to list linked evidence for a mission.
- Extended audit evidence validation, repository, service, controller, and route coverage.
- Updated the next build step toward enforcing linked readiness evidence for mission approval.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/audit-evidence.test.ts` passed: 11 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 155 tests.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #19.
