### PR TITLE
Add mission planning review endpoint #29

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission planning review endpoint so a completed draft can produce a gate-ready planning summary before approval.",
+ "nextBuildStep": "Add mission planning approval handoff so a gate-ready review can be linked to approval evidence without mutating the draft review itself.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/mission-planning/mission-planning.controller.ts
+++ b/src/mission-planning/mission-planning.controller.ts
@@ -36,6 +36,21 @@ export class MissionPlanningController {
     }
   };
 
+  reviewDraft = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const review = await this.missionPlanningService.reviewDraft(
+        req.params.missionId,
+      );
+      res.status(200).json({ review });
+    } catch (error) {
+      next(error);
+    }
+  };
+
   updateDraft = async (
     req: Request<MissionIdParams>,
     res: Response,

--- a/src/mission-planning/mission-planning.routes.ts
+++ b/src/mission-planning/mission-planning.routes.ts
@@ -8,6 +8,7 @@ export function createMissionPlanningRouter(
 
   router.post("/drafts", controller.createDraft);
   router.patch("/drafts/:missionId", controller.updateDraft);
+  router.get("/drafts/:missionId/review", controller.reviewDraft);
   router.get("/drafts/:missionId", controller.getDraft);
 
   return router;

--- a/src/mission-planning/mission-planning.service.ts
+++ b/src/mission-planning/mission-planning.service.ts
@@ -12,6 +12,7 @@ import type {
   CreateMissionPlanningDraftInput,
   MissionPlanningDraft,
   MissionPlanningChecklistItem,
+  MissionPlanningReview,
   UpdateMissionPlanningDraftInput,
 } from "./mission-planning.types";
 import {
@@ -209,6 +210,24 @@ export class MissionPlanningService {
     } finally {
       client.release();
     }
+  }
+
+  async reviewDraft(missionId: string): Promise<MissionPlanningReview> {
+    const draft = await this.getDraft(missionId);
+    const blockingReasons = draft.checklist
+      .filter((item) => item.status === "missing")
+      .map((item) => item.message);
+
+    return {
+      missionId: draft.missionId,
+      missionPlanId: draft.missionPlanId,
+      status: draft.status,
+      platformId: draft.platformId,
+      pilotId: draft.pilotId,
+      readyForApproval: blockingReasons.length === 0,
+      blockingReasons,
+      checklist: draft.checklist,
+    };
   }
 
   private async getDraftForClient(

--- a/src/mission-planning/mission-planning.types.ts
+++ b/src/mission-planning/mission-planning.types.ts
@@ -38,3 +38,14 @@ export interface MissionPlanningDraft {
   checklist: MissionPlanningChecklistItem[];
   readinessCheckAvailable: boolean;
 }
+
+export interface MissionPlanningReview {
+  missionId: string;
+  missionPlanId: string | null;
+  status: "draft";
+  platformId: string | null;
+  pilotId: string | null;
+  readyForApproval: boolean;
+  blockingReasons: string[];
+  checklist: MissionPlanningChecklistItem[];
+}

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -240,6 +240,79 @@ describe("mission planning drafts", () => {
     expect(getResponse.body.draft).toEqual(createResponse.body.draft);
   });
 
+  it("reviews a complete draft as gate-ready without side effects", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    const createResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-review-ready",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(createResponse.status).toBe(201);
+
+    const beforeReview = await countRows(createResponse.body.draft.missionId);
+    const reviewResponse = await request(app).get(
+      `/mission-plans/drafts/${createResponse.body.draft.missionId}/review`,
+    );
+    const afterReview = await countRows(createResponse.body.draft.missionId);
+
+    expect(reviewResponse.status).toBe(200);
+    expect(reviewResponse.body.review).toMatchObject({
+      missionId: createResponse.body.draft.missionId,
+      missionPlanId: "plan-review-ready",
+      status: "draft",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      readyForApproval: true,
+      blockingReasons: [],
+      checklist: [
+        { key: "platform", status: "present" },
+        { key: "pilot", status: "present" },
+        { key: "risk", status: "present" },
+        { key: "airspace", status: "present" },
+      ],
+    });
+    expect(afterReview).toEqual(beforeReview);
+  });
+
+  it("reviews an incomplete draft with blocking reasons", async () => {
+    const platform = await createPlatform();
+    const createResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-review-blocked",
+      platformId: platform.id,
+    });
+
+    expect(createResponse.status).toBe(201);
+
+    const reviewResponse = await request(app).get(
+      `/mission-plans/drafts/${createResponse.body.draft.missionId}/review`,
+    );
+
+    expect(reviewResponse.status).toBe(200);
+    expect(reviewResponse.body.review).toMatchObject({
+      missionId: createResponse.body.draft.missionId,
+      missionPlanId: "plan-review-blocked",
+      status: "draft",
+      platformId: platform.id,
+      pilotId: null,
+      readyForApproval: false,
+      blockingReasons: [
+        "Assign a pilot before readiness can pass",
+        "Add mission risk inputs before readiness can pass",
+        "Add airspace compliance inputs before readiness can pass",
+      ],
+      checklist: [
+        { key: "platform", status: "present" },
+        { key: "pilot", status: "missing" },
+        { key: "risk", status: "missing" },
+        { key: "airspace", status: "missing" },
+      ],
+    });
+  });
+
   it("updates draft placeholders without replacing omitted values", async () => {
     const platform = await createPlatform();
     const pilot = await createPilot();
@@ -488,6 +561,33 @@ describe("mission planning drafts", () => {
 
     const submittedResponse = await request(app).get(
       `/mission-plans/drafts/${missionId}`,
+    );
+
+    expect(missingResponse.status).toBe(404);
+    expect(submittedResponse.status).toBe(404);
+  });
+
+  it("returns 404 when reviewing missing or non-draft missions", async () => {
+    const missingResponse = await request(app).get(
+      `/mission-plans/drafts/${randomUUID()}/review`,
+    );
+    const missionId = randomUUID();
+
+    await pool.query(
+      `
+      insert into missions (
+        id,
+        status,
+        mission_plan_id,
+        last_event_sequence_no
+      )
+      values ($1, 'submitted', 'submitted-plan', 0)
+      `,
+      [missionId],
+    );
+
+    const submittedResponse = await request(app).get(
+      `/mission-plans/drafts/${missionId}/review`,
     );
 
     expect(missingResponse.status).toBe(404);


### PR DESCRIPTION
## Summary
Implements issue #29 by adding a read-only mission planning review endpoint for gate-ready draft summaries.

## What changed
- Added `GET /mission-plans/drafts/:missionId/review`.
- Returns mission draft identity, mission plan reference, platform/pilot assignments, checklist, blocking reasons, and `readyForApproval`.
- Marks complete drafts as gate-ready when platform, pilot, risk, and airspace placeholders are present.
- Marks incomplete drafts as not ready with blocking reasons from the existing checklist.
- Rejects missing or non-draft missions with 404.
- Keeps review operations read-only with no lifecycle events, audit snapshots, approval evidence, dispatch evidence, or mission state mutation.
- Updated the next build step toward approval handoff.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/mission-planning.test.ts` passed: 14 tests.
- `./node_modules/.bin/vitest.cmd run src/tests/mission-planning.test.ts src/tests/mission-lifecycle.test.ts src/tests/audit-evidence.test.ts` passed: 49 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 175 tests.
- `git diff --check` passed.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #29.
