### PR TITLE
Require gate-ready planning evidence for approval #33

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission approval endpoint integration so approval can require the linked gate-ready planning evidence before changing mission state.",
+ "nextBuildStep": "Add mission dispatch integration so launch decisions can require linked approval and dispatch evidence without weakening the audit chain.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.repository.ts
+++ b/src/audit-evidence/audit-evidence.repository.ts
@@ -242,4 +242,31 @@ export class AuditEvidenceRepository {
 
     return result.rowCount === 1;
   }
+
+  async decisionEvidenceLinkReferencesPlanningApprovalHandoff(
+    tx: PoolClient,
+    missionId: string,
+    linkId: string,
+  ): Promise<boolean> {
+    const result = await tx.query(
+      `
+      select 1
+      from mission_planning_approval_handoffs handoffs
+      inner join mission_decision_evidence_links links
+        on links.id = handoffs.mission_decision_evidence_link_id
+       and links.mission_id = handoffs.mission_id
+      inner join audit_evidence_snapshots snapshots
+        on snapshots.mission_id = handoffs.mission_id
+       and snapshots.id = handoffs.audit_evidence_snapshot_id
+      where handoffs.mission_id = $1
+        and handoffs.mission_decision_evidence_link_id = $2
+        and links.decision_type = 'approval'
+        and snapshots.evidence_type = 'mission_readiness_gate'
+        and coalesce((handoffs.planning_review ->> 'readyForApproval')::boolean, false) = true
+      `,
+      [missionId, linkId],
+    );
+
+    return result.rowCount === 1;
+  }
 }

--- a/src/migrations/015_create_mission_planning_approval_handoffs.sql
+++ b/src/migrations/015_create_mission_planning_approval_handoffs.sql
@@ -1,0 +1,18 @@
+create table if not exists mission_planning_approval_handoffs (
+  id uuid primary key,
+  mission_id uuid not null references missions(id) on delete cascade,
+  audit_evidence_snapshot_id uuid not null,
+  mission_decision_evidence_link_id uuid not null references mission_decision_evidence_links(id) on delete cascade,
+  planning_review jsonb not null,
+  created_by text null,
+  created_at timestamptz not null default now(),
+  constraint mission_planning_approval_handoff_snapshot_fk
+    foreign key (mission_id, audit_evidence_snapshot_id)
+    references audit_evidence_snapshots (mission_id, id),
+  constraint mission_planning_approval_handoff_link_uniq
+    unique (mission_decision_evidence_link_id)
+);
+
+create index if not exists idx_mission_planning_approval_handoffs_mission_created
+  on mission_planning_approval_handoffs (mission_id, created_at desc);
+

--- a/src/mission-planning/mission-planning.repository.ts
+++ b/src/mission-planning/mission-planning.repository.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
 import type { PoolClient, QueryResultRow } from "pg";
+import type { MissionPlanningReview } from "./mission-planning.types";
 
 interface MissionPlanningDraftRow extends QueryResultRow {
   id: string;
@@ -139,5 +140,41 @@ export class MissionPlanningRepository {
     );
 
     return result.rows[0] ?? null;
+  }
+
+  async insertApprovalHandoffTrace(
+    tx: PoolClient,
+    input: {
+      missionId: string;
+      snapshotId: string;
+      approvalEvidenceLinkId: string;
+      review: MissionPlanningReview;
+      createdBy: string | null;
+    },
+  ): Promise<string> {
+    const result = await tx.query<{ id: string }>(
+      `
+      insert into mission_planning_approval_handoffs (
+        id,
+        mission_id,
+        audit_evidence_snapshot_id,
+        mission_decision_evidence_link_id,
+        planning_review,
+        created_by
+      )
+      values ($1, $2, $3, $4, $5::jsonb, $6)
+      returning id
+      `,
+      [
+        randomUUID(),
+        input.missionId,
+        input.snapshotId,
+        input.approvalEvidenceLinkId,
+        JSON.stringify(input.review),
+        input.createdBy,
+      ],
+    );
+
+    return result.rows[0].id;
   }
 }

--- a/src/mission-planning/mission-planning.service.ts
+++ b/src/mission-planning/mission-planning.service.ts
@@ -260,12 +260,38 @@ export class MissionPlanningService {
           createdBy: validated.createdBy,
         },
       );
+    await this.recordApprovalHandoffTrace({
+      missionId,
+      snapshotId: snapshot.id,
+      approvalEvidenceLinkId: approvalEvidenceLink.id,
+      review,
+      createdBy: validated.createdBy,
+    });
 
     return {
       review,
       snapshot,
       approvalEvidenceLink,
     };
+  }
+
+  private async recordApprovalHandoffTrace(input: {
+    missionId: string;
+    snapshotId: string;
+    approvalEvidenceLinkId: string;
+    review: MissionPlanningReview;
+    createdBy: string | null;
+  }): Promise<void> {
+    const client = await this.pool.connect();
+
+    try {
+      await this.missionPlanningRepository.insertApprovalHandoffTrace(
+        client,
+        input,
+      );
+    } finally {
+      client.release();
+    }
   }
 
   private async getDraftForClient(

--- a/src/missions/mission.service.ts
+++ b/src/missions/mission.service.ts
@@ -190,6 +190,19 @@ export class MissionService {
         "Mission approval evidence must reference a readiness snapshot",
       );
     }
+
+    const referencesPlanningHandoff =
+      await this.auditEvidenceRepository.decisionEvidenceLinkReferencesPlanningApprovalHandoff(
+        tx,
+        missionId,
+        decisionEvidenceLinkId,
+      );
+
+    if (!referencesPlanningHandoff) {
+      throw new InvalidMissionApprovalEvidenceError(
+        "Mission approval evidence must reference a gate-ready planning handoff",
+      );
+    }
   }
 
   async launchMission(params: {

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -5,6 +5,7 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from mission_planning_approval_handoffs");
   await pool.query("delete from mission_decision_evidence_links");
   await pool.query("delete from audit_evidence_snapshots");
   await pool.query("delete from airspace_compliance_inputs");

--- a/src/tests/mission-lifecycle.test.ts
+++ b/src/tests/mission-lifecycle.test.ts
@@ -101,11 +101,49 @@ const createDecisionEvidenceLink = async (
 
   expect(linkResponse.status).toBe(201);
 
-  return linkResponse.body.link as { id: string };
+  return linkResponse.body.link as {
+    id: string;
+    auditEvidenceSnapshotId: string;
+  };
 };
 
-const createApprovalEvidenceLink = async (missionId: string) =>
-  createDecisionEvidenceLink(missionId, "approval");
+const createPlanningApprovalHandoffTrace = async (
+  missionId: string,
+  link: { id: string; auditEvidenceSnapshotId: string },
+) => {
+  await pool.query(
+    `
+    insert into mission_planning_approval_handoffs (
+      id,
+      mission_id,
+      audit_evidence_snapshot_id,
+      mission_decision_evidence_link_id,
+      planning_review,
+      created_by
+    )
+    values ($1, $2, $3, $4, $5::jsonb, $6)
+    `,
+    [
+      randomUUID(),
+      missionId,
+      link.auditEvidenceSnapshotId,
+      link.id,
+      JSON.stringify({
+        missionId,
+        readyForApproval: true,
+        blockingReasons: [],
+        checklist: [],
+      }),
+      "reviewer-1",
+    ],
+  );
+};
+
+const createApprovalEvidenceLink = async (missionId: string) => {
+  const link = await createDecisionEvidenceLink(missionId, "approval");
+  await createPlanningApprovalHandoffTrace(missionId, link);
+  return link;
+};
 
 const createDispatchEvidenceLink = async (missionId: string) =>
   createDecisionEvidenceLink(missionId, "dispatch");
@@ -384,6 +422,39 @@ describe("mission integration", () => {
     expect(approveResponse.body).toMatchObject({
       error: {
         type: "invalid_mission_approval_evidence",
+      },
+    });
+
+    expect(await getMissionState(missionId)).toEqual({
+      status: "submitted",
+      last_event_sequence_no: 0,
+    });
+    expect(await getMissionEvents(missionId)).toEqual([]);
+    expect(await getAuditEvidenceState(missionId)).toEqual(auditBefore);
+  });
+
+  it("POST /missions/:missionId/approve rejects generic approval evidence without planning handoff trace", async () => {
+    const missionId = randomUUID();
+
+    await insertMission({
+      id: missionId,
+      status: "submitted",
+    });
+    const approvalLink = await createDecisionEvidenceLink(missionId, "approval");
+    const auditBefore = await getAuditEvidenceState(missionId);
+
+    const approveResponse = await request(app)
+      .post(`/missions/${missionId}/approve`)
+      .send({
+        reviewerId: "reviewer-1",
+        decisionEvidenceLinkId: approvalLink.id,
+      });
+
+    expect(approveResponse.status).toBe(409);
+    expect(approveResponse.body).toMatchObject({
+      error: {
+        type: "invalid_mission_approval_evidence",
+        message: expect.stringContaining("gate-ready planning handoff"),
       },
     });
 

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -5,6 +5,7 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from mission_planning_approval_handoffs");
   await pool.query("delete from mission_decision_evidence_links");
   await pool.query("delete from audit_evidence_snapshots");
   await pool.query("delete from airspace_compliance_inputs");
@@ -83,6 +84,7 @@ const countRows = async (missionId?: string) => {
       (select count(*)::int from mission_risk_inputs where ($1::uuid is null or mission_id = $1)) as risk_input_count,
       (select count(*)::int from airspace_compliance_inputs where ($1::uuid is null or mission_id = $1)) as airspace_input_count,
       (select count(*)::int from audit_evidence_snapshots where ($1::uuid is null or mission_id = $1)) as snapshot_count,
+      (select count(*)::int from mission_planning_approval_handoffs where ($1::uuid is null or mission_id = $1)) as planning_handoff_count,
       (select count(*)::int from mission_decision_evidence_links where ($1::uuid is null or mission_id = $1)) as decision_link_count
     `,
     [missionId ?? null],
@@ -94,6 +96,7 @@ const countRows = async (missionId?: string) => {
     risk_input_count: number;
     airspace_input_count: number;
     snapshot_count: number;
+    planning_handoff_count: number;
     decision_link_count: number;
   };
 };
@@ -154,6 +157,7 @@ describe("mission planning drafts", () => {
       risk_input_count: 0,
       airspace_input_count: 0,
       snapshot_count: 0,
+      planning_handoff_count: 0,
       decision_link_count: 0,
     });
     expect((await countRows()).mission_count).toBe(before.mission_count + 1);
@@ -229,6 +233,7 @@ describe("mission planning drafts", () => {
       risk_input_count: 1,
       airspace_input_count: 1,
       snapshot_count: 0,
+      planning_handoff_count: 0,
       decision_link_count: 0,
     });
   });
@@ -369,11 +374,69 @@ describe("mission planning drafts", () => {
     expect(afterCounts).toEqual({
       ...beforeCounts,
       snapshot_count: beforeCounts.snapshot_count + 1,
+      planning_handoff_count: beforeCounts.planning_handoff_count + 1,
       decision_link_count: beforeCounts.decision_link_count + 1,
     });
     expect(afterCounts.mission_event_count).toBe(0);
     expect(await getMissionStatus(createResponse.body.draft.missionId)).toBe(
       "draft",
+    );
+  });
+
+  it("allows approval with linked gate-ready planning handoff evidence", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    const createResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-handoff-approval",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(createResponse.status).toBe(201);
+
+    const handoffResponse = await request(app)
+      .post(
+        `/mission-plans/drafts/${createResponse.body.draft.missionId}/approval-handoff`,
+      )
+      .send({
+        createdBy: "planning lead",
+      });
+    const submitResponse = await request(app)
+      .post(`/missions/${createResponse.body.draft.missionId}/submit`)
+      .send({
+        userId: "operator-1",
+      });
+    const approveResponse = await request(app)
+      .post(`/missions/${createResponse.body.draft.missionId}/approve`)
+      .send({
+        reviewerId: "approver-1",
+        decisionEvidenceLinkId:
+          handoffResponse.body.handoff.approvalEvidenceLink.id,
+        notes: "planning evidence verified",
+      });
+    const eventsResponse = await request(app).get(
+      `/missions/${createResponse.body.draft.missionId}/events`,
+    );
+
+    expect(handoffResponse.status).toBe(201);
+    expect(submitResponse.status).toBe(204);
+    expect(approveResponse.status).toBe(204);
+    expect(await getMissionStatus(createResponse.body.draft.missionId)).toBe(
+      "approved",
+    );
+    expect(eventsResponse.status).toBe(200);
+    expect(eventsResponse.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "mission.approved",
+          details: expect.objectContaining({
+            decision_evidence_link_id:
+              handoffResponse.body.handoff.approvalEvidenceLink.id,
+          }),
+        }),
+      ]),
     );
   });
 
@@ -451,6 +514,7 @@ describe("mission planning drafts", () => {
       risk_input_count: 1,
       airspace_input_count: 0,
       snapshot_count: 0,
+      planning_handoff_count: 0,
       decision_link_count: 0,
     });
   });
@@ -493,6 +557,7 @@ describe("mission planning drafts", () => {
       risk_input_count: 2,
       airspace_input_count: 2,
       snapshot_count: 0,
+      planning_handoff_count: 0,
       decision_link_count: 0,
     });
 
@@ -605,6 +670,7 @@ describe("mission planning drafts", () => {
       risk_input_count: 0,
       airspace_input_count: 0,
       snapshot_count: 0,
+      planning_handoff_count: 0,
       decision_link_count: 0,
     });
   });
@@ -632,6 +698,7 @@ describe("mission planning drafts", () => {
     expect(await countRows()).toMatchObject({
       mission_count: 0,
       snapshot_count: 0,
+      planning_handoff_count: 0,
       decision_link_count: 0,
     });
   });

--- a/src/tests/mission.transition-matrix.integration.test.ts
+++ b/src/tests/mission.transition-matrix.integration.test.ts
@@ -97,11 +97,49 @@ const createDecisionEvidenceLink = async (
 
   expect(linkResponse.status).toBe(201);
 
-  return linkResponse.body.link as { id: string };
+  return linkResponse.body.link as {
+    id: string;
+    auditEvidenceSnapshotId: string;
+  };
 };
 
-const createApprovalEvidenceLink = async (missionId: string) =>
-  createDecisionEvidenceLink(missionId, "approval");
+const createPlanningApprovalHandoffTrace = async (
+  missionId: string,
+  link: { id: string; auditEvidenceSnapshotId: string },
+) => {
+  await pool.query(
+    `
+    insert into mission_planning_approval_handoffs (
+      id,
+      mission_id,
+      audit_evidence_snapshot_id,
+      mission_decision_evidence_link_id,
+      planning_review,
+      created_by
+    )
+    values ($1, $2, $3, $4, $5::jsonb, $6)
+    `,
+    [
+      randomUUID(),
+      missionId,
+      link.auditEvidenceSnapshotId,
+      link.id,
+      JSON.stringify({
+        missionId,
+        readyForApproval: true,
+        blockingReasons: [],
+        checklist: [],
+      }),
+      "reviewer-1",
+    ],
+  );
+};
+
+const createApprovalEvidenceLink = async (missionId: string) => {
+  const link = await createDecisionEvidenceLink(missionId, "approval");
+  await createPlanningApprovalHandoffTrace(missionId, link);
+  return link;
+};
 
 const createDispatchEvidenceLink = async (missionId: string) =>
   createDecisionEvidenceLink(missionId, "dispatch");


### PR DESCRIPTION
## Summary
Implements issue #33 by requiring mission approval evidence to be traceable to a gate-ready mission planning handoff.

## What changed
- Added `mission_planning_approval_handoffs` migration to persist the planning-review-to-approval-evidence trace.
- Records a handoff trace when `POST /mission-plans/drafts/:missionId/approval-handoff` creates the readiness snapshot and approval evidence link.
- Adds repository support to verify that an approval evidence link references a gate-ready planning handoff.
- Tightens `POST /missions/:missionId/approve` so generic readiness snapshot approval links are rejected unless they are backed by the planning handoff trace.
- Preserves existing lifecycle transition behavior and approval event details for successful approvals.
- Updates regression fixtures so allowed approval paths carry planning handoff evidence.
- Updates the next build step toward dispatch integration.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/mission-planning.test.ts src/tests/mission-lifecycle.test.ts src/tests/mission.transition-matrix.integration.test.ts` passed: 59 tests.
- `./node_modules/.bin/vitest.cmd run src/tests/mission-planning.test.ts src/tests/mission-lifecycle.test.ts src/tests/audit-evidence.test.ts src/tests/mission.transition-matrix.integration.test.ts` passed: 70 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 180 tests.
- `git diff --check` passed.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #33.
