### PR TITLE
Require approval evidence links #21

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission approval guard migration so approval decisions require linked readiness evidence snapshots.",
+ "nextBuildStep": "Add mission dispatch guard migration so launch decisions require linked readiness evidence snapshots.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -124,6 +124,7 @@ const airspaceComplianceService = new AirspaceComplianceService(
 const airspaceComplianceController = new AirspaceComplianceController(
   airspaceComplianceService,
 );
+const auditEvidenceRepository = new AuditEvidenceRepository();
 const missionService = new MissionService(
   db,
   missionRepo,
@@ -132,9 +133,9 @@ const missionService = new MissionService(
   pilotService,
   missionRiskService,
   airspaceComplianceService,
+  auditEvidenceRepository,
 );
 const missionController = new MissionController(missionService);
-const auditEvidenceRepository = new AuditEvidenceRepository();
 const auditEvidenceService = new AuditEvidenceService(
   pool,
   auditEvidenceRepository,

--- a/src/audit-evidence/audit-evidence.repository.ts
+++ b/src/audit-evidence/audit-evidence.repository.ts
@@ -201,4 +201,45 @@ export class AuditEvidenceRepository {
 
     return result.rows.map(toMissionDecisionEvidenceLink);
   }
+
+  async getDecisionEvidenceLinkForMission(
+    tx: PoolClient,
+    missionId: string,
+    linkId: string,
+  ): Promise<MissionDecisionEvidenceLink | null> {
+    const result = await tx.query<MissionDecisionEvidenceLinkRow>(
+      `
+      select *
+      from mission_decision_evidence_links
+      where mission_id = $1
+        and id = $2
+      limit 1
+      `,
+      [missionId, linkId],
+    );
+
+    return result.rows[0] ? toMissionDecisionEvidenceLink(result.rows[0]) : null;
+  }
+
+  async decisionEvidenceLinkReferencesReadinessSnapshot(
+    tx: PoolClient,
+    missionId: string,
+    linkId: string,
+  ): Promise<boolean> {
+    const result = await tx.query(
+      `
+      select 1
+      from mission_decision_evidence_links links
+      inner join audit_evidence_snapshots snapshots
+        on snapshots.mission_id = links.mission_id
+       and snapshots.id = links.audit_evidence_snapshot_id
+      where links.mission_id = $1
+        and links.id = $2
+        and snapshots.evidence_type = 'mission_readiness_gate'
+      `,
+      [missionId, linkId],
+    );
+
+    return result.rowCount === 1;
+  }
 }

--- a/src/missions/errors.ts
+++ b/src/missions/errors.ts
@@ -6,3 +6,21 @@ export class InvalidMissionTransitionError extends HttpError {
     this.name = "InvalidMissionTransitionError";
   }
 }
+
+export class MissionApprovalEvidenceRequiredError extends HttpError {
+  constructor() {
+    super(
+      400,
+      "Mission approval requires a linked readiness evidence snapshot",
+      "mission_approval_evidence_required",
+    );
+    this.name = "MissionApprovalEvidenceRequiredError";
+  }
+}
+
+export class InvalidMissionApprovalEvidenceError extends HttpError {
+  constructor(message: string) {
+    super(409, message, "invalid_mission_approval_evidence");
+    this.name = "InvalidMissionApprovalEvidenceError";
+  }
+}

--- a/src/missions/mission.controller.ts
+++ b/src/missions/mission.controller.ts
@@ -123,6 +123,7 @@ export class MissionController {
           (req as any).user?.id ?? req.body.reviewerId,
           "reviewerId",
         ),
+        decisionEvidenceLinkId: this.optionalString(req.body.decisionEvidenceLinkId),
         notes: this.optionalString(req.body.notes),
         requestId: this.optionalString(req.headers["x-request-id"]),
         correlationId: this.optionalString(req.headers["x-correlation-id"]),

--- a/src/missions/mission.service.ts
+++ b/src/missions/mission.service.ts
@@ -12,6 +12,7 @@ import { PilotNotFoundError } from "../pilots/pilot.errors";
 import { PilotService } from "../pilots/pilot.service";
 import { MissionRiskService } from "../mission-risk/mission-risk.service";
 import { AirspaceComplianceService } from "../airspace-compliance/airspace-compliance.service";
+import { AuditEvidenceRepository } from "../audit-evidence/audit-evidence.repository";
 import type {
   MissionReadinessCheck,
   MissionReadinessReason,
@@ -20,6 +21,10 @@ import type {
 import type { PilotReadinessResult } from "../pilots/pilot.types";
 import type { MissionRiskResult } from "../mission-risk/mission-risk.types";
 import type { AirspaceComplianceResult } from "../airspace-compliance/airspace-compliance.types";
+import {
+  InvalidMissionApprovalEvidenceError,
+  MissionApprovalEvidenceRequiredError,
+} from "./errors";
 
 export interface GetMissionEventsFilters {
   safety?: boolean;
@@ -60,6 +65,7 @@ export class MissionService {
     private readonly pilotService?: PilotService,
     private readonly missionRiskService?: MissionRiskService,
     private readonly airspaceComplianceService?: AirspaceComplianceService,
+    private readonly auditEvidenceRepository?: AuditEvidenceRepository,
   ) {}
 
   async submitMission(params: {
@@ -97,6 +103,7 @@ export class MissionService {
   async approveMission(params: {
   missionId: string;
   reviewerId: string;
+  decisionEvidenceLinkId?: string;
   notes?: string;
   requestId?: string;
   correlationId?: string;
@@ -105,6 +112,12 @@ export class MissionService {
     const mission = await this.missionRepo.getForUpdate(tx, params.missionId);
 
     assertMissionActionAllowed(mission.status, "approve");
+
+    await this.assertApprovalEvidenceLinked(
+      tx,
+      mission.id,
+      params.decisionEvidenceLinkId,
+    );
 
     await this.missionRepo.updateStatus(tx, params.missionId, "approved");
 
@@ -119,6 +132,7 @@ export class MissionService {
       summary: "Mission approved",
       details: {
         decision: "approved",
+        decision_evidence_link_id: params.decisionEvidenceLinkId,
         notes: params.notes ?? null,
       },
       source: "mission-review-service",
@@ -127,6 +141,54 @@ export class MissionService {
     });
   });
 } 
+
+  private async assertApprovalEvidenceLinked(
+    tx: any,
+    missionId: string,
+    decisionEvidenceLinkId?: string,
+  ): Promise<void> {
+    if (!decisionEvidenceLinkId) {
+      throw new MissionApprovalEvidenceRequiredError();
+    }
+
+    if (!this.auditEvidenceRepository) {
+      throw new InvalidMissionApprovalEvidenceError(
+        "Mission approval evidence repository is not available",
+      );
+    }
+
+    const link =
+      await this.auditEvidenceRepository.getDecisionEvidenceLinkForMission(
+        tx,
+        missionId,
+        decisionEvidenceLinkId,
+      );
+
+    if (!link) {
+      throw new InvalidMissionApprovalEvidenceError(
+        "Mission approval evidence link was not found for this mission",
+      );
+    }
+
+    if (link.decisionType !== "approval") {
+      throw new InvalidMissionApprovalEvidenceError(
+        "Mission approval requires an approval evidence link",
+      );
+    }
+
+    const referencesReadinessSnapshot =
+      await this.auditEvidenceRepository.decisionEvidenceLinkReferencesReadinessSnapshot(
+        tx,
+        missionId,
+        decisionEvidenceLinkId,
+      );
+
+    if (!referencesReadinessSnapshot) {
+      throw new InvalidMissionApprovalEvidenceError(
+        "Mission approval evidence must reference a readiness snapshot",
+      );
+    }
+  }
 
   async launchMission(params: {
     missionId: string;

--- a/src/tests/mission-lifecycle.test.ts
+++ b/src/tests/mission-lifecycle.test.ts
@@ -81,12 +81,64 @@ const countMissionEventsByType = async (
   return result.rows[0].count as number;
 };
 
+const createDecisionEvidenceLink = async (
+  missionId: string,
+  decisionType: "approval" | "dispatch",
+) => {
+  const snapshotResponse = await request(app)
+    .post(`/missions/${missionId}/readiness/audit-snapshots`)
+    .send({});
+
+  expect(snapshotResponse.status).toBe(201);
+
+  const linkResponse = await request(app)
+    .post(`/missions/${missionId}/decision-evidence-links`)
+    .send({
+      snapshotId: snapshotResponse.body.snapshot.id,
+      decisionType,
+      createdBy: "reviewer-1",
+    });
+
+  expect(linkResponse.status).toBe(201);
+
+  return linkResponse.body.link as { id: string };
+};
+
+const createApprovalEvidenceLink = async (missionId: string) =>
+  createDecisionEvidenceLink(missionId, "approval");
+
+const getAuditEvidenceState = async (missionId: string) => {
+  const result = await pool.query(
+    `
+    select
+      (select count(*)::int from audit_evidence_snapshots where mission_id = $1) as snapshot_count,
+      (select count(*)::int from mission_decision_evidence_links where mission_id = $1) as decision_link_count,
+      (
+        select readiness_snapshot
+        from audit_evidence_snapshots
+        where mission_id = $1
+        order by created_at desc, id desc
+        limit 1
+      ) as latest_snapshot
+    `,
+    [missionId],
+  );
+
+  return result.rows[0] as {
+    snapshot_count: number;
+    decision_link_count: number;
+    latest_snapshot: Record<string, unknown> | null;
+  };
+};
+
 type DuplicateTransitionCase = {
   name: string;
   route: (missionId: string) => string;
   initialStatus: string;
   expectedStatusAfterFirstCall: string;
-  requestBody: Record<string, unknown>;
+  requestBody:
+    | Record<string, unknown>
+    | ((missionId: string) => Promise<Record<string, unknown>>);
   expectedErrorMessage: string;
   eventType: string;
 };
@@ -108,9 +160,14 @@ const runDuplicateTransitionTest = ({
       status: initialStatus,
     });
 
+    const resolvedRequestBody =
+      typeof requestBody === "function"
+        ? await requestBody(missionId)
+        : requestBody;
+
     const firstResponse = await request(app)
       .post(route(missionId))
-      .send(requestBody);
+      .send(resolvedRequestBody);
 
     expect(firstResponse.status).toBe(204);
 
@@ -129,7 +186,7 @@ const runDuplicateTransitionTest = ({
 
     const secondResponse = await request(app)
       .post(route(missionId))
-      .send(requestBody);
+      .send(resolvedRequestBody);
 
     expect(secondResponse.status).toBe(409);
 
@@ -178,9 +235,14 @@ describe("mission integration", () => {
     route: (missionId) => `/missions/${missionId}/approve`,
     initialStatus: "submitted",
     expectedStatusAfterFirstCall: "approved",
-    requestBody: {
-      reviewerId: "reviewer-1",
-      notes: "first approval",
+    requestBody: async (missionId) => {
+      const link = await createApprovalEvidenceLink(missionId);
+
+      return {
+        reviewerId: "reviewer-1",
+        decisionEvidenceLinkId: link.id,
+        notes: "first approval",
+      };
     },
     expectedErrorMessage: "Mission cannot be approved from status approved",
     eventType: "mission.approved",
@@ -259,6 +321,109 @@ describe("mission integration", () => {
 
     expect(await getMissionEvents(missionId)).toEqual([]);
     expect(await countMissionEventsByType(missionId, "mission.approved")).toBe(0);
+  });
+
+  it("POST /missions/:missionId/approve rejects submitted approval without linked readiness evidence", async () => {
+    const missionId = randomUUID();
+
+    await insertMission({
+      id: missionId,
+      status: "submitted",
+    });
+    const auditBefore = await getAuditEvidenceState(missionId);
+
+    const approveResponse = await request(app)
+      .post(`/missions/${missionId}/approve`)
+      .send({
+        reviewerId: "reviewer-1",
+        notes: "should fail without evidence",
+      });
+
+    expect(approveResponse.status).toBe(400);
+    expect(approveResponse.body).toMatchObject({
+      error: {
+        type: "mission_approval_evidence_required",
+      },
+    });
+
+    expect(await getMissionState(missionId)).toEqual({
+      status: "submitted",
+      last_event_sequence_no: 0,
+    });
+    expect(await getMissionEvents(missionId)).toEqual([]);
+    expect(await getAuditEvidenceState(missionId)).toEqual(auditBefore);
+  });
+
+  it("POST /missions/:missionId/approve rejects dispatch evidence links", async () => {
+    const missionId = randomUUID();
+
+    await insertMission({
+      id: missionId,
+      status: "submitted",
+    });
+    const dispatchLink = await createDecisionEvidenceLink(missionId, "dispatch");
+    const auditBefore = await getAuditEvidenceState(missionId);
+
+    const approveResponse = await request(app)
+      .post(`/missions/${missionId}/approve`)
+      .send({
+        reviewerId: "reviewer-1",
+        decisionEvidenceLinkId: dispatchLink.id,
+        notes: "should fail with dispatch evidence",
+      });
+
+    expect(approveResponse.status).toBe(409);
+    expect(approveResponse.body).toMatchObject({
+      error: {
+        type: "invalid_mission_approval_evidence",
+      },
+    });
+
+    expect(await getMissionState(missionId)).toEqual({
+      status: "submitted",
+      last_event_sequence_no: 0,
+    });
+    expect(await getMissionEvents(missionId)).toEqual([]);
+    expect(await getAuditEvidenceState(missionId)).toEqual(auditBefore);
+  });
+
+  it("POST /missions/:missionId/approve rejects approval evidence from another mission", async () => {
+    const missionId = randomUUID();
+    const otherMissionId = randomUUID();
+
+    await insertMission({
+      id: missionId,
+      status: "submitted",
+    });
+    await insertMission({
+      id: otherMissionId,
+      status: "submitted",
+    });
+    const otherLink = await createApprovalEvidenceLink(otherMissionId);
+    const auditBefore = await getAuditEvidenceState(missionId);
+    const otherAuditBefore = await getAuditEvidenceState(otherMissionId);
+
+    const approveResponse = await request(app)
+      .post(`/missions/${missionId}/approve`)
+      .send({
+        reviewerId: "reviewer-1",
+        decisionEvidenceLinkId: otherLink.id,
+      });
+
+    expect(approveResponse.status).toBe(409);
+    expect(approveResponse.body).toMatchObject({
+      error: {
+        type: "invalid_mission_approval_evidence",
+      },
+    });
+
+    expect(await getMissionState(missionId)).toEqual({
+      status: "submitted",
+      last_event_sequence_no: 0,
+    });
+    expect(await getMissionEvents(missionId)).toEqual([]);
+    expect(await getAuditEvidenceState(missionId)).toEqual(auditBefore);
+    expect(await getAuditEvidenceState(otherMissionId)).toEqual(otherAuditBefore);
   });
 
   it("POST /missions/:missionId/complete rejects complete before launch and does not append mission.completed", async () => {
@@ -708,10 +873,13 @@ it("POST mission lifecycle submit -> approve -> launch -> complete writes ordere
 
     expect(submitResponse.status).toBe(204);
 
+    const approvalEvidenceLink = await createApprovalEvidenceLink(missionId);
+
     const approveResponse = await request(app)
       .post(`/missions/${missionId}/approve`)
       .send({
         reviewerId: "reviewer-1",
+        decisionEvidenceLinkId: approvalEvidenceLink.id,
         notes: "approved in lifecycle test",
       });
 
@@ -795,6 +963,7 @@ it("POST mission lifecycle submit -> approve -> launch -> complete writes ordere
       summary: "Mission approved",
       details: {
         decision: "approved",
+        decision_evidence_link_id: approvalEvidenceLink.id,
         notes: "approved in lifecycle test",
       },
     });

--- a/src/tests/mission.transition-matrix.integration.test.ts
+++ b/src/tests/mission.transition-matrix.integration.test.ts
@@ -77,6 +77,26 @@ const countMissionEventsByType = async (
   return result.rows[0].count as number;
 };
 
+const createApprovalEvidenceLink = async (missionId: string) => {
+  const snapshotResponse = await request(app)
+    .post(`/missions/${missionId}/readiness/audit-snapshots`)
+    .send({});
+
+  expect(snapshotResponse.status).toBe(201);
+
+  const linkResponse = await request(app)
+    .post(`/missions/${missionId}/decision-evidence-links`)
+    .send({
+      snapshotId: snapshotResponse.body.snapshot.id,
+      decisionType: "approval",
+      createdBy: "reviewer-1",
+    });
+
+  expect(linkResponse.status).toBe(201);
+
+  return linkResponse.body.link as { id: string };
+};
+
 type TransitionCase = {
   name: string;
   route: (missionId: string) => string;
@@ -276,10 +296,16 @@ describe("mission transition matrix integration", () => {
 
       const stateBefore = await getMissionState(missionId);
       const eventsBefore = await getMissionEvents(missionId);
+      const requestBody = { ...testCase.requestBody };
+
+      if (testCase.expectedEventType === "mission.approved" && testCase.allowed) {
+        const link = await createApprovalEvidenceLink(missionId);
+        requestBody.decisionEvidenceLinkId = link.id;
+      }
 
       const response = await request(app)
         .post(testCase.route(missionId))
-        .send(testCase.requestBody);
+        .send(requestBody);
 
       if (testCase.allowed) {
         expect(response.status).toBe(204);


### PR DESCRIPTION
## Summary
Implements issue #21 by requiring mission approval decisions to reference a linked readiness evidence snapshot.

## What changed
- Extended mission approval requests with `decisionEvidenceLinkId`.
- Added approval guard validation that requires the evidence link to belong to the same mission, have `decisionType: approval`, and reference a readiness audit snapshot.
- Records the `decision_evidence_link_id` in `mission.approved` event details.
- Added audit repository helpers for same-mission decision evidence link lookup and readiness snapshot verification.
- Updated lifecycle and transition matrix tests for evidence-backed approval.
- Updated the next build step toward dispatch/launch evidence guard enforcement.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/mission-lifecycle.test.ts src/tests/audit-evidence.test.ts` passed: 32 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 158 tests.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #21.
