### PR TITLE
Add mission planning draft endpoints  #25

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission planning draft endpoints so operators can create mission plans with platform, pilot, risk, and airspace placeholders.",
+ "nextBuildStep": "Add mission planning draft update endpoints so operators can progressively fill platform, pilot, risk, and airspace placeholders.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,6 +46,10 @@ import { AuditEvidenceRepository } from "./audit-evidence/audit-evidence.reposit
 import { AuditEvidenceService } from "./audit-evidence/audit-evidence.service";
 import { AuditEvidenceController } from "./audit-evidence/audit-evidence.controller";
 import { createAuditEvidenceRouter } from "./audit-evidence/audit-evidence.routes";
+import { MissionPlanningRepository } from "./mission-planning/mission-planning.repository";
+import { MissionPlanningService } from "./mission-planning/mission-planning.service";
+import { MissionPlanningController } from "./mission-planning/mission-planning.controller";
+import { createMissionPlanningRouter } from "./mission-planning/mission-planning.routes";
 
 dotenv.config({
   path: path.resolve(process.cwd(), ".env"),
@@ -144,7 +148,18 @@ const auditEvidenceService = new AuditEvidenceService(
 const auditEvidenceController = new AuditEvidenceController(
   auditEvidenceService,
 );
+const missionPlanningRepository = new MissionPlanningRepository();
+const missionPlanningService = new MissionPlanningService(
+  pool,
+  missionPlanningRepository,
+  missionRiskRepository,
+  airspaceComplianceRepository,
+);
+const missionPlanningController = new MissionPlanningController(
+  missionPlanningService,
+);
 
+app.use("/mission-plans", createMissionPlanningRouter(missionPlanningController));
 app.use("/missions", createMissionRouter(missionController));
 app.use("/missions", createMissionRiskRouter(missionRiskController));
 app.use("/missions", createAirspaceComplianceRouter(airspaceComplianceController));

--- a/src/mission-planning/mission-planning.controller.ts
+++ b/src/mission-planning/mission-planning.controller.ts
@@ -1,0 +1,38 @@
+import type { NextFunction, Request, Response } from "express";
+import { MissionPlanningService } from "./mission-planning.service";
+
+type MissionIdParams = {
+  missionId: string;
+};
+
+export class MissionPlanningController {
+  constructor(private readonly missionPlanningService: MissionPlanningService) {}
+
+  createDraft = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const draft = await this.missionPlanningService.createDraft(req.body);
+      res.status(201).json({ draft });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getDraft = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const draft = await this.missionPlanningService.getDraft(
+        req.params.missionId,
+      );
+      res.status(200).json({ draft });
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/mission-planning/mission-planning.errors.ts
+++ b/src/mission-planning/mission-planning.errors.ts
@@ -1,0 +1,22 @@
+export class MissionPlanningValidationError extends Error {
+  readonly statusCode = 400;
+  readonly code = "MISSION_PLANNING_VALIDATION_FAILED";
+}
+
+export class MissionPlanningDraftNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "MISSION_DRAFT_NOT_FOUND";
+
+  constructor(missionId: string) {
+    super(`Mission planning draft not found: ${missionId}`);
+  }
+}
+
+export class MissionPlanningReferenceNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "MISSION_PLANNING_REFERENCE_NOT_FOUND";
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/mission-planning/mission-planning.repository.ts
+++ b/src/mission-planning/mission-planning.repository.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from "crypto";
+import type { PoolClient, QueryResultRow } from "pg";
+
+interface MissionPlanningDraftRow extends QueryResultRow {
+  id: string;
+  status: "draft";
+  mission_plan_id: string | null;
+  platform_id: string | null;
+  pilot_id: string | null;
+  risk_input_present: boolean;
+  airspace_input_present: boolean;
+}
+
+export class MissionPlanningRepository {
+  async platformExists(tx: PoolClient, platformId: string): Promise<boolean> {
+    const result = await tx.query(
+      `
+      select 1
+      from platforms
+      where id = $1
+      `,
+      [platformId],
+    );
+
+    return result.rowCount === 1;
+  }
+
+  async pilotExists(tx: PoolClient, pilotId: string): Promise<boolean> {
+    const result = await tx.query(
+      `
+      select 1
+      from pilots
+      where id = $1
+      `,
+      [pilotId],
+    );
+
+    return result.rowCount === 1;
+  }
+
+  async insertDraftMission(
+    tx: PoolClient,
+    input: {
+      missionPlanId: string | null;
+      platformId: string | null;
+      pilotId: string | null;
+    },
+  ): Promise<string> {
+    const result = await tx.query<{ id: string }>(
+      `
+      insert into missions (
+        id,
+        status,
+        mission_plan_id,
+        platform_id,
+        pilot_id,
+        last_event_sequence_no
+      )
+      values ($1, 'draft', $2, $3, $4, 0)
+      returning id
+      `,
+      [randomUUID(), input.missionPlanId, input.platformId, input.pilotId],
+    );
+
+    return result.rows[0].id;
+  }
+
+  async getDraftMission(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<MissionPlanningDraftRow | null> {
+    const result = await tx.query<MissionPlanningDraftRow>(
+      `
+      select
+        missions.id,
+        missions.status,
+        missions.mission_plan_id,
+        missions.platform_id,
+        missions.pilot_id,
+        exists (
+          select 1
+          from mission_risk_inputs risk
+          where risk.mission_id = missions.id
+        ) as risk_input_present,
+        exists (
+          select 1
+          from airspace_compliance_inputs airspace
+          where airspace.mission_id = missions.id
+        ) as airspace_input_present
+      from missions
+      where missions.id = $1
+        and missions.status = 'draft'
+      `,
+      [missionId],
+    );
+
+    return result.rows[0] ?? null;
+  }
+}

--- a/src/mission-planning/mission-planning.routes.ts
+++ b/src/mission-planning/mission-planning.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { MissionPlanningController } from "./mission-planning.controller";
+
+export function createMissionPlanningRouter(
+  controller: MissionPlanningController,
+): Router {
+  const router = Router();
+
+  router.post("/drafts", controller.createDraft);
+  router.get("/drafts/:missionId", controller.getDraft);
+
+  return router;
+}

--- a/src/mission-planning/mission-planning.service.ts
+++ b/src/mission-planning/mission-planning.service.ts
@@ -1,0 +1,194 @@
+import type { Pool } from "pg";
+import { AirspaceComplianceRepository } from "../airspace-compliance/airspace-compliance.repository";
+import { validateCreateAirspaceComplianceInput } from "../airspace-compliance/airspace-compliance.validators";
+import { MissionRiskRepository } from "../mission-risk/mission-risk.repository";
+import { validateCreateMissionRiskInput } from "../mission-risk/mission-risk.validators";
+import {
+  MissionPlanningDraftNotFoundError,
+  MissionPlanningReferenceNotFoundError,
+} from "./mission-planning.errors";
+import { MissionPlanningRepository } from "./mission-planning.repository";
+import type {
+  CreateMissionPlanningDraftInput,
+  MissionPlanningDraft,
+  MissionPlanningChecklistItem,
+} from "./mission-planning.types";
+import { validateCreateMissionPlanningDraftInput } from "./mission-planning.validators";
+
+export class MissionPlanningService {
+  constructor(
+    private readonly pool: Pool,
+    private readonly missionPlanningRepository: MissionPlanningRepository,
+    private readonly missionRiskRepository: MissionRiskRepository,
+    private readonly airspaceComplianceRepository: AirspaceComplianceRepository,
+  ) {}
+
+  async createDraft(
+    input: CreateMissionPlanningDraftInput | undefined,
+  ): Promise<MissionPlanningDraft> {
+    const validated = validateCreateMissionPlanningDraftInput(input);
+    const riskInput = validated.riskInput
+      ? validateCreateMissionRiskInput(validated.riskInput)
+      : null;
+    const airspaceInput = validated.airspaceInput
+      ? validateCreateAirspaceComplianceInput(validated.airspaceInput)
+      : null;
+    const client = await this.pool.connect();
+
+    try {
+      await client.query("BEGIN");
+
+      if (
+        validated.platformId &&
+        !(await this.missionPlanningRepository.platformExists(
+          client,
+          validated.platformId,
+        ))
+      ) {
+        throw new MissionPlanningReferenceNotFoundError(
+          `Platform not found: ${validated.platformId}`,
+        );
+      }
+
+      if (
+        validated.pilotId &&
+        !(await this.missionPlanningRepository.pilotExists(
+          client,
+          validated.pilotId,
+        ))
+      ) {
+        throw new MissionPlanningReferenceNotFoundError(
+          `Pilot not found: ${validated.pilotId}`,
+        );
+      }
+
+      const missionId =
+        await this.missionPlanningRepository.insertDraftMission(client, {
+          missionPlanId: validated.missionPlanId,
+          platformId: validated.platformId,
+          pilotId: validated.pilotId,
+        });
+
+      if (riskInput) {
+        await this.missionRiskRepository.insertMissionRiskInput(client, {
+          missionId,
+          ...riskInput,
+        });
+      }
+
+      if (airspaceInput) {
+        await this.airspaceComplianceRepository.insertAirspaceComplianceInput(
+          client,
+          {
+            missionId,
+            ...airspaceInput,
+          },
+        );
+      }
+
+      const draft = await this.getDraftForClient(client, missionId);
+      await client.query("COMMIT");
+      return draft;
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async getDraft(missionId: string): Promise<MissionPlanningDraft> {
+    const client = await this.pool.connect();
+
+    try {
+      return await this.getDraftForClient(client, missionId);
+    } finally {
+      client.release();
+    }
+  }
+
+  private async getDraftForClient(
+    client: Parameters<MissionPlanningRepository["getDraftMission"]>[0],
+    missionId: string,
+  ): Promise<MissionPlanningDraft> {
+    const row = await this.missionPlanningRepository.getDraftMission(
+      client,
+      missionId,
+    );
+
+    if (!row) {
+      throw new MissionPlanningDraftNotFoundError(missionId);
+    }
+
+    return this.toDraft(row);
+  }
+
+  private toDraft(row: {
+    id: string;
+    status: "draft";
+    mission_plan_id: string | null;
+    platform_id: string | null;
+    pilot_id: string | null;
+    risk_input_present: boolean;
+    airspace_input_present: boolean;
+  }): MissionPlanningDraft {
+    const placeholders = {
+      platformAssigned: row.platform_id !== null,
+      pilotAssigned: row.pilot_id !== null,
+      riskInputPresent: row.risk_input_present,
+      airspaceInputPresent: row.airspace_input_present,
+    };
+    const checklist = this.buildChecklist(placeholders);
+
+    return {
+      missionId: row.id,
+      missionPlanId: row.mission_plan_id,
+      status: row.status,
+      platformId: row.platform_id,
+      pilotId: row.pilot_id,
+      placeholders,
+      checklist,
+      readinessCheckAvailable: checklist.every(
+        (item) => item.status === "present",
+      ),
+    };
+  }
+
+  private buildChecklist(placeholders: {
+    platformAssigned: boolean;
+    pilotAssigned: boolean;
+    riskInputPresent: boolean;
+    airspaceInputPresent: boolean;
+  }): MissionPlanningChecklistItem[] {
+    return [
+      {
+        key: "platform",
+        status: placeholders.platformAssigned ? "present" : "missing",
+        message: placeholders.platformAssigned
+          ? "Platform assignment placeholder is present"
+          : "Assign a platform before readiness can pass",
+      },
+      {
+        key: "pilot",
+        status: placeholders.pilotAssigned ? "present" : "missing",
+        message: placeholders.pilotAssigned
+          ? "Pilot assignment placeholder is present"
+          : "Assign a pilot before readiness can pass",
+      },
+      {
+        key: "risk",
+        status: placeholders.riskInputPresent ? "present" : "missing",
+        message: placeholders.riskInputPresent
+          ? "Mission risk input placeholder is present"
+          : "Add mission risk inputs before readiness can pass",
+      },
+      {
+        key: "airspace",
+        status: placeholders.airspaceInputPresent ? "present" : "missing",
+        message: placeholders.airspaceInputPresent
+          ? "Airspace compliance input placeholder is present"
+          : "Add airspace compliance inputs before readiness can pass",
+      },
+    ];
+  }
+}

--- a/src/mission-planning/mission-planning.types.ts
+++ b/src/mission-planning/mission-planning.types.ts
@@ -1,0 +1,32 @@
+import type { CreateAirspaceComplianceInput } from "../airspace-compliance/airspace-compliance.types";
+import type { CreateMissionRiskInput } from "../mission-risk/mission-risk.types";
+
+export interface CreateMissionPlanningDraftInput {
+  missionPlanId?: string | null;
+  platformId?: string | null;
+  pilotId?: string | null;
+  riskInput?: CreateMissionRiskInput | null;
+  airspaceInput?: CreateAirspaceComplianceInput | null;
+}
+
+export interface MissionPlanningChecklistItem {
+  key: "platform" | "pilot" | "risk" | "airspace";
+  status: "present" | "missing";
+  message: string;
+}
+
+export interface MissionPlanningDraft {
+  missionId: string;
+  missionPlanId: string | null;
+  status: "draft";
+  platformId: string | null;
+  pilotId: string | null;
+  placeholders: {
+    platformAssigned: boolean;
+    pilotAssigned: boolean;
+    riskInputPresent: boolean;
+    airspaceInputPresent: boolean;
+  };
+  checklist: MissionPlanningChecklistItem[];
+  readinessCheckAvailable: boolean;
+}

--- a/src/mission-planning/mission-planning.validators.ts
+++ b/src/mission-planning/mission-planning.validators.ts
@@ -1,0 +1,53 @@
+import { MissionPlanningValidationError } from "./mission-planning.errors";
+import type { CreateMissionPlanningDraftInput } from "./mission-planning.types";
+
+function optionalTrimmed(value: unknown, fieldName: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    throw new MissionPlanningValidationError(`${fieldName} must be a string`);
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function optionalObject<T>(value: unknown, fieldName: string): T | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new MissionPlanningValidationError(`${fieldName} must be an object`);
+  }
+
+  return value as T;
+}
+
+export function validateCreateMissionPlanningDraftInput(
+  input: CreateMissionPlanningDraftInput | undefined,
+) {
+  if (input === undefined || input === null) {
+    return {
+      missionPlanId: null,
+      platformId: null,
+      pilotId: null,
+      riskInput: null,
+      airspaceInput: null,
+    };
+  }
+
+  if (typeof input !== "object" || Array.isArray(input)) {
+    throw new MissionPlanningValidationError("Request body must be an object");
+  }
+
+  return {
+    missionPlanId: optionalTrimmed(input.missionPlanId, "missionPlanId"),
+    platformId: optionalTrimmed(input.platformId, "platformId"),
+    pilotId: optionalTrimmed(input.pilotId, "pilotId"),
+    riskInput: optionalObject(input.riskInput, "riskInput"),
+    airspaceInput: optionalObject(input.airspaceInput, "airspaceInput"),
+  };
+}

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -1,0 +1,276 @@
+import { randomUUID } from "crypto";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import app, { pool } from "../app";
+import { runMigrations } from "../migrations/runMigrations";
+
+const clearTables = async () => {
+  await pool.query("delete from mission_decision_evidence_links");
+  await pool.query("delete from audit_evidence_snapshots");
+  await pool.query("delete from airspace_compliance_inputs");
+  await pool.query("delete from mission_risk_inputs");
+  await pool.query("delete from mission_events");
+  await pool.query("delete from missions");
+  await pool.query("delete from pilot_readiness_evidence");
+  await pool.query("delete from pilots");
+  await pool.query("delete from maintenance_records");
+  await pool.query("delete from maintenance_schedules");
+  await pool.query("delete from platforms");
+};
+
+const createPlatform = async () => {
+  const response = await request(app).post("/platforms").send({
+    name: "Planning UAV",
+    status: "active",
+  });
+
+  expect(response.status).toBe(201);
+  return response.body.platform as { id: string };
+};
+
+const createPilot = async () => {
+  const response = await request(app).post("/pilots").send({
+    displayName: "Planning Pilot",
+    status: "active",
+  });
+
+  expect(response.status).toBe(201);
+  return response.body.pilot as { id: string };
+};
+
+const lowRiskInput = {
+  operatingCategory: "open",
+  missionComplexity: "low",
+  populationExposure: "low",
+  airspaceComplexity: "low",
+  weatherRisk: "low",
+  payloadRisk: "low",
+};
+
+const clearAirspaceInput = {
+  airspaceClass: "g",
+  maxAltitudeFt: 300,
+  restrictionStatus: "clear",
+  permissionStatus: "not_required",
+};
+
+const countRows = async (missionId?: string) => {
+  const result = await pool.query(
+    `
+    select
+      (select count(*)::int from missions where ($1::uuid is null or id = $1)) as mission_count,
+      (select count(*)::int from mission_events where ($1::uuid is null or mission_id = $1)) as mission_event_count,
+      (select count(*)::int from mission_risk_inputs where ($1::uuid is null or mission_id = $1)) as risk_input_count,
+      (select count(*)::int from airspace_compliance_inputs where ($1::uuid is null or mission_id = $1)) as airspace_input_count,
+      (select count(*)::int from audit_evidence_snapshots where ($1::uuid is null or mission_id = $1)) as snapshot_count,
+      (select count(*)::int from mission_decision_evidence_links where ($1::uuid is null or mission_id = $1)) as decision_link_count
+    `,
+    [missionId ?? null],
+  );
+
+  return result.rows[0] as {
+    mission_count: number;
+    mission_event_count: number;
+    risk_input_count: number;
+    airspace_input_count: number;
+    snapshot_count: number;
+    decision_link_count: number;
+  };
+};
+
+describe("mission planning drafts", () => {
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  beforeEach(async () => {
+    await clearTables();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("creates a draft mission with missing planning placeholders", async () => {
+    const before = await countRows();
+
+    const response = await request(app).post("/mission-plans/drafts").send({});
+
+    expect(response.status).toBe(201);
+    expect(response.body.draft).toMatchObject({
+      missionPlanId: null,
+      status: "draft",
+      platformId: null,
+      pilotId: null,
+      placeholders: {
+        platformAssigned: false,
+        pilotAssigned: false,
+        riskInputPresent: false,
+        airspaceInputPresent: false,
+      },
+      readinessCheckAvailable: false,
+      checklist: [
+        { key: "platform", status: "missing" },
+        { key: "pilot", status: "missing" },
+        { key: "risk", status: "missing" },
+        { key: "airspace", status: "missing" },
+      ],
+    });
+    expect(response.body.draft.missionId).toEqual(expect.any(String));
+
+    const after = await countRows(response.body.draft.missionId);
+    expect(after).toEqual({
+      mission_count: 1,
+      mission_event_count: 0,
+      risk_input_count: 0,
+      airspace_input_count: 0,
+      snapshot_count: 0,
+      decision_link_count: 0,
+    });
+    expect((await countRows()).mission_count).toBe(before.mission_count + 1);
+  });
+
+  it("creates a draft mission with platform and pilot assignments", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+
+    const response = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-alpha",
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.draft).toMatchObject({
+      missionPlanId: "plan-alpha",
+      status: "draft",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      placeholders: {
+        platformAssigned: true,
+        pilotAssigned: true,
+        riskInputPresent: false,
+        airspaceInputPresent: false,
+      },
+      readinessCheckAvailable: false,
+      checklist: [
+        { key: "platform", status: "present" },
+        { key: "pilot", status: "present" },
+        { key: "risk", status: "missing" },
+        { key: "airspace", status: "missing" },
+      ],
+    });
+  });
+
+  it("creates a draft mission with risk and airspace placeholders", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+
+    const response = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-complete",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.draft).toMatchObject({
+      missionPlanId: "plan-complete",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      placeholders: {
+        platformAssigned: true,
+        pilotAssigned: true,
+        riskInputPresent: true,
+        airspaceInputPresent: true,
+      },
+      readinessCheckAvailable: true,
+      checklist: [
+        { key: "platform", status: "present" },
+        { key: "pilot", status: "present" },
+        { key: "risk", status: "present" },
+        { key: "airspace", status: "present" },
+      ],
+    });
+
+    expect(await countRows(response.body.draft.missionId)).toEqual({
+      mission_count: 1,
+      mission_event_count: 0,
+      risk_input_count: 1,
+      airspace_input_count: 1,
+      snapshot_count: 0,
+      decision_link_count: 0,
+    });
+  });
+
+  it("returns an existing planning draft by mission id", async () => {
+    const createResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-lookup",
+      riskInput: lowRiskInput,
+    });
+
+    expect(createResponse.status).toBe(201);
+
+    const getResponse = await request(app).get(
+      `/mission-plans/drafts/${createResponse.body.draft.missionId}`,
+    );
+
+    expect(getResponse.status).toBe(200);
+    expect(getResponse.body.draft).toEqual(createResponse.body.draft);
+  });
+
+  it("rejects unknown platform and pilot placeholders", async () => {
+    const platformResponse = await request(app).post("/mission-plans/drafts").send({
+      platformId: randomUUID(),
+    });
+    const pilotResponse = await request(app).post("/mission-plans/drafts").send({
+      pilotId: randomUUID(),
+    });
+
+    expect(platformResponse.status).toBe(404);
+    expect(platformResponse.body).toMatchObject({
+      error: {
+        type: "mission_planning_reference_not_found",
+      },
+    });
+    expect(pilotResponse.status).toBe(404);
+    expect(pilotResponse.body).toMatchObject({
+      error: {
+        type: "mission_planning_reference_not_found",
+      },
+    });
+    expect(await countRows()).toMatchObject({
+      mission_count: 0,
+      snapshot_count: 0,
+      decision_link_count: 0,
+    });
+  });
+
+  it("returns 404 for missing or non-draft missions", async () => {
+    const missingResponse = await request(app).get(
+      `/mission-plans/drafts/${randomUUID()}`,
+    );
+    const missionId = randomUUID();
+
+    await pool.query(
+      `
+      insert into missions (
+        id,
+        status,
+        mission_plan_id,
+        last_event_sequence_no
+      )
+      values ($1, 'submitted', 'submitted-plan', 0)
+      `,
+      [missionId],
+    );
+
+    const submittedResponse = await request(app).get(
+      `/mission-plans/drafts/${missionId}`,
+    );
+
+    expect(missingResponse.status).toBe(404);
+    expect(submittedResponse.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
Implements issue #25 by adding mission planning draft endpoints that create draft missions with optional platform, pilot, risk, and airspace placeholders.

## What changed
- Added `POST /mission-plans/drafts` to create a draft mission planning record.
- Added `GET /mission-plans/drafts/:missionId` to retrieve draft planning status.
- Added a mission planning checklist showing platform, pilot, risk, and airspace placeholder completeness.
- Allows optional platform/pilot assignment and optional seeded risk/airspace inputs.
- Keeps draft creation free of lifecycle events, audit snapshots, approval evidence, and dispatch evidence.
- Updated the next build step toward progressive draft update endpoints.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/mission-planning.test.ts src/tests/mission-lifecycle.test.ts src/tests/audit-evidence.test.ts` passed: 41 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 167 tests.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #25.
