### PR TITLE
Require linked approval evidence for dispatch #35

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission dispatch integration so launch decisions can require linked approval and dispatch evidence without weakening the audit chain.",
+ "nextBuildStep": "Add post-operation completion evidence snapshots so completed missions preserve launch, flight, and readiness decisions as reviewable records.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.repository.ts
+++ b/src/audit-evidence/audit-evidence.repository.ts
@@ -269,4 +269,31 @@ export class AuditEvidenceRepository {
 
     return result.rowCount === 1;
   }
+
+  async missionHasPlanningBackedApprovalEvent(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<boolean> {
+    const result = await tx.query(
+      `
+      select 1
+      from mission_events events
+      inner join mission_planning_approval_handoffs handoffs
+        on handoffs.mission_id = events.mission_id
+       and handoffs.mission_decision_evidence_link_id::text =
+        events.details ->> 'decision_evidence_link_id'
+      inner join mission_decision_evidence_links links
+        on links.id = handoffs.mission_decision_evidence_link_id
+       and links.mission_id = handoffs.mission_id
+      where events.mission_id = $1
+        and events.event_type = 'mission.approved'
+        and links.decision_type = 'approval'
+        and coalesce((handoffs.planning_review ->> 'readyForApproval')::boolean, false) = true
+      limit 1
+      `,
+      [missionId],
+    );
+
+    return result.rowCount === 1;
+  }
 }

--- a/src/missions/mission.service.ts
+++ b/src/missions/mission.service.ts
@@ -225,6 +225,7 @@ export class MissionService {
         mission.id,
         params.decisionEvidenceLinkId,
       );
+      await this.assertPlanningBackedApprovalForDispatch(tx, mission.id);
       
       await this.missionRepo.updateStatus(tx, params.missionId, "active");
 
@@ -296,6 +297,29 @@ export class MissionService {
     if (!referencesReadinessSnapshot) {
       throw new InvalidMissionDispatchEvidenceError(
         "Mission dispatch evidence must reference a readiness snapshot",
+      );
+    }
+  }
+
+  private async assertPlanningBackedApprovalForDispatch(
+    tx: any,
+    missionId: string,
+  ): Promise<void> {
+    if (!this.auditEvidenceRepository) {
+      throw new InvalidMissionDispatchEvidenceError(
+        "Mission dispatch evidence repository is not available",
+      );
+    }
+
+    const hasPlanningBackedApproval =
+      await this.auditEvidenceRepository.missionHasPlanningBackedApprovalEvent(
+        tx,
+        missionId,
+      );
+
+    if (!hasPlanningBackedApproval) {
+      throw new InvalidMissionDispatchEvidenceError(
+        "Mission launch requires approval backed by gate-ready planning evidence",
       );
     }
   }

--- a/src/tests/mission-lifecycle.test.ts
+++ b/src/tests/mission-lifecycle.test.ts
@@ -148,6 +148,75 @@ const createApprovalEvidenceLink = async (missionId: string) => {
 const createDispatchEvidenceLink = async (missionId: string) =>
   createDecisionEvidenceLink(missionId, "dispatch");
 
+const recordPlanningBackedApprovalEvent = async (missionId: string) => {
+  const approvalLink = await createApprovalEvidenceLink(missionId);
+
+  await pool.query(
+    `
+    insert into mission_events (
+      mission_id,
+      mission_plan_id,
+      event_type,
+      event_version,
+      event_ts,
+      recorded_at,
+      sequence_no,
+      actor_type,
+      actor_id,
+      from_state,
+      to_state,
+      summary,
+      details,
+      source_component,
+      source,
+      severity,
+      safety_relevant,
+      compliance_relevant,
+      metadata
+    )
+    values (
+      $1,
+      'plan-1',
+      'mission.approved',
+      1,
+      now(),
+      now(),
+      1,
+      'user',
+      'reviewer-1',
+      'submitted',
+      'approved',
+      'Mission approved',
+      $2::jsonb,
+      'mission-review-service',
+      'mission-review-service',
+      'info',
+      false,
+      true,
+      '{}'::jsonb
+    )
+    `,
+    [
+      missionId,
+      JSON.stringify({
+        decision: "approved",
+        decision_evidence_link_id: approvalLink.id,
+        notes: "planning-backed approval fixture",
+      }),
+    ],
+  );
+  await pool.query(
+    `
+    update missions
+    set last_event_sequence_no = greatest(last_event_sequence_no, 1)
+    where id = $1
+    `,
+    [missionId],
+  );
+
+  return approvalLink;
+};
+
 const getAuditEvidenceState = async (missionId: string) => {
   const result = await pool.query(
     `
@@ -295,6 +364,7 @@ describe("mission integration", () => {
     initialStatus: "approved",
     expectedStatusAfterFirstCall: "active",
     requestBody: async (missionId) => {
+      await recordPlanningBackedApprovalEvent(missionId);
       const link = await createDispatchEvidenceLink(missionId);
 
       return {
@@ -721,6 +791,42 @@ describe("mission integration", () => {
     expect(await getAuditEvidenceState(otherMissionId)).toEqual(otherAuditBefore);
   });
 
+  it("POST /missions/:missionId/launch rejects approved missions without planning-backed approval evidence", async () => {
+    const missionId = randomUUID();
+
+    await insertMission({
+      id: missionId,
+      status: "approved",
+    });
+    const dispatchLink = await createDispatchEvidenceLink(missionId);
+    const auditBefore = await getAuditEvidenceState(missionId);
+
+    const launchResponse = await request(app)
+      .post(`/missions/${missionId}/launch`)
+      .send({
+        operatorId: "operator-1",
+        vehicleId: "vehicle-1",
+        lat: 51.5074,
+        lng: -0.1278,
+        decisionEvidenceLinkId: dispatchLink.id,
+      });
+
+    expect(launchResponse.status).toBe(409);
+    expect(launchResponse.body).toMatchObject({
+      error: {
+        type: "invalid_mission_dispatch_evidence",
+        message: expect.stringContaining("gate-ready planning evidence"),
+      },
+    });
+
+    expect(await getMissionState(missionId)).toEqual({
+      status: "approved",
+      last_event_sequence_no: 0,
+    });
+    expect(await getMissionEvents(missionId)).toEqual([]);
+    expect(await getAuditEvidenceState(missionId)).toEqual(auditBefore);
+  });
+
   it("POST /missions/:missionId/launch updates mission state and creates exactly one mission.launched event", async () => {
     const missionId = randomUUID();
 
@@ -728,6 +834,7 @@ describe("mission integration", () => {
       id: missionId,
       status: "approved",
     });
+    await recordPlanningBackedApprovalEvent(missionId);
     const dispatchLink = await createDispatchEvidenceLink(missionId);
 
     const launchResponse = await request(app)

--- a/src/tests/mission.transition-matrix.integration.test.ts
+++ b/src/tests/mission.transition-matrix.integration.test.ts
@@ -144,6 +144,73 @@ const createApprovalEvidenceLink = async (missionId: string) => {
 const createDispatchEvidenceLink = async (missionId: string) =>
   createDecisionEvidenceLink(missionId, "dispatch");
 
+const recordPlanningBackedApprovalEvent = async (missionId: string) => {
+  const approvalLink = await createApprovalEvidenceLink(missionId);
+
+  await pool.query(
+    `
+    insert into mission_events (
+      mission_id,
+      mission_plan_id,
+      event_type,
+      event_version,
+      event_ts,
+      recorded_at,
+      sequence_no,
+      actor_type,
+      actor_id,
+      from_state,
+      to_state,
+      summary,
+      details,
+      source_component,
+      source,
+      severity,
+      safety_relevant,
+      compliance_relevant,
+      metadata
+    )
+    values (
+      $1,
+      'plan-1',
+      'mission.approved',
+      1,
+      now(),
+      now(),
+      1,
+      'user',
+      'reviewer-1',
+      'submitted',
+      'approved',
+      'Mission approved',
+      $2::jsonb,
+      'mission-review-service',
+      'mission-review-service',
+      'info',
+      false,
+      true,
+      '{}'::jsonb
+    )
+    `,
+    [
+      missionId,
+      JSON.stringify({
+        decision: "approved",
+        decision_evidence_link_id: approvalLink.id,
+        notes: "planning-backed approval fixture",
+      }),
+    ],
+  );
+  await pool.query(
+    `
+    update missions
+    set last_event_sequence_no = greatest(last_event_sequence_no, 1)
+    where id = $1
+    `,
+    [missionId],
+  );
+};
+
 type TransitionCase = {
   name: string;
   route: (missionId: string) => string;
@@ -351,6 +418,7 @@ describe("mission transition matrix integration", () => {
       }
 
       if (testCase.expectedEventType === "mission.launched" && testCase.allowed) {
+        await recordPlanningBackedApprovalEvent(missionId);
         const link = await createDispatchEvidenceLink(missionId);
         requestBody.decisionEvidenceLinkId = link.id;
       }


### PR DESCRIPTION
## Summary
Implements issue #35 by requiring launch/dispatch to verify that the mission approval was backed by gate-ready planning evidence as well as requiring valid dispatch evidence.

## What changed
- Keeps the existing `POST /missions/:missionId/launch` dispatch decision evidence requirement.
- Adds a launch precondition that verifies the mission has a `mission.approved` event whose approval evidence link is traceable to a gate-ready planning approval handoff.
- Rejects launch attempts for approved missions that have dispatch evidence but no planning-backed approval event.
- Preserves existing dispatch evidence checks for missing, wrong-type, cross-mission, and non-readiness-snapshot links.
- Preserves successful launch event behavior and dispatch evidence link recording.
- Updates transition/lifecycle fixtures so allowed launch paths include a planning-backed approval event.
- Updates the next build step toward post-operation completion evidence snapshots.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/mission-lifecycle.test.ts src/tests/mission.transition-matrix.integration.test.ts` passed: 42 tests.
- `./node_modules/.bin/vitest.cmd run src/tests/mission-planning.test.ts src/tests/mission-lifecycle.test.ts src/tests/audit-evidence.test.ts src/tests/mission.transition-matrix.integration.test.ts` passed: 71 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 181 tests.
- `git diff --check` passed.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.

Closes #35.
