### PR TITLE
Add mission planning approval handoff #31

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission planning approval handoff so a gate-ready review can be linked to approval evidence without mutating the draft review itself.",
+ "nextBuildStep": "Add mission approval endpoint integration so approval can require the linked gate-ready planning evidence before changing mission state.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -154,6 +154,7 @@ const missionPlanningService = new MissionPlanningService(
   missionPlanningRepository,
   missionRiskRepository,
   airspaceComplianceRepository,
+  auditEvidenceService,
 );
 const missionPlanningController = new MissionPlanningController(
   missionPlanningService,
@@ -194,12 +195,14 @@ app.use((error: unknown, _req: Request, res: Response, _next: NextFunction) => {
       statusCode: number;
       code?: string;
       type?: string;
+      blockingReasons?: string[];
     };
 
     return res.status(appError.statusCode).json({
       error: {
         message: appError.message,
         type: appError.type ?? appError.code?.toLowerCase() ?? "application_error",
+        blockingReasons: appError.blockingReasons,
       },
     });
   }

--- a/src/mission-planning/mission-planning.controller.ts
+++ b/src/mission-planning/mission-planning.controller.ts
@@ -51,6 +51,23 @@ export class MissionPlanningController {
     }
   };
 
+  createApprovalHandoff = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const handoff =
+        await this.missionPlanningService.createApprovalHandoff(
+          req.params.missionId,
+          req.body,
+        );
+      res.status(201).json({ handoff });
+    } catch (error) {
+      next(error);
+    }
+  };
+
   updateDraft = async (
     req: Request<MissionIdParams>,
     res: Response,

--- a/src/mission-planning/mission-planning.errors.ts
+++ b/src/mission-planning/mission-planning.errors.ts
@@ -20,3 +20,12 @@ export class MissionPlanningReferenceNotFoundError extends Error {
     super(message);
   }
 }
+
+export class MissionPlanningReviewNotReadyError extends Error {
+  readonly statusCode = 409;
+  readonly code = "MISSION_PLANNING_REVIEW_NOT_READY";
+
+  constructor(readonly blockingReasons: string[]) {
+    super("Mission planning review is not ready for approval handoff");
+  }
+}

--- a/src/mission-planning/mission-planning.routes.ts
+++ b/src/mission-planning/mission-planning.routes.ts
@@ -8,6 +8,10 @@ export function createMissionPlanningRouter(
 
   router.post("/drafts", controller.createDraft);
   router.patch("/drafts/:missionId", controller.updateDraft);
+  router.post(
+    "/drafts/:missionId/approval-handoff",
+    controller.createApprovalHandoff,
+  );
   router.get("/drafts/:missionId/review", controller.reviewDraft);
   router.get("/drafts/:missionId", controller.getDraft);
 

--- a/src/mission-planning/mission-planning.service.ts
+++ b/src/mission-planning/mission-planning.service.ts
@@ -1,21 +1,26 @@
 import type { Pool } from "pg";
 import { AirspaceComplianceRepository } from "../airspace-compliance/airspace-compliance.repository";
 import { validateCreateAirspaceComplianceInput } from "../airspace-compliance/airspace-compliance.validators";
+import { AuditEvidenceService } from "../audit-evidence/audit-evidence.service";
 import { MissionRiskRepository } from "../mission-risk/mission-risk.repository";
 import { validateCreateMissionRiskInput } from "../mission-risk/mission-risk.validators";
 import {
   MissionPlanningDraftNotFoundError,
   MissionPlanningReferenceNotFoundError,
+  MissionPlanningReviewNotReadyError,
 } from "./mission-planning.errors";
 import { MissionPlanningRepository } from "./mission-planning.repository";
 import type {
+  CreateMissionPlanningApprovalHandoffInput,
   CreateMissionPlanningDraftInput,
+  MissionPlanningApprovalHandoff,
   MissionPlanningDraft,
   MissionPlanningChecklistItem,
   MissionPlanningReview,
   UpdateMissionPlanningDraftInput,
 } from "./mission-planning.types";
 import {
+  validateCreateMissionPlanningApprovalHandoffInput,
   validateCreateMissionPlanningDraftInput,
   validateUpdateMissionPlanningDraftInput,
 } from "./mission-planning.validators";
@@ -26,6 +31,7 @@ export class MissionPlanningService {
     private readonly missionPlanningRepository: MissionPlanningRepository,
     private readonly missionRiskRepository: MissionRiskRepository,
     private readonly airspaceComplianceRepository: AirspaceComplianceRepository,
+    private readonly auditEvidenceService: AuditEvidenceService,
   ) {}
 
   async createDraft(
@@ -227,6 +233,38 @@ export class MissionPlanningService {
       readyForApproval: blockingReasons.length === 0,
       blockingReasons,
       checklist: draft.checklist,
+    };
+  }
+
+  async createApprovalHandoff(
+    missionId: string,
+    input: CreateMissionPlanningApprovalHandoffInput | undefined,
+  ): Promise<MissionPlanningApprovalHandoff> {
+    const validated = validateCreateMissionPlanningApprovalHandoffInput(input);
+    const review = await this.reviewDraft(missionId);
+
+    if (!review.readyForApproval) {
+      throw new MissionPlanningReviewNotReadyError(review.blockingReasons);
+    }
+
+    const snapshot =
+      await this.auditEvidenceService.createMissionReadinessSnapshot(missionId, {
+        createdBy: validated.createdBy,
+      });
+    const approvalEvidenceLink =
+      await this.auditEvidenceService.createMissionDecisionEvidenceLink(
+        missionId,
+        {
+          snapshotId: snapshot.id,
+          decisionType: "approval",
+          createdBy: validated.createdBy,
+        },
+      );
+
+    return {
+      review,
+      snapshot,
+      approvalEvidenceLink,
     };
   }
 

--- a/src/mission-planning/mission-planning.types.ts
+++ b/src/mission-planning/mission-planning.types.ts
@@ -1,4 +1,8 @@
 import type { CreateAirspaceComplianceInput } from "../airspace-compliance/airspace-compliance.types";
+import type {
+  AuditEvidenceSnapshot,
+  MissionDecisionEvidenceLink,
+} from "../audit-evidence/audit-evidence.types";
 import type { CreateMissionRiskInput } from "../mission-risk/mission-risk.types";
 
 export interface CreateMissionPlanningDraftInput {
@@ -48,4 +52,14 @@ export interface MissionPlanningReview {
   readyForApproval: boolean;
   blockingReasons: string[];
   checklist: MissionPlanningChecklistItem[];
+}
+
+export interface CreateMissionPlanningApprovalHandoffInput {
+  createdBy?: string | null;
+}
+
+export interface MissionPlanningApprovalHandoff {
+  review: MissionPlanningReview;
+  snapshot: AuditEvidenceSnapshot;
+  approvalEvidenceLink: MissionDecisionEvidenceLink;
 }

--- a/src/mission-planning/mission-planning.validators.ts
+++ b/src/mission-planning/mission-planning.validators.ts
@@ -1,5 +1,6 @@
 import { MissionPlanningValidationError } from "./mission-planning.errors";
 import type {
+  CreateMissionPlanningApprovalHandoffInput,
   CreateMissionPlanningDraftInput,
   UpdateMissionPlanningDraftInput,
 } from "./mission-planning.types";
@@ -93,5 +94,23 @@ export function validateUpdateMissionPlanningDraftInput(
     },
     riskInput: requiredPatchObject(input.riskInput, "riskInput"),
     airspaceInput: requiredPatchObject(input.airspaceInput, "airspaceInput"),
+  };
+}
+
+export function validateCreateMissionPlanningApprovalHandoffInput(
+  input: CreateMissionPlanningApprovalHandoffInput | undefined,
+) {
+  if (input === undefined || input === null) {
+    return {
+      createdBy: null,
+    };
+  }
+
+  if (typeof input !== "object" || Array.isArray(input)) {
+    throw new MissionPlanningValidationError("Request body must be an object");
+  }
+
+  return {
+    createdBy: optionalTrimmed(input.createdBy, "createdBy"),
   };
 }

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -98,6 +98,15 @@ const countRows = async (missionId?: string) => {
   };
 };
 
+const getMissionStatus = async (missionId: string) => {
+  const result = await pool.query<{ status: string }>(
+    "select status from missions where id = $1",
+    [missionId],
+  );
+
+  return result.rows[0]?.status;
+};
+
 describe("mission planning drafts", () => {
   beforeAll(async () => {
     await runMigrations(pool);
@@ -311,6 +320,93 @@ describe("mission planning drafts", () => {
         { key: "airspace", status: "missing" },
       ],
     });
+  });
+
+  it("hands off a gate-ready planning review to approval evidence", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    const createResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-handoff-ready",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(createResponse.status).toBe(201);
+
+    const beforeReview = await request(app).get(
+      `/mission-plans/drafts/${createResponse.body.draft.missionId}/review`,
+    );
+    const beforeCounts = await countRows(createResponse.body.draft.missionId);
+    const handoffResponse = await request(app)
+      .post(
+        `/mission-plans/drafts/${createResponse.body.draft.missionId}/approval-handoff`,
+      )
+      .send({
+        createdBy: " planning lead ",
+      });
+    const afterReview = await request(app).get(
+      `/mission-plans/drafts/${createResponse.body.draft.missionId}/review`,
+    );
+    const afterCounts = await countRows(createResponse.body.draft.missionId);
+
+    expect(beforeReview.status).toBe(200);
+    expect(handoffResponse.status).toBe(201);
+    expect(handoffResponse.body.handoff.review).toEqual(beforeReview.body.review);
+    expect(handoffResponse.body.handoff.snapshot).toMatchObject({
+      missionId: createResponse.body.draft.missionId,
+      evidenceType: "mission_readiness_gate",
+      createdBy: "planning lead",
+    });
+    expect(handoffResponse.body.handoff.approvalEvidenceLink).toMatchObject({
+      missionId: createResponse.body.draft.missionId,
+      auditEvidenceSnapshotId: handoffResponse.body.handoff.snapshot.id,
+      decisionType: "approval",
+      createdBy: "planning lead",
+    });
+    expect(afterReview.body.review).toEqual(beforeReview.body.review);
+    expect(afterCounts).toEqual({
+      ...beforeCounts,
+      snapshot_count: beforeCounts.snapshot_count + 1,
+      decision_link_count: beforeCounts.decision_link_count + 1,
+    });
+    expect(afterCounts.mission_event_count).toBe(0);
+    expect(await getMissionStatus(createResponse.body.draft.missionId)).toBe(
+      "draft",
+    );
+  });
+
+  it("rejects approval handoff when the planning review is not ready", async () => {
+    const createResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-handoff-blocked",
+      riskInput: lowRiskInput,
+    });
+
+    expect(createResponse.status).toBe(201);
+
+    const beforeCounts = await countRows(createResponse.body.draft.missionId);
+    const handoffResponse = await request(app)
+      .post(
+        `/mission-plans/drafts/${createResponse.body.draft.missionId}/approval-handoff`,
+      )
+      .send({
+        createdBy: "approver",
+      });
+    const afterCounts = await countRows(createResponse.body.draft.missionId);
+
+    expect(handoffResponse.status).toBe(409);
+    expect(handoffResponse.body).toMatchObject({
+      error: {
+        type: "mission_planning_review_not_ready",
+        blockingReasons: [
+          "Assign a platform before readiness can pass",
+          "Assign a pilot before readiness can pass",
+          "Add airspace compliance inputs before readiness can pass",
+        ],
+      },
+    });
+    expect(afterCounts).toEqual(beforeCounts);
   });
 
   it("updates draft placeholders without replacing omitted values", async () => {
@@ -589,6 +685,37 @@ describe("mission planning drafts", () => {
     const submittedResponse = await request(app).get(
       `/mission-plans/drafts/${missionId}/review`,
     );
+
+    expect(missingResponse.status).toBe(404);
+    expect(submittedResponse.status).toBe(404);
+  });
+
+  it("returns 404 when handing off missing or non-draft missions", async () => {
+    const missingResponse = await request(app)
+      .post(`/mission-plans/drafts/${randomUUID()}/approval-handoff`)
+      .send({
+        createdBy: "approver",
+      });
+    const missionId = randomUUID();
+
+    await pool.query(
+      `
+      insert into missions (
+        id,
+        status,
+        mission_plan_id,
+        last_event_sequence_no
+      )
+      values ($1, 'submitted', 'submitted-plan', 0)
+      `,
+      [missionId],
+    );
+
+    const submittedResponse = await request(app)
+      .post(`/mission-plans/drafts/${missionId}/approval-handoff`)
+      .send({
+        createdBy: "approver",
+      });
 
     expect(missingResponse.status).toBe(404);
     expect(submittedResponse.status).toBe(404);


### PR DESCRIPTION
## Summary
Implements issue #31 by adding a mission planning approval handoff endpoint that links a gate-ready planning review to approval evidence.

## What changed
- Added `POST /mission-plans/drafts/:missionId/approval-handoff`.
- Requires the existing planning review to be gate-ready before handoff.
- Creates a readiness audit snapshot and an approval decision evidence link using the existing audit evidence path.
- Returns the review, snapshot, and approval evidence link in the handoff response.
- Rejects not-ready planning reviews with 409 and blocking reasons.
- Rejects missing or non-draft missions with 404.
- Keeps the review endpoint read-only and verifies handoff does not mutate mission status or create lifecycle events.
- Updates the next build step toward approval endpoint integration.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/mission-planning.test.ts` passed: 17 tests.
- `./node_modules/.bin/vitest.cmd run src/tests/mission-planning.test.ts src/tests/mission-lifecycle.test.ts src/tests/audit-evidence.test.ts` passed: 52 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 178 tests.
- `git diff --check` passed.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #31.
