### PR TITLE
Require dispatch evidence links #23

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission dispatch guard migration so launch decisions require linked readiness evidence snapshots.",
+ "nextBuildStep": "Add mission planning draft endpoints so operators can create mission plans with platform, pilot, risk, and airspace placeholders.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/missions/errors.ts
+++ b/src/missions/errors.ts
@@ -24,3 +24,21 @@ export class InvalidMissionApprovalEvidenceError extends HttpError {
     this.name = "InvalidMissionApprovalEvidenceError";
   }
 }
+
+export class MissionDispatchEvidenceRequiredError extends HttpError {
+  constructor() {
+    super(
+      400,
+      "Mission launch requires a linked readiness evidence snapshot",
+      "mission_dispatch_evidence_required",
+    );
+    this.name = "MissionDispatchEvidenceRequiredError";
+  }
+}
+
+export class InvalidMissionDispatchEvidenceError extends HttpError {
+  constructor(message: string) {
+    super(409, message, "invalid_mission_dispatch_evidence");
+    this.name = "InvalidMissionDispatchEvidenceError";
+  }
+}

--- a/src/missions/mission.controller.ts
+++ b/src/missions/mission.controller.ts
@@ -150,6 +150,7 @@ export class MissionController {
         vehicleId: this.requireString(req.body.vehicleId, "vehicleId"),
         lat: this.requireNumber(req.body.lat, "lat"),
         lng: this.requireNumber(req.body.lng, "lng"),
+        decisionEvidenceLinkId: this.optionalString(req.body.decisionEvidenceLinkId),
         requestId: this.optionalString(req.headers["x-request-id"]),
         correlationId: this.optionalString(req.headers["x-correlation-id"]),
       });

--- a/src/missions/mission.service.ts
+++ b/src/missions/mission.service.ts
@@ -23,7 +23,9 @@ import type { MissionRiskResult } from "../mission-risk/mission-risk.types";
 import type { AirspaceComplianceResult } from "../airspace-compliance/airspace-compliance.types";
 import {
   InvalidMissionApprovalEvidenceError,
+  InvalidMissionDispatchEvidenceError,
   MissionApprovalEvidenceRequiredError,
+  MissionDispatchEvidenceRequiredError,
 } from "./errors";
 
 export interface GetMissionEventsFilters {
@@ -196,6 +198,7 @@ export class MissionService {
     vehicleId: string;
     lat: number;
     lng: number;
+    decisionEvidenceLinkId?: string;
     requestId?: string;
     correlationId?: string;
   }): Promise<void> {
@@ -204,6 +207,11 @@ export class MissionService {
       
       assertMissionActionAllowed(mission.status, "launch");
 
+      await this.assertDispatchEvidenceLinked(
+        tx,
+        mission.id,
+        params.decisionEvidenceLinkId,
+      );
       
       await this.missionRepo.updateStatus(tx, params.missionId, "active");
 
@@ -218,6 +226,7 @@ export class MissionService {
         summary: "Mission launched",
         details: {
           vehicle_id: params.vehicleId,
+          decision_evidence_link_id: params.decisionEvidenceLinkId,
           launch_site: {
             lat: params.lat,
             lng: params.lng,
@@ -228,6 +237,54 @@ export class MissionService {
         correlationId: params.correlationId ?? null,
       });
     });
+  }
+
+  private async assertDispatchEvidenceLinked(
+    tx: any,
+    missionId: string,
+    decisionEvidenceLinkId?: string,
+  ): Promise<void> {
+    if (!decisionEvidenceLinkId) {
+      throw new MissionDispatchEvidenceRequiredError();
+    }
+
+    if (!this.auditEvidenceRepository) {
+      throw new InvalidMissionDispatchEvidenceError(
+        "Mission dispatch evidence repository is not available",
+      );
+    }
+
+    const link =
+      await this.auditEvidenceRepository.getDecisionEvidenceLinkForMission(
+        tx,
+        missionId,
+        decisionEvidenceLinkId,
+      );
+
+    if (!link) {
+      throw new InvalidMissionDispatchEvidenceError(
+        "Mission dispatch evidence link was not found for this mission",
+      );
+    }
+
+    if (link.decisionType !== "dispatch") {
+      throw new InvalidMissionDispatchEvidenceError(
+        "Mission launch requires a dispatch evidence link",
+      );
+    }
+
+    const referencesReadinessSnapshot =
+      await this.auditEvidenceRepository.decisionEvidenceLinkReferencesReadinessSnapshot(
+        tx,
+        missionId,
+        decisionEvidenceLinkId,
+      );
+
+    if (!referencesReadinessSnapshot) {
+      throw new InvalidMissionDispatchEvidenceError(
+        "Mission dispatch evidence must reference a readiness snapshot",
+      );
+    }
   }
 
   async completeMission(params: {

--- a/src/tests/mission-lifecycle.test.ts
+++ b/src/tests/mission-lifecycle.test.ts
@@ -107,6 +107,9 @@ const createDecisionEvidenceLink = async (
 const createApprovalEvidenceLink = async (missionId: string) =>
   createDecisionEvidenceLink(missionId, "approval");
 
+const createDispatchEvidenceLink = async (missionId: string) =>
+  createDecisionEvidenceLink(missionId, "dispatch");
+
 const getAuditEvidenceState = async (missionId: string) => {
   const result = await pool.query(
     `
@@ -253,11 +256,16 @@ describe("mission integration", () => {
     route: (missionId) => `/missions/${missionId}/launch`,
     initialStatus: "approved",
     expectedStatusAfterFirstCall: "active",
-    requestBody: {
-      operatorId: "operator-1",
-      vehicleId: "vehicle-1",
-      lat: 51.5074,
-      lng: -0.1278,
+    requestBody: async (missionId) => {
+      const link = await createDispatchEvidenceLink(missionId);
+
+      return {
+        operatorId: "operator-1",
+        vehicleId: "vehicle-1",
+        lat: 51.5074,
+        lng: -0.1278,
+        decisionEvidenceLinkId: link.id,
+      };
     },
     expectedErrorMessage: "Mission cannot be launched from status active",
     eventType: "mission.launched",
@@ -532,13 +540,14 @@ describe("mission integration", () => {
   expect(await countMissionEventsByType(missionId, "mission.launched")).toBe(0);
 });
 
-  it("POST /missions/:missionId/launch updates mission state and creates exactly one mission.launched event", async () => {
+  it("POST /missions/:missionId/launch rejects approved launch without linked readiness evidence", async () => {
     const missionId = randomUUID();
 
     await insertMission({
       id: missionId,
       status: "approved",
     });
+    const auditBefore = await getAuditEvidenceState(missionId);
 
     const launchResponse = await request(app)
       .post(`/missions/${missionId}/launch`)
@@ -547,6 +556,117 @@ describe("mission integration", () => {
         vehicleId: "vehicle-1",
         lat: 51.5074,
         lng: -0.1278,
+      });
+
+    expect(launchResponse.status).toBe(400);
+    expect(launchResponse.body).toMatchObject({
+      error: {
+        type: "mission_dispatch_evidence_required",
+      },
+    });
+
+    expect(await getMissionState(missionId)).toEqual({
+      status: "approved",
+      last_event_sequence_no: 0,
+    });
+    expect(await getMissionEvents(missionId)).toEqual([]);
+    expect(await getAuditEvidenceState(missionId)).toEqual(auditBefore);
+  });
+
+  it("POST /missions/:missionId/launch rejects approval evidence links", async () => {
+    const missionId = randomUUID();
+
+    await insertMission({
+      id: missionId,
+      status: "approved",
+    });
+    const approvalLink = await createApprovalEvidenceLink(missionId);
+    const auditBefore = await getAuditEvidenceState(missionId);
+
+    const launchResponse = await request(app)
+      .post(`/missions/${missionId}/launch`)
+      .send({
+        operatorId: "operator-1",
+        vehicleId: "vehicle-1",
+        lat: 51.5074,
+        lng: -0.1278,
+        decisionEvidenceLinkId: approvalLink.id,
+      });
+
+    expect(launchResponse.status).toBe(409);
+    expect(launchResponse.body).toMatchObject({
+      error: {
+        type: "invalid_mission_dispatch_evidence",
+      },
+    });
+
+    expect(await getMissionState(missionId)).toEqual({
+      status: "approved",
+      last_event_sequence_no: 0,
+    });
+    expect(await getMissionEvents(missionId)).toEqual([]);
+    expect(await getAuditEvidenceState(missionId)).toEqual(auditBefore);
+  });
+
+  it("POST /missions/:missionId/launch rejects dispatch evidence from another mission", async () => {
+    const missionId = randomUUID();
+    const otherMissionId = randomUUID();
+
+    await insertMission({
+      id: missionId,
+      status: "approved",
+    });
+    await insertMission({
+      id: otherMissionId,
+      status: "approved",
+    });
+    const otherLink = await createDispatchEvidenceLink(otherMissionId);
+    const auditBefore = await getAuditEvidenceState(missionId);
+    const otherAuditBefore = await getAuditEvidenceState(otherMissionId);
+
+    const launchResponse = await request(app)
+      .post(`/missions/${missionId}/launch`)
+      .send({
+        operatorId: "operator-1",
+        vehicleId: "vehicle-1",
+        lat: 51.5074,
+        lng: -0.1278,
+        decisionEvidenceLinkId: otherLink.id,
+      });
+
+    expect(launchResponse.status).toBe(409);
+    expect(launchResponse.body).toMatchObject({
+      error: {
+        type: "invalid_mission_dispatch_evidence",
+      },
+    });
+
+    expect(await getMissionState(missionId)).toEqual({
+      status: "approved",
+      last_event_sequence_no: 0,
+    });
+    expect(await getMissionEvents(missionId)).toEqual([]);
+    expect(await getAuditEvidenceState(missionId)).toEqual(auditBefore);
+    expect(await getAuditEvidenceState(otherMissionId)).toEqual(otherAuditBefore);
+  });
+
+  it("POST /missions/:missionId/launch updates mission state and creates exactly one mission.launched event", async () => {
+    const missionId = randomUUID();
+
+    await insertMission({
+      id: missionId,
+      status: "approved",
+    });
+    const dispatchLink = await createDispatchEvidenceLink(missionId);
+
+    const launchResponse = await request(app)
+      .post(`/missions/${missionId}/launch`)
+      .send({
+        operatorId: "operator-1",
+        vehicleId: "vehicle-1",
+        lat: 51.5074,
+        lng: -0.1278,
+        decisionEvidenceLinkId: dispatchLink.id,
       });
 
     expect(launchResponse.status).toBe(204);
@@ -573,6 +693,7 @@ describe("mission integration", () => {
 
     expect(launchedEvents[0].details).toMatchObject({
       vehicle_id: "vehicle-1",
+      decision_evidence_link_id: dispatchLink.id,
       launch_site: {
         lat: 51.5074,
         lng: -0.1278,
@@ -885,6 +1006,8 @@ it("POST mission lifecycle submit -> approve -> launch -> complete writes ordere
 
     expect(approveResponse.status).toBe(204);
 
+    const dispatchEvidenceLink = await createDispatchEvidenceLink(missionId);
+
     const launchResponse = await request(app)
       .post(`/missions/${missionId}/launch`)
       .send({
@@ -892,6 +1015,7 @@ it("POST mission lifecycle submit -> approve -> launch -> complete writes ordere
         vehicleId: "vehicle-1",
         lat: 51.5074,
         lng: -0.1278,
+        decisionEvidenceLinkId: dispatchEvidenceLink.id,
       });
 
     expect(launchResponse.status).toBe(204);
@@ -977,6 +1101,7 @@ it("POST mission lifecycle submit -> approve -> launch -> complete writes ordere
       summary: "Mission launched",
       details: {
         vehicle_id: "vehicle-1",
+        decision_evidence_link_id: dispatchEvidenceLink.id,
         launch_site: {
           lat: 51.5074,
           lng: -0.1278,

--- a/src/tests/mission.transition-matrix.integration.test.ts
+++ b/src/tests/mission.transition-matrix.integration.test.ts
@@ -77,7 +77,10 @@ const countMissionEventsByType = async (
   return result.rows[0].count as number;
 };
 
-const createApprovalEvidenceLink = async (missionId: string) => {
+const createDecisionEvidenceLink = async (
+  missionId: string,
+  decisionType: "approval" | "dispatch",
+) => {
   const snapshotResponse = await request(app)
     .post(`/missions/${missionId}/readiness/audit-snapshots`)
     .send({});
@@ -88,7 +91,7 @@ const createApprovalEvidenceLink = async (missionId: string) => {
     .post(`/missions/${missionId}/decision-evidence-links`)
     .send({
       snapshotId: snapshotResponse.body.snapshot.id,
-      decisionType: "approval",
+      decisionType,
       createdBy: "reviewer-1",
     });
 
@@ -96,6 +99,12 @@ const createApprovalEvidenceLink = async (missionId: string) => {
 
   return linkResponse.body.link as { id: string };
 };
+
+const createApprovalEvidenceLink = async (missionId: string) =>
+  createDecisionEvidenceLink(missionId, "approval");
+
+const createDispatchEvidenceLink = async (missionId: string) =>
+  createDecisionEvidenceLink(missionId, "dispatch");
 
 type TransitionCase = {
   name: string;
@@ -300,6 +309,11 @@ describe("mission transition matrix integration", () => {
 
       if (testCase.expectedEventType === "mission.approved" && testCase.allowed) {
         const link = await createApprovalEvidenceLink(missionId);
+        requestBody.decisionEvidenceLinkId = link.id;
+      }
+
+      if (testCase.expectedEventType === "mission.launched" && testCase.allowed) {
+        const link = await createDispatchEvidenceLink(missionId);
         requestBody.decisionEvidenceLinkId = link.id;
       }
 


### PR DESCRIPTION
## Summary
Implements issue #23 by requiring mission launch/dispatch decisions to reference a linked readiness evidence snapshot.

## What changed
- Extended launch requests with `decisionEvidenceLinkId`.
- Added dispatch guard validation that requires the evidence link to belong to the same mission, have `decisionType: dispatch`, and reference a readiness audit snapshot.
- Records the `decision_evidence_link_id` in `mission.launched` event details.
- Added dispatch-specific evidence errors.
- Updated lifecycle and transition matrix tests for evidence-backed launch.
- Updated the next build step toward mission planning draft endpoints.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/mission-lifecycle.test.ts src/tests/audit-evidence.test.ts src/tests/mission.transition-matrix.integration.test.ts` passed: 51 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 161 tests.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #23.
