### PR TITLE
Add mission planning draft update endpoints #27

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission planning draft update endpoints so operators can progressively fill platform, pilot, risk, and airspace placeholders.",
+ "nextBuildStep": "Add mission planning review endpoint so a completed draft can produce a gate-ready planning summary before approval.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/mission-planning/mission-planning.controller.ts
+++ b/src/mission-planning/mission-planning.controller.ts
@@ -35,4 +35,20 @@ export class MissionPlanningController {
       next(error);
     }
   };
+
+  updateDraft = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const draft = await this.missionPlanningService.updateDraft(
+        req.params.missionId,
+        req.body,
+      );
+      res.status(200).json({ draft });
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/mission-planning/mission-planning.repository.ts
+++ b/src/mission-planning/mission-planning.repository.ts
@@ -65,6 +65,50 @@ export class MissionPlanningRepository {
     return result.rows[0].id;
   }
 
+  async updateDraftMissionPlaceholders(
+    tx: PoolClient,
+    missionId: string,
+    input: {
+      missionPlanId?: string | null;
+      platformId?: string | null;
+      pilotId?: string | null;
+    },
+  ): Promise<boolean> {
+    const setClauses: string[] = [];
+    const values: Array<string | null> = [missionId];
+
+    if (Object.prototype.hasOwnProperty.call(input, "missionPlanId")) {
+      values.push(input.missionPlanId ?? null);
+      setClauses.push(`mission_plan_id = $${values.length}`);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(input, "platformId")) {
+      values.push(input.platformId ?? null);
+      setClauses.push(`platform_id = $${values.length}`);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(input, "pilotId")) {
+      values.push(input.pilotId ?? null);
+      setClauses.push(`pilot_id = $${values.length}`);
+    }
+
+    if (setClauses.length === 0) {
+      return true;
+    }
+
+    const result = await tx.query(
+      `
+      update missions
+      set ${setClauses.join(", ")}
+      where id = $1
+        and status = 'draft'
+      `,
+      values,
+    );
+
+    return result.rowCount === 1;
+  }
+
   async getDraftMission(
     tx: PoolClient,
     missionId: string,

--- a/src/mission-planning/mission-planning.routes.ts
+++ b/src/mission-planning/mission-planning.routes.ts
@@ -7,6 +7,7 @@ export function createMissionPlanningRouter(
   const router = Router();
 
   router.post("/drafts", controller.createDraft);
+  router.patch("/drafts/:missionId", controller.updateDraft);
   router.get("/drafts/:missionId", controller.getDraft);
 
   return router;

--- a/src/mission-planning/mission-planning.service.ts
+++ b/src/mission-planning/mission-planning.service.ts
@@ -12,8 +12,12 @@ import type {
   CreateMissionPlanningDraftInput,
   MissionPlanningDraft,
   MissionPlanningChecklistItem,
+  UpdateMissionPlanningDraftInput,
 } from "./mission-planning.types";
-import { validateCreateMissionPlanningDraftInput } from "./mission-planning.validators";
+import {
+  validateCreateMissionPlanningDraftInput,
+  validateUpdateMissionPlanningDraftInput,
+} from "./mission-planning.validators";
 
 export class MissionPlanningService {
   constructor(
@@ -102,6 +106,106 @@ export class MissionPlanningService {
 
     try {
       return await this.getDraftForClient(client, missionId);
+    } finally {
+      client.release();
+    }
+  }
+
+  async updateDraft(
+    missionId: string,
+    input: UpdateMissionPlanningDraftInput | undefined,
+  ): Promise<MissionPlanningDraft> {
+    const validated = validateUpdateMissionPlanningDraftInput(input);
+    const riskInput = validated.riskInput
+      ? validateCreateMissionRiskInput(validated.riskInput)
+      : null;
+    const airspaceInput = validated.airspaceInput
+      ? validateCreateAirspaceComplianceInput(validated.airspaceInput)
+      : null;
+    const client = await this.pool.connect();
+
+    try {
+      await client.query("BEGIN");
+      await this.getDraftForClient(client, missionId);
+
+      if (
+        validated.platformId.provided &&
+        validated.platformId.value &&
+        !(await this.missionPlanningRepository.platformExists(
+          client,
+          validated.platformId.value,
+        ))
+      ) {
+        throw new MissionPlanningReferenceNotFoundError(
+          `Platform not found: ${validated.platformId.value}`,
+        );
+      }
+
+      if (
+        validated.pilotId.provided &&
+        validated.pilotId.value &&
+        !(await this.missionPlanningRepository.pilotExists(
+          client,
+          validated.pilotId.value,
+        ))
+      ) {
+        throw new MissionPlanningReferenceNotFoundError(
+          `Pilot not found: ${validated.pilotId.value}`,
+        );
+      }
+
+      const placeholderUpdates: {
+        missionPlanId?: string | null;
+        platformId?: string | null;
+        pilotId?: string | null;
+      } = {};
+
+      if (validated.missionPlanId.provided) {
+        placeholderUpdates.missionPlanId = validated.missionPlanId.value;
+      }
+
+      if (validated.platformId.provided) {
+        placeholderUpdates.platformId = validated.platformId.value;
+      }
+
+      if (validated.pilotId.provided) {
+        placeholderUpdates.pilotId = validated.pilotId.value;
+      }
+
+      const updated =
+        await this.missionPlanningRepository.updateDraftMissionPlaceholders(
+          client,
+          missionId,
+          placeholderUpdates,
+        );
+
+      if (!updated) {
+        throw new MissionPlanningDraftNotFoundError(missionId);
+      }
+
+      if (riskInput) {
+        await this.missionRiskRepository.insertMissionRiskInput(client, {
+          missionId,
+          ...riskInput,
+        });
+      }
+
+      if (airspaceInput) {
+        await this.airspaceComplianceRepository.insertAirspaceComplianceInput(
+          client,
+          {
+            missionId,
+            ...airspaceInput,
+          },
+        );
+      }
+
+      const draft = await this.getDraftForClient(client, missionId);
+      await client.query("COMMIT");
+      return draft;
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
     } finally {
       client.release();
     }

--- a/src/mission-planning/mission-planning.types.ts
+++ b/src/mission-planning/mission-planning.types.ts
@@ -9,6 +9,14 @@ export interface CreateMissionPlanningDraftInput {
   airspaceInput?: CreateAirspaceComplianceInput | null;
 }
 
+export interface UpdateMissionPlanningDraftInput {
+  missionPlanId?: string | null;
+  platformId?: string | null;
+  pilotId?: string | null;
+  riskInput?: CreateMissionRiskInput;
+  airspaceInput?: CreateAirspaceComplianceInput;
+}
+
 export interface MissionPlanningChecklistItem {
   key: "platform" | "pilot" | "risk" | "airspace";
   status: "present" | "missing";

--- a/src/mission-planning/mission-planning.validators.ts
+++ b/src/mission-planning/mission-planning.validators.ts
@@ -1,5 +1,8 @@
 import { MissionPlanningValidationError } from "./mission-planning.errors";
-import type { CreateMissionPlanningDraftInput } from "./mission-planning.types";
+import type {
+  CreateMissionPlanningDraftInput,
+  UpdateMissionPlanningDraftInput,
+} from "./mission-planning.types";
 
 function optionalTrimmed(value: unknown, fieldName: string): string | null {
   if (value === undefined || value === null) {
@@ -20,6 +23,18 @@ function optionalObject<T>(value: unknown, fieldName: string): T | null {
   }
 
   if (typeof value !== "object" || Array.isArray(value)) {
+    throw new MissionPlanningValidationError(`${fieldName} must be an object`);
+  }
+
+  return value as T;
+}
+
+function requiredPatchObject<T>(value: unknown, fieldName: string): T | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
     throw new MissionPlanningValidationError(`${fieldName} must be an object`);
   }
 
@@ -49,5 +64,34 @@ export function validateCreateMissionPlanningDraftInput(
     pilotId: optionalTrimmed(input.pilotId, "pilotId"),
     riskInput: optionalObject(input.riskInput, "riskInput"),
     airspaceInput: optionalObject(input.airspaceInput, "airspaceInput"),
+  };
+}
+
+export function validateUpdateMissionPlanningDraftInput(
+  input: UpdateMissionPlanningDraftInput | undefined,
+) {
+  if (input === undefined || input === null) {
+    throw new MissionPlanningValidationError("Request body must be an object");
+  }
+
+  if (typeof input !== "object" || Array.isArray(input)) {
+    throw new MissionPlanningValidationError("Request body must be an object");
+  }
+
+  return {
+    missionPlanId: {
+      provided: Object.prototype.hasOwnProperty.call(input, "missionPlanId"),
+      value: optionalTrimmed(input.missionPlanId, "missionPlanId"),
+    },
+    platformId: {
+      provided: Object.prototype.hasOwnProperty.call(input, "platformId"),
+      value: optionalTrimmed(input.platformId, "platformId"),
+    },
+    pilotId: {
+      provided: Object.prototype.hasOwnProperty.call(input, "pilotId"),
+      value: optionalTrimmed(input.pilotId, "pilotId"),
+    },
+    riskInput: requiredPatchObject(input.riskInput, "riskInput"),
+    airspaceInput: requiredPatchObject(input.airspaceInput, "airspaceInput"),
   };
 }

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -54,6 +54,26 @@ const clearAirspaceInput = {
   permissionStatus: "not_required",
 };
 
+const elevatedRiskInput = {
+  operatingCategory: "specific",
+  missionComplexity: "medium",
+  populationExposure: "medium",
+  airspaceComplexity: "medium",
+  weatherRisk: "medium",
+  payloadRisk: "medium",
+  mitigationSummary: "Supervisor review required before approval",
+};
+
+const controlledAirspaceInput = {
+  airspaceClass: "d",
+  maxAltitudeFt: 350,
+  restrictionStatus: "permission_required",
+  permissionStatus: "pending",
+  controlledAirspace: true,
+  nearbyAerodrome: true,
+  evidenceRef: "airspace-case-27",
+};
+
 const countRows = async (missionId?: string) => {
   const result = await pool.query(
     `
@@ -220,6 +240,206 @@ describe("mission planning drafts", () => {
     expect(getResponse.body.draft).toEqual(createResponse.body.draft);
   });
 
+  it("updates draft placeholders without replacing omitted values", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    const createResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-progressive",
+      platformId: platform.id,
+    });
+
+    expect(createResponse.status).toBe(201);
+
+    const updateResponse = await request(app)
+      .patch(`/mission-plans/drafts/${createResponse.body.draft.missionId}`)
+      .send({
+        pilotId: pilot.id,
+        riskInput: lowRiskInput,
+      });
+
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body.draft).toMatchObject({
+      missionPlanId: "plan-progressive",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      placeholders: {
+        platformAssigned: true,
+        pilotAssigned: true,
+        riskInputPresent: true,
+        airspaceInputPresent: false,
+      },
+      readinessCheckAvailable: false,
+      checklist: [
+        { key: "platform", status: "present" },
+        { key: "pilot", status: "present" },
+        { key: "risk", status: "present" },
+        { key: "airspace", status: "missing" },
+      ],
+    });
+    expect(await countRows(createResponse.body.draft.missionId)).toEqual({
+      mission_count: 1,
+      mission_event_count: 0,
+      risk_input_count: 1,
+      airspace_input_count: 0,
+      snapshot_count: 0,
+      decision_link_count: 0,
+    });
+  });
+
+  it("replaces draft risk and airspace placeholders with latest input rows", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    const createResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-replace",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(createResponse.status).toBe(201);
+
+    const updateResponse = await request(app)
+      .patch(`/mission-plans/drafts/${createResponse.body.draft.missionId}`)
+      .send({
+        riskInput: elevatedRiskInput,
+        airspaceInput: controlledAirspaceInput,
+      });
+
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body.draft).toMatchObject({
+      platformId: platform.id,
+      pilotId: pilot.id,
+      placeholders: {
+        platformAssigned: true,
+        pilotAssigned: true,
+        riskInputPresent: true,
+        airspaceInputPresent: true,
+      },
+      readinessCheckAvailable: true,
+    });
+    expect(await countRows(createResponse.body.draft.missionId)).toEqual({
+      mission_count: 1,
+      mission_event_count: 0,
+      risk_input_count: 2,
+      airspace_input_count: 2,
+      snapshot_count: 0,
+      decision_link_count: 0,
+    });
+
+    const latestRisk = await pool.query(
+      `
+      select operating_category, mission_complexity
+      from mission_risk_inputs
+      where mission_id = $1
+      order by created_at desc, id desc
+      limit 1
+      `,
+      [createResponse.body.draft.missionId],
+    );
+    const latestAirspace = await pool.query(
+      `
+      select airspace_class, permission_status
+      from airspace_compliance_inputs
+      where mission_id = $1
+      order by created_at desc, id desc
+      limit 1
+      `,
+      [createResponse.body.draft.missionId],
+    );
+
+    expect(latestRisk.rows[0]).toMatchObject({
+      operating_category: "specific",
+      mission_complexity: "medium",
+    });
+    expect(latestAirspace.rows[0]).toMatchObject({
+      airspace_class: "d",
+      permission_status: "pending",
+    });
+  });
+
+  it("clears explicitly nulled platform and pilot placeholders", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    const createResponse = await request(app).post("/mission-plans/drafts").send({
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(createResponse.status).toBe(201);
+
+    const updateResponse = await request(app)
+      .patch(`/mission-plans/drafts/${createResponse.body.draft.missionId}`)
+      .send({
+        platformId: null,
+        pilotId: null,
+      });
+
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body.draft).toMatchObject({
+      platformId: null,
+      pilotId: null,
+      placeholders: {
+        platformAssigned: false,
+        pilotAssigned: false,
+        riskInputPresent: true,
+        airspaceInputPresent: true,
+      },
+      readinessCheckAvailable: false,
+      checklist: [
+        { key: "platform", status: "missing" },
+        { key: "pilot", status: "missing" },
+        { key: "risk", status: "present" },
+        { key: "airspace", status: "present" },
+      ],
+    });
+  });
+
+  it("rejects update requests for unknown references or invalid placeholder bodies", async () => {
+    const createResponse = await request(app).post("/mission-plans/drafts").send({});
+
+    expect(createResponse.status).toBe(201);
+
+    const unknownPlatformResponse = await request(app)
+      .patch(`/mission-plans/drafts/${createResponse.body.draft.missionId}`)
+      .send({
+        platformId: randomUUID(),
+      });
+    const unknownPilotResponse = await request(app)
+      .patch(`/mission-plans/drafts/${createResponse.body.draft.missionId}`)
+      .send({
+        pilotId: randomUUID(),
+      });
+    const invalidRiskResponse = await request(app)
+      .patch(`/mission-plans/drafts/${createResponse.body.draft.missionId}`)
+      .send({
+        riskInput: null,
+      });
+
+    expect(unknownPlatformResponse.status).toBe(404);
+    expect(unknownPlatformResponse.body).toMatchObject({
+      error: { type: "mission_planning_reference_not_found" },
+    });
+    expect(unknownPilotResponse.status).toBe(404);
+    expect(unknownPilotResponse.body).toMatchObject({
+      error: { type: "mission_planning_reference_not_found" },
+    });
+    expect(invalidRiskResponse.status).toBe(400);
+    expect(invalidRiskResponse.body).toMatchObject({
+      error: { type: "mission_planning_validation_failed" },
+    });
+    expect(await countRows(createResponse.body.draft.missionId)).toEqual({
+      mission_count: 1,
+      mission_event_count: 0,
+      risk_input_count: 0,
+      airspace_input_count: 0,
+      snapshot_count: 0,
+      decision_link_count: 0,
+    });
+  });
+
   it("rejects unknown platform and pilot placeholders", async () => {
     const platformResponse = await request(app).post("/mission-plans/drafts").send({
       platformId: randomUUID(),
@@ -272,5 +492,36 @@ describe("mission planning drafts", () => {
 
     expect(missingResponse.status).toBe(404);
     expect(submittedResponse.status).toBe(404);
+  });
+
+  it("returns 404 when updating missing or non-draft missions", async () => {
+    const missingResponse = await request(app)
+      .patch(`/mission-plans/drafts/${randomUUID()}`)
+      .send({
+        missionPlanId: "missing-plan",
+      });
+    const missionId = randomUUID();
+
+    await pool.query(
+      `
+      insert into missions (
+        id,
+        status,
+        mission_plan_id,
+        last_event_sequence_no
+      )
+      values ($1, 'approved', 'approved-plan', 0)
+      `,
+      [missionId],
+    );
+
+    const approvedResponse = await request(app)
+      .patch(`/mission-plans/drafts/${missionId}`)
+      .send({
+        missionPlanId: "updated-approved-plan",
+      });
+
+    expect(missingResponse.status).toBe(404);
+    expect(approvedResponse.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary
Implements issue #27 by adding progressive update support for mission planning drafts.

## What changed
- Added `PATCH /mission-plans/drafts/:missionId`.
- Allows draft mission plan, platform, and pilot placeholders to be updated while preserving omitted values.
- Allows explicit `null` platform and pilot values to clear draft assignments.
- Adds fresh mission risk and airspace compliance input rows when those placeholders are supplied, preserving previous rows as history while making the latest input available to downstream readiness logic.
- Rejects updates for missing or non-draft missions.
- Rejects unknown platform and pilot references.
- Keeps draft updates free of lifecycle events, audit snapshots, approval evidence, and dispatch evidence.
- Updates the next build step toward a mission planning review endpoint.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/mission-planning.test.ts` passed: 11 tests.
- `./node_modules/.bin/vitest.cmd run src/tests/mission-planning.test.ts src/tests/mission-lifecycle.test.ts src/tests/audit-evidence.test.ts` passed: 46 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 172 tests.
- `git diff --check` passed.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #27.
