### PR TITLE
Add post-operation completion evidence snapshots

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add post-operation completion evidence snapshots so completed missions preserve launch, flight, and readiness decisions as reviewable records.",
+ "nextBuildStep": "Add post-operation audit export endpoint so reviewable completion snapshots can be packaged for operators, accountable managers, or regulators.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add post-operation audit export endpoint so reviewable completion snapshots can be packaged for operators, accountable managers, or regulators.",
+ "nextBuildStep": "Add migration-backed post-operation audit export endpoint so reviewable completion snapshots can be packaged for operators, accountable managers, or regulators.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.controller.ts
+++ b/src/audit-evidence/audit-evidence.controller.ts
@@ -73,4 +73,37 @@ export class AuditEvidenceController {
       next(error);
     }
   };
+
+  createPostOperationEvidenceSnapshot = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const snapshot =
+        await this.auditEvidenceService.createPostOperationEvidenceSnapshot(
+          req.params.missionId,
+          req.body,
+        );
+      res.status(201).json({ snapshot });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listPostOperationEvidenceSnapshots = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const snapshots =
+        await this.auditEvidenceService.listPostOperationEvidenceSnapshots(
+          req.params.missionId,
+        );
+      res.status(200).json({ snapshots });
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/audit-evidence/audit-evidence.errors.ts
+++ b/src/audit-evidence/audit-evidence.errors.ts
@@ -20,3 +20,14 @@ export class AuditEvidenceSnapshotNotFoundError extends Error {
     super(`Audit evidence snapshot not found for mission: ${snapshotId}`);
   }
 }
+
+export class AuditEvidenceMissionNotCompletedError extends Error {
+  readonly statusCode = 409;
+  readonly code = "MISSION_NOT_COMPLETED";
+
+  constructor(missionId: string, status: string) {
+    super(
+      `Mission ${missionId} must be completed before post-operation evidence can be captured; current status is ${status}`,
+    );
+  }
+}

--- a/src/audit-evidence/audit-evidence.repository.ts
+++ b/src/audit-evidence/audit-evidence.repository.ts
@@ -4,6 +4,10 @@ import type { MissionReadinessCheck } from "../missions/mission-readiness.types"
 import type {
   AuditEvidenceSnapshot,
   MissionDecisionEvidenceLink,
+  MissionLifecycleEvidenceEvent,
+  PlanningApprovalHandoffEvidence,
+  PostOperationCompletionSnapshot,
+  PostOperationEvidenceSnapshot,
 } from "./audit-evidence.types";
 
 interface AuditEvidenceSnapshotRow extends QueryResultRow {
@@ -42,6 +46,53 @@ interface CreateMissionDecisionEvidenceLinkRow {
   createdBy: string | null;
 }
 
+interface MissionAuditStateRow extends QueryResultRow {
+  id: string;
+  status: string;
+  mission_plan_id: string | null;
+}
+
+interface MissionLifecycleEvidenceEventRow extends QueryResultRow {
+  id: string;
+  sequence_no: number;
+  event_type: string;
+  event_ts: Date;
+  recorded_at: Date;
+  actor_type: string;
+  actor_id: string | null;
+  from_state: string | null;
+  to_state: string | null;
+  summary: string;
+  details: Record<string, unknown>;
+}
+
+interface PlanningApprovalHandoffEvidenceRow extends QueryResultRow {
+  id: string;
+  mission_id: string;
+  audit_evidence_snapshot_id: string;
+  mission_decision_evidence_link_id: string;
+  planning_review: Record<string, unknown>;
+  created_by: string | null;
+  created_at: Date;
+}
+
+interface PostOperationEvidenceSnapshotRow extends QueryResultRow {
+  id: string;
+  mission_id: string;
+  evidence_type: PostOperationEvidenceSnapshot["evidenceType"];
+  lifecycle_state: string;
+  completion_snapshot: PostOperationCompletionSnapshot;
+  created_by: string | null;
+  created_at: Date;
+}
+
+interface CreatePostOperationEvidenceSnapshotRow {
+  missionId: string;
+  lifecycleState: string;
+  completionSnapshot: PostOperationCompletionSnapshot;
+  createdBy: string | null;
+}
+
 const toAuditEvidenceSnapshot = (
   row: AuditEvidenceSnapshotRow,
 ): AuditEvidenceSnapshot => ({
@@ -69,6 +120,46 @@ const toMissionDecisionEvidenceLink = (
   createdAt: row.created_at.toISOString(),
 });
 
+const toMissionLifecycleEvidenceEvent = (
+  row: MissionLifecycleEvidenceEventRow,
+): MissionLifecycleEvidenceEvent => ({
+  id: Number(row.id),
+  sequence: row.sequence_no,
+  type: row.event_type,
+  time: row.event_ts.toISOString(),
+  recordedAt: row.recorded_at.toISOString(),
+  actorType: row.actor_type,
+  actorId: row.actor_id,
+  fromState: row.from_state,
+  toState: row.to_state,
+  summary: row.summary,
+  details: row.details,
+});
+
+const toPlanningApprovalHandoffEvidence = (
+  row: PlanningApprovalHandoffEvidenceRow,
+): PlanningApprovalHandoffEvidence => ({
+  id: row.id,
+  missionId: row.mission_id,
+  auditEvidenceSnapshotId: row.audit_evidence_snapshot_id,
+  missionDecisionEvidenceLinkId: row.mission_decision_evidence_link_id,
+  planningReview: row.planning_review,
+  createdBy: row.created_by,
+  createdAt: row.created_at.toISOString(),
+});
+
+const toPostOperationEvidenceSnapshot = (
+  row: PostOperationEvidenceSnapshotRow,
+): PostOperationEvidenceSnapshot => ({
+  id: row.id,
+  missionId: row.mission_id,
+  evidenceType: row.evidence_type,
+  lifecycleState: row.lifecycle_state,
+  completionSnapshot: row.completion_snapshot,
+  createdBy: row.created_by,
+  createdAt: row.created_at.toISOString(),
+});
+
 export class AuditEvidenceRepository {
   async missionExists(tx: PoolClient, missionId: string): Promise<boolean> {
     const result = await tx.query(
@@ -81,6 +172,22 @@ export class AuditEvidenceRepository {
     );
 
     return result.rowCount === 1;
+  }
+
+  async getMissionAuditState(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<MissionAuditStateRow | null> {
+    const result = await tx.query<MissionAuditStateRow>(
+      `
+      select id, status, mission_plan_id
+      from missions
+      where id = $1
+      `,
+      [missionId],
+    );
+
+    return result.rows[0] ?? null;
   }
 
   async insertReadinessSnapshot(
@@ -219,6 +326,124 @@ export class AuditEvidenceRepository {
     );
 
     return result.rows[0] ? toMissionDecisionEvidenceLink(result.rows[0]) : null;
+  }
+
+  async getDecisionEvidenceLinkById(
+    tx: PoolClient,
+    missionId: string,
+    linkId: string | null,
+  ): Promise<MissionDecisionEvidenceLink | null> {
+    if (!linkId) {
+      return null;
+    }
+
+    return this.getDecisionEvidenceLinkForMission(tx, missionId, linkId);
+  }
+
+  async getLifecycleEvidenceEvents(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<MissionLifecycleEvidenceEvent[]> {
+    const result = await tx.query<MissionLifecycleEvidenceEventRow>(
+      `
+      select
+        id,
+        sequence_no,
+        event_type,
+        event_ts,
+        recorded_at,
+        actor_type,
+        actor_id,
+        from_state,
+        to_state,
+        summary,
+        details
+      from mission_events
+      where mission_id = $1
+        and event_type in (
+          'mission.approved',
+          'mission.launched',
+          'mission.completed'
+        )
+      order by sequence_no asc, id asc
+      `,
+      [missionId],
+    );
+
+    return result.rows.map(toMissionLifecycleEvidenceEvent);
+  }
+
+  async getPlanningApprovalHandoffForDecisionLink(
+    tx: PoolClient,
+    missionId: string,
+    decisionEvidenceLinkId: string | null,
+  ): Promise<PlanningApprovalHandoffEvidence | null> {
+    if (!decisionEvidenceLinkId) {
+      return null;
+    }
+
+    const result = await tx.query<PlanningApprovalHandoffEvidenceRow>(
+      `
+      select *
+      from mission_planning_approval_handoffs
+      where mission_id = $1
+        and mission_decision_evidence_link_id = $2
+      limit 1
+      `,
+      [missionId, decisionEvidenceLinkId],
+    );
+
+    return result.rows[0]
+      ? toPlanningApprovalHandoffEvidence(result.rows[0])
+      : null;
+  }
+
+  async insertPostOperationEvidenceSnapshot(
+    tx: PoolClient,
+    input: CreatePostOperationEvidenceSnapshotRow,
+  ): Promise<PostOperationEvidenceSnapshot> {
+    const result = await tx.query<PostOperationEvidenceSnapshotRow>(
+      `
+      insert into post_operation_evidence_snapshots (
+        id,
+        mission_id,
+        evidence_type,
+        lifecycle_state,
+        completion_snapshot,
+        created_by
+      )
+      values ($1, $2, $3, $4, $5::jsonb, $6)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.missionId,
+        "post_operation_completion",
+        input.lifecycleState,
+        JSON.stringify(input.completionSnapshot),
+        input.createdBy,
+      ],
+    );
+
+    return toPostOperationEvidenceSnapshot(result.rows[0]);
+  }
+
+  async listPostOperationEvidenceSnapshots(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<PostOperationEvidenceSnapshot[]> {
+    const result = await tx.query<PostOperationEvidenceSnapshotRow>(
+      `
+      select *
+      from post_operation_evidence_snapshots
+      where mission_id = $1
+        and evidence_type = 'post_operation_completion'
+      order by created_at desc, id desc
+      `,
+      [missionId],
+    );
+
+    return result.rows.map(toPostOperationEvidenceSnapshot);
   }
 
   async decisionEvidenceLinkReferencesReadinessSnapshot(

--- a/src/audit-evidence/audit-evidence.routes.ts
+++ b/src/audit-evidence/audit-evidence.routes.ts
@@ -22,6 +22,14 @@ export function createAuditEvidenceRouter(
     "/:missionId/decision-evidence-links",
     controller.listMissionDecisionEvidenceLinks,
   );
+  router.post(
+    "/:missionId/post-operation/evidence-snapshots",
+    controller.createPostOperationEvidenceSnapshot,
+  );
+  router.get(
+    "/:missionId/post-operation/evidence-snapshots",
+    controller.listPostOperationEvidenceSnapshots,
+  );
 
   return router;
 }

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -1,6 +1,7 @@
 import type { Pool } from "pg";
 import { MissionService } from "../missions/mission.service";
 import {
+  AuditEvidenceMissionNotCompletedError,
   AuditEvidenceMissionNotFoundError,
   AuditEvidenceSnapshotNotFoundError,
 } from "./audit-evidence.errors";
@@ -9,11 +10,16 @@ import type {
   AuditEvidenceSnapshot,
   CreateAuditEvidenceSnapshotInput,
   CreateMissionDecisionEvidenceLinkInput,
+  CreatePostOperationEvidenceSnapshotInput,
   MissionDecisionEvidenceLink,
+  MissionLifecycleEvidenceEvent,
+  PostOperationCompletionSnapshot,
+  PostOperationEvidenceSnapshot,
 } from "./audit-evidence.types";
 import {
   validateCreateAuditEvidenceSnapshotInput,
   validateCreateMissionDecisionEvidenceLinkInput,
+  validateCreatePostOperationEvidenceSnapshotInput,
 } from "./audit-evidence.validators";
 
 export class AuditEvidenceService {
@@ -132,5 +138,152 @@ export class AuditEvidenceService {
     } finally {
       client.release();
     }
+  }
+
+  async createPostOperationEvidenceSnapshot(
+    missionId: string,
+    input: CreatePostOperationEvidenceSnapshotInput | undefined,
+  ): Promise<PostOperationEvidenceSnapshot> {
+    const validated = validateCreatePostOperationEvidenceSnapshotInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      await client.query("BEGIN");
+
+      const mission = await this.auditEvidenceRepository.getMissionAuditState(
+        client,
+        missionId,
+      );
+
+      if (!mission) {
+        throw new AuditEvidenceMissionNotFoundError(missionId);
+      }
+
+      if (mission.status !== "completed") {
+        throw new AuditEvidenceMissionNotCompletedError(
+          missionId,
+          mission.status,
+        );
+      }
+
+      const completionSnapshot =
+        await this.buildPostOperationCompletionSnapshot(client, {
+          missionId: mission.id,
+          missionPlanId: mission.mission_plan_id,
+          status: mission.status,
+        });
+
+      const snapshot =
+        await this.auditEvidenceRepository.insertPostOperationEvidenceSnapshot(
+          client,
+          {
+            missionId,
+            lifecycleState: mission.status,
+            completionSnapshot,
+            createdBy: validated.createdBy,
+          },
+        );
+
+      await client.query("COMMIT");
+      return snapshot;
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async listPostOperationEvidenceSnapshots(
+    missionId: string,
+  ): Promise<PostOperationEvidenceSnapshot[]> {
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.auditEvidenceRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new AuditEvidenceMissionNotFoundError(missionId);
+      }
+
+      return await this.auditEvidenceRepository.listPostOperationEvidenceSnapshots(
+        client,
+        missionId,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  private async buildPostOperationCompletionSnapshot(
+    client: Awaited<ReturnType<Pool["connect"]>>,
+    mission: { missionId: string; missionPlanId: string | null; status: string },
+  ): Promise<PostOperationCompletionSnapshot> {
+    const events =
+      await this.auditEvidenceRepository.getLifecycleEvidenceEvents(
+        client,
+        mission.missionId,
+      );
+    const approvalEvent = this.findLastEvent(events, "mission.approved");
+    const launchEvent = this.findLastEvent(events, "mission.launched");
+    const completionEvent = this.findLastEvent(events, "mission.completed");
+    const approvalEvidenceLinkId = this.extractDecisionEvidenceLinkId(
+      approvalEvent,
+    );
+    const dispatchEvidenceLinkId = this.extractDecisionEvidenceLinkId(
+      launchEvent,
+    );
+    const approvalEvidenceLink =
+      await this.auditEvidenceRepository.getDecisionEvidenceLinkById(
+        client,
+        mission.missionId,
+        approvalEvidenceLinkId,
+      );
+    const dispatchEvidenceLink =
+      await this.auditEvidenceRepository.getDecisionEvidenceLinkById(
+        client,
+        mission.missionId,
+        dispatchEvidenceLinkId,
+      );
+    const planningApprovalHandoff =
+      await this.auditEvidenceRepository.getPlanningApprovalHandoffForDecisionLink(
+        client,
+        mission.missionId,
+        approvalEvidenceLinkId,
+      );
+
+    return {
+      missionId: mission.missionId,
+      missionPlanId: mission.missionPlanId,
+      status: mission.status,
+      capturedAt: new Date().toISOString(),
+      approvalEvent,
+      launchEvent,
+      completionEvent,
+      approvalEvidenceLink,
+      dispatchEvidenceLink,
+      planningApprovalHandoff,
+    };
+  }
+
+  private findLastEvent(
+    events: MissionLifecycleEvidenceEvent[],
+    eventType: string,
+  ): MissionLifecycleEvidenceEvent | null {
+    return (
+      [...events].reverse().find((event) => event.type === eventType) ?? null
+    );
+  }
+
+  private extractDecisionEvidenceLinkId(
+    event: MissionLifecycleEvidenceEvent | null,
+  ): string | null {
+    const linkId = event?.details.decision_evidence_link_id;
+    return typeof linkId === "string" && linkId.trim().length > 0
+      ? linkId
+      : null;
   }
 }

--- a/src/audit-evidence/audit-evidence.types.ts
+++ b/src/audit-evidence/audit-evidence.types.ts
@@ -2,9 +2,15 @@ import type { MissionReadinessCheck } from "../missions/mission-readiness.types"
 
 export type AuditEvidenceType = "mission_readiness_gate";
 
+export type PostOperationEvidenceType = "post_operation_completion";
+
 export type MissionDecisionType = "approval" | "dispatch";
 
 export interface CreateAuditEvidenceSnapshotInput {
+  createdBy?: string | null;
+}
+
+export interface CreatePostOperationEvidenceSnapshotInput {
   createdBy?: string | null;
 }
 
@@ -33,6 +39,53 @@ export interface MissionDecisionEvidenceLink {
   missionId: string;
   auditEvidenceSnapshotId: string;
   decisionType: MissionDecisionType;
+  createdBy: string | null;
+  createdAt: string;
+}
+
+export interface MissionLifecycleEvidenceEvent {
+  id: number;
+  sequence: number;
+  type: string;
+  time: string;
+  recordedAt: string;
+  actorType: string;
+  actorId: string | null;
+  fromState: string | null;
+  toState: string | null;
+  summary: string;
+  details: Record<string, unknown>;
+}
+
+export interface PlanningApprovalHandoffEvidence {
+  id: string;
+  missionId: string;
+  auditEvidenceSnapshotId: string;
+  missionDecisionEvidenceLinkId: string;
+  planningReview: Record<string, unknown>;
+  createdBy: string | null;
+  createdAt: string;
+}
+
+export interface PostOperationCompletionSnapshot {
+  missionId: string;
+  missionPlanId: string | null;
+  status: string;
+  capturedAt: string;
+  approvalEvent: MissionLifecycleEvidenceEvent | null;
+  launchEvent: MissionLifecycleEvidenceEvent | null;
+  completionEvent: MissionLifecycleEvidenceEvent | null;
+  approvalEvidenceLink: MissionDecisionEvidenceLink | null;
+  dispatchEvidenceLink: MissionDecisionEvidenceLink | null;
+  planningApprovalHandoff: PlanningApprovalHandoffEvidence | null;
+}
+
+export interface PostOperationEvidenceSnapshot {
+  id: string;
+  missionId: string;
+  evidenceType: PostOperationEvidenceType;
+  lifecycleState: string;
+  completionSnapshot: PostOperationCompletionSnapshot;
   createdBy: string | null;
   createdAt: string;
 }

--- a/src/audit-evidence/audit-evidence.validators.ts
+++ b/src/audit-evidence/audit-evidence.validators.ts
@@ -2,6 +2,7 @@ import { AuditEvidenceValidationError } from "./audit-evidence.errors";
 import type {
   CreateAuditEvidenceSnapshotInput,
   CreateMissionDecisionEvidenceLinkInput,
+  CreatePostOperationEvidenceSnapshotInput,
   MissionDecisionType,
 } from "./audit-evidence.types";
 
@@ -22,6 +23,24 @@ function optionalTrimmed(value: unknown, fieldName: string): string | null {
 
 export function validateCreateAuditEvidenceSnapshotInput(
   input: CreateAuditEvidenceSnapshotInput | undefined,
+) {
+  if (input === undefined || input === null) {
+    return {
+      createdBy: null,
+    };
+  }
+
+  if (typeof input !== "object") {
+    throw new AuditEvidenceValidationError("Request body must be an object");
+  }
+
+  return {
+    createdBy: optionalTrimmed(input.createdBy, "createdBy"),
+  };
+}
+
+export function validateCreatePostOperationEvidenceSnapshotInput(
+  input: CreatePostOperationEvidenceSnapshotInput | undefined,
 ) {
   if (input === undefined || input === null) {
     return {

--- a/src/migrations/016_create_post_operation_evidence_snapshots.sql
+++ b/src/migrations/016_create_post_operation_evidence_snapshots.sql
@@ -1,0 +1,14 @@
+create table if not exists post_operation_evidence_snapshots (
+  id uuid primary key,
+  mission_id uuid not null references missions(id) on delete cascade,
+  evidence_type text not null default 'post_operation_completion',
+  lifecycle_state text not null,
+  completion_snapshot jsonb not null,
+  created_by text null,
+  created_at timestamptz not null default now(),
+  constraint post_operation_evidence_type_chk
+    check (evidence_type in ('post_operation_completion'))
+);
+
+create index if not exists idx_post_operation_evidence_snapshots_mission_created
+  on post_operation_evidence_snapshots (mission_id, created_at desc);

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -5,6 +5,7 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from post_operation_evidence_snapshots");
   await pool.query("delete from mission_planning_approval_handoffs");
   await pool.query("delete from mission_decision_evidence_links");
   await pool.query("delete from audit_evidence_snapshots");
@@ -156,11 +157,117 @@ const createReadyMission = async () => {
   };
 };
 
+const createDecisionEvidenceLink = async (
+  missionId: string,
+  decisionType: "approval" | "dispatch",
+) => {
+  const snapshotResponse = await request(app)
+    .post(`/missions/${missionId}/readiness/audit-snapshots`)
+    .send({ createdBy: "evidence-reviewer" });
+
+  expect(snapshotResponse.status).toBe(201);
+
+  const linkResponse = await request(app)
+    .post(`/missions/${missionId}/decision-evidence-links`)
+    .send({
+      snapshotId: snapshotResponse.body.snapshot.id,
+      decisionType,
+      createdBy: "evidence-reviewer",
+    });
+
+  expect(linkResponse.status).toBe(201);
+
+  return linkResponse.body.link as {
+    id: string;
+    auditEvidenceSnapshotId: string;
+    decisionType: "approval" | "dispatch";
+  };
+};
+
+const createPlanningApprovalHandoffTrace = async (
+  missionId: string,
+  link: { id: string; auditEvidenceSnapshotId: string },
+) => {
+  await pool.query(
+    `
+    insert into mission_planning_approval_handoffs (
+      id,
+      mission_id,
+      audit_evidence_snapshot_id,
+      mission_decision_evidence_link_id,
+      planning_review,
+      created_by
+    )
+    values ($1, $2, $3, $4, $5::jsonb, $6)
+    `,
+    [
+      randomUUID(),
+      missionId,
+      link.auditEvidenceSnapshotId,
+      link.id,
+      JSON.stringify({
+        missionId,
+        readyForApproval: true,
+        blockingReasons: [],
+        checklist: [
+          {
+            code: "MISSION_READY_FOR_APPROVAL",
+            passed: true,
+          },
+        ],
+      }),
+      "planning-lead",
+    ],
+  );
+};
+
+const createCompletedMission = async () => {
+  const { missionId } = await createReadyMission();
+  const approvalLink = await createDecisionEvidenceLink(missionId, "approval");
+  await createPlanningApprovalHandoffTrace(missionId, approvalLink);
+
+  const approveResponse = await request(app)
+    .post(`/missions/${missionId}/approve`)
+    .send({
+      reviewerId: "approver-1",
+      decisionEvidenceLinkId: approvalLink.id,
+      notes: "post-operation evidence test approval",
+    });
+  expect(approveResponse.status).toBe(204);
+
+  const dispatchLink = await createDecisionEvidenceLink(missionId, "dispatch");
+  const launchResponse = await request(app)
+    .post(`/missions/${missionId}/launch`)
+    .send({
+      operatorId: "operator-1",
+      vehicleId: "uav-1",
+      lat: 51.5074,
+      lng: -0.1278,
+      decisionEvidenceLinkId: dispatchLink.id,
+    });
+  expect(launchResponse.status).toBe(204);
+
+  const completeResponse = await request(app)
+    .post(`/missions/${missionId}/complete`)
+    .send({
+      operatorId: "operator-1",
+    });
+  expect(completeResponse.status).toBe(204);
+
+  return {
+    missionId,
+    approvalLink,
+    dispatchLink,
+  };
+};
+
 const countRows = async (missionId: string) => {
   const result = await pool.query(
     `
     select
+      (select status from missions where id = $1) as mission_status,
       (select count(*)::int from audit_evidence_snapshots where mission_id = $1) as snapshot_count,
+      (select count(*)::int from post_operation_evidence_snapshots where mission_id = $1) as post_operation_snapshot_count,
       (select count(*)::int from mission_decision_evidence_links where mission_id = $1) as decision_link_count,
       (select count(*)::int from mission_events where mission_id = $1) as mission_event_count,
       (select count(*)::int from mission_risk_inputs where mission_id = $1) as risk_input_count,
@@ -171,7 +278,9 @@ const countRows = async (missionId: string) => {
   );
 
   return result.rows[0] as {
+    mission_status: string;
     snapshot_count: number;
+    post_operation_snapshot_count: number;
     decision_link_count: number;
     mission_event_count: number;
     risk_input_count: number;
@@ -528,5 +637,161 @@ describe("audit evidence snapshots", () => {
 
     expect(listResponse.status).toBe(200);
     expect(listResponse.body.snapshots[0]).toEqual(beforeSnapshot);
+  });
+
+  it("captures post-operation completion evidence without mutating the mission", async () => {
+    const { missionId, approvalLink, dispatchLink } =
+      await createCompletedMission();
+    const before = await countRows(missionId);
+
+    const response = await request(app)
+      .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
+      .send({
+        createdBy: " accountable-manager ",
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.snapshot).toMatchObject({
+      missionId,
+      evidenceType: "post_operation_completion",
+      lifecycleState: "completed",
+      createdBy: "accountable-manager",
+      completionSnapshot: {
+        missionId,
+        status: "completed",
+        approvalEvent: {
+          type: "mission.approved",
+          details: {
+            decision_evidence_link_id: approvalLink.id,
+          },
+        },
+        launchEvent: {
+          type: "mission.launched",
+          details: {
+            decision_evidence_link_id: dispatchLink.id,
+            vehicle_id: "uav-1",
+          },
+        },
+        completionEvent: {
+          type: "mission.completed",
+          toState: "completed",
+        },
+        approvalEvidenceLink: {
+          id: approvalLink.id,
+          decisionType: "approval",
+        },
+        dispatchEvidenceLink: {
+          id: dispatchLink.id,
+          decisionType: "dispatch",
+        },
+        planningApprovalHandoff: {
+          missionDecisionEvidenceLinkId: approvalLink.id,
+          planningReview: {
+            readyForApproval: true,
+          },
+        },
+      },
+    });
+    expect(response.body.snapshot.id).toEqual(expect.any(String));
+    expect(response.body.snapshot.createdAt).toEqual(expect.any(String));
+    expect(response.body.snapshot.completionSnapshot.capturedAt).toEqual(
+      expect.any(String),
+    );
+
+    expect(await countRows(missionId)).toEqual({
+      ...before,
+      post_operation_snapshot_count:
+        before.post_operation_snapshot_count + 1,
+    });
+  });
+
+  it("keeps post-operation snapshots immutable when source events are later queried again", async () => {
+    const { missionId, approvalLink, dispatchLink } =
+      await createCompletedMission();
+
+    const snapshotResponse = await request(app)
+      .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
+      .send({});
+
+    expect(snapshotResponse.status).toBe(201);
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/post-operation/evidence-snapshots`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.snapshots).toHaveLength(1);
+    expect(listResponse.body.snapshots[0]).toEqual(snapshotResponse.body.snapshot);
+    expect(listResponse.body.snapshots[0].completionSnapshot).toMatchObject({
+      approvalEvidenceLink: {
+        id: approvalLink.id,
+      },
+      dispatchEvidenceLink: {
+        id: dispatchLink.id,
+      },
+      completionEvent: {
+        type: "mission.completed",
+      },
+    });
+  });
+
+  it("lists post-operation snapshots only for the requested mission", async () => {
+    const first = await createCompletedMission();
+    const second = await createCompletedMission();
+
+    const firstSnapshot = await request(app)
+      .post(`/missions/${first.missionId}/post-operation/evidence-snapshots`)
+      .send({ createdBy: "reviewer-a" });
+    const secondSnapshot = await request(app)
+      .post(`/missions/${second.missionId}/post-operation/evidence-snapshots`)
+      .send({ createdBy: "reviewer-b" });
+
+    expect(firstSnapshot.status).toBe(201);
+    expect(secondSnapshot.status).toBe(201);
+
+    const response = await request(app).get(
+      `/missions/${first.missionId}/post-operation/evidence-snapshots`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.snapshots).toHaveLength(1);
+    expect(response.body.snapshots[0]).toMatchObject({
+      missionId: first.missionId,
+      createdBy: "reviewer-a",
+    });
+  });
+
+  it("rejects post-operation evidence before mission completion", async () => {
+    const { missionId } = await createReadyMission();
+    const before = await countRows(missionId);
+
+    const response = await request(app)
+      .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
+      .send({});
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "mission_not_completed",
+      },
+    });
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("rejects invalid post-operation snapshot metadata", async () => {
+    const { missionId } = await createCompletedMission();
+
+    const response = await request(app)
+      .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
+      .send({
+        createdBy: 42,
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "audit_evidence_validation_failed",
+      },
+    });
   });
 });


### PR DESCRIPTION
Implements #37 by adding post-operation completion evidence snapshots for completed missions.

## What changed

- Added `post_operation_evidence_snapshots`.
- Added `POST /missions/:missionId/post-operation/evidence-snapshots`.
- Added `GET /missions/:missionId/post-operation/evidence-snapshots`.
- Completion snapshots preserve approval, launch, completion, approval evidence, dispatch evidence, and gate-ready planning handoff trace data.
- Rejects snapshot capture before mission completion with `409`.
- Adds integration tests for capture, immutability, mission isolation, invalid metadata, and incomplete mission rejection.

## Verification

- `npm ci`
- `.\node_modules\.bin\vitest.cmd run src/tests/audit-evidence.test.ts`
- `.\node_modules\.bin\vitest.cmd run src/tests/audit-evidence.test.ts src/tests/mission-planning.test.ts src/tests/mission-lifecycle.test.ts src/tests/mission.transition-matrix.integration.test.ts`
- `.\node_modules\.bin\vitest.cmd run`
- `git diff --check`
- `node scripts/check-next-build-step-pr.mjs origin/main`
- `node scripts/validate-save-point.mjs fsms-save-point.json`

Closes #37.
