### PR TITLE
Add post-operation audit export endpoint

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add migration-backed post-operation audit export endpoint so reviewable completion snapshots can be packaged for operators, accountable managers, or regulators.",
+ "nextBuildStep": "Add post-operation audit export rendering endpoint so completion evidence packages can be delivered as regulator-ready reports.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.controller.ts
+++ b/src/audit-evidence/audit-evidence.controller.ts
@@ -5,6 +5,10 @@ type MissionIdParams = {
   missionId: string;
 };
 
+type PostOperationSnapshotParams = MissionIdParams & {
+  snapshotId: string;
+};
+
 export class AuditEvidenceController {
   constructor(private readonly auditEvidenceService: AuditEvidenceService) {}
 
@@ -102,6 +106,23 @@ export class AuditEvidenceController {
           req.params.missionId,
         );
       res.status(200).json({ snapshots });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  exportPostOperationEvidenceSnapshot = async (
+    req: Request<PostOperationSnapshotParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const evidenceExport =
+        await this.auditEvidenceService.exportPostOperationEvidenceSnapshot(
+          req.params.missionId,
+          req.params.snapshotId,
+        );
+      res.status(200).json({ export: evidenceExport });
     } catch (error) {
       next(error);
     }

--- a/src/audit-evidence/audit-evidence.errors.ts
+++ b/src/audit-evidence/audit-evidence.errors.ts
@@ -31,3 +31,12 @@ export class AuditEvidenceMissionNotCompletedError extends Error {
     );
   }
 }
+
+export class PostOperationEvidenceSnapshotNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "POST_OPERATION_EVIDENCE_SNAPSHOT_NOT_FOUND";
+
+  constructor(snapshotId: string) {
+    super(`Post-operation evidence snapshot not found for mission: ${snapshotId}`);
+  }
+}

--- a/src/audit-evidence/audit-evidence.repository.ts
+++ b/src/audit-evidence/audit-evidence.repository.ts
@@ -446,6 +446,28 @@ export class AuditEvidenceRepository {
     return result.rows.map(toPostOperationEvidenceSnapshot);
   }
 
+  async getPostOperationEvidenceSnapshotForMission(
+    tx: PoolClient,
+    missionId: string,
+    snapshotId: string,
+  ): Promise<PostOperationEvidenceSnapshot | null> {
+    const result = await tx.query<PostOperationEvidenceSnapshotRow>(
+      `
+      select *
+      from post_operation_evidence_snapshots
+      where mission_id = $1
+        and id = $2
+        and evidence_type = 'post_operation_completion'
+      limit 1
+      `,
+      [missionId, snapshotId],
+    );
+
+    return result.rows[0]
+      ? toPostOperationEvidenceSnapshot(result.rows[0])
+      : null;
+  }
+
   async decisionEvidenceLinkReferencesReadinessSnapshot(
     tx: PoolClient,
     missionId: string,

--- a/src/audit-evidence/audit-evidence.routes.ts
+++ b/src/audit-evidence/audit-evidence.routes.ts
@@ -30,6 +30,10 @@ export function createAuditEvidenceRouter(
     "/:missionId/post-operation/evidence-snapshots",
     controller.listPostOperationEvidenceSnapshots,
   );
+  router.get(
+    "/:missionId/post-operation/evidence-snapshots/:snapshotId/export",
+    controller.exportPostOperationEvidenceSnapshot,
+  );
 
   return router;
 }

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -4,6 +4,7 @@ import {
   AuditEvidenceMissionNotCompletedError,
   AuditEvidenceMissionNotFoundError,
   AuditEvidenceSnapshotNotFoundError,
+  PostOperationEvidenceSnapshotNotFoundError,
 } from "./audit-evidence.errors";
 import { AuditEvidenceRepository } from "./audit-evidence.repository";
 import type {
@@ -14,6 +15,7 @@ import type {
   MissionDecisionEvidenceLink,
   MissionLifecycleEvidenceEvent,
   PostOperationCompletionSnapshot,
+  PostOperationEvidenceExportPackage,
   PostOperationEvidenceSnapshot,
 } from "./audit-evidence.types";
 import {
@@ -213,6 +215,50 @@ export class AuditEvidenceService {
         client,
         missionId,
       );
+    } finally {
+      client.release();
+    }
+  }
+
+  async exportPostOperationEvidenceSnapshot(
+    missionId: string,
+    snapshotId: string,
+  ): Promise<PostOperationEvidenceExportPackage> {
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.auditEvidenceRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new AuditEvidenceMissionNotFoundError(missionId);
+      }
+
+      const snapshot =
+        await this.auditEvidenceRepository.getPostOperationEvidenceSnapshotForMission(
+          client,
+          missionId,
+          snapshotId,
+        );
+
+      if (!snapshot) {
+        throw new PostOperationEvidenceSnapshotNotFoundError(snapshotId);
+      }
+
+      return {
+        exportType: "post_operation_completion_evidence",
+        formatVersion: 1,
+        generatedAt: new Date().toISOString(),
+        missionId: snapshot.missionId,
+        snapshotId: snapshot.id,
+        evidenceType: snapshot.evidenceType,
+        lifecycleState: snapshot.lifecycleState,
+        createdBy: snapshot.createdBy,
+        createdAt: snapshot.createdAt,
+        completionSnapshot: snapshot.completionSnapshot,
+      };
     } finally {
       client.release();
     }

--- a/src/audit-evidence/audit-evidence.types.ts
+++ b/src/audit-evidence/audit-evidence.types.ts
@@ -89,3 +89,16 @@ export interface PostOperationEvidenceSnapshot {
   createdBy: string | null;
   createdAt: string;
 }
+
+export interface PostOperationEvidenceExportPackage {
+  exportType: "post_operation_completion_evidence";
+  formatVersion: 1;
+  generatedAt: string;
+  missionId: string;
+  snapshotId: string;
+  evidenceType: PostOperationEvidenceType;
+  lifecycleState: string;
+  createdBy: string | null;
+  createdAt: string;
+  completionSnapshot: PostOperationCompletionSnapshot;
+}

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -794,4 +794,113 @@ describe("audit evidence snapshots", () => {
       },
     });
   });
+
+  it("exports a post-operation evidence package without mutating audit state", async () => {
+    const { missionId, approvalLink, dispatchLink } =
+      await createCompletedMission();
+    const snapshotResponse = await request(app)
+      .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
+      .send({ createdBy: "accountable-manager" });
+
+    expect(snapshotResponse.status).toBe(201);
+    const before = await countRows(missionId);
+
+    const response = await request(app).get(
+      `/missions/${missionId}/post-operation/evidence-snapshots/${snapshotResponse.body.snapshot.id}/export`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.export).toMatchObject({
+      exportType: "post_operation_completion_evidence",
+      formatVersion: 1,
+      missionId,
+      snapshotId: snapshotResponse.body.snapshot.id,
+      evidenceType: "post_operation_completion",
+      lifecycleState: "completed",
+      createdBy: "accountable-manager",
+      createdAt: snapshotResponse.body.snapshot.createdAt,
+      completionSnapshot: {
+        missionId,
+        status: "completed",
+        approvalEvent: {
+          details: {
+            decision_evidence_link_id: approvalLink.id,
+          },
+        },
+        launchEvent: {
+          details: {
+            decision_evidence_link_id: dispatchLink.id,
+          },
+        },
+        completionEvent: {
+          type: "mission.completed",
+        },
+        approvalEvidenceLink: {
+          id: approvalLink.id,
+        },
+        dispatchEvidenceLink: {
+          id: dispatchLink.id,
+        },
+        planningApprovalHandoff: {
+          missionDecisionEvidenceLinkId: approvalLink.id,
+        },
+      },
+    });
+    expect(response.body.export.generatedAt).toEqual(expect.any(String));
+    expect(response.body.export.completionSnapshot).toEqual(
+      snapshotResponse.body.snapshot.completionSnapshot,
+    );
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("does not export post-operation snapshots from another mission", async () => {
+    const first = await createCompletedMission();
+    const second = await createCompletedMission();
+    const secondSnapshot = await request(app)
+      .post(`/missions/${second.missionId}/post-operation/evidence-snapshots`)
+      .send({});
+
+    expect(secondSnapshot.status).toBe(201);
+    const firstBefore = await countRows(first.missionId);
+    const secondBefore = await countRows(second.missionId);
+
+    const response = await request(app).get(
+      `/missions/${first.missionId}/post-operation/evidence-snapshots/${secondSnapshot.body.snapshot.id}/export`,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "post_operation_evidence_snapshot_not_found",
+      },
+    });
+    expect(await countRows(first.missionId)).toEqual(firstBefore);
+    expect(await countRows(second.missionId)).toEqual(secondBefore);
+  });
+
+  it("returns 404 for unknown post-operation export missions and snapshots", async () => {
+    const { missionId } = await createCompletedMission();
+    const before = await countRows(missionId);
+
+    const missingSnapshotResponse = await request(app).get(
+      `/missions/${missionId}/post-operation/evidence-snapshots/${randomUUID()}/export`,
+    );
+    const missingMissionResponse = await request(app).get(
+      `/missions/${randomUUID()}/post-operation/evidence-snapshots/${randomUUID()}/export`,
+    );
+
+    expect(missingSnapshotResponse.status).toBe(404);
+    expect(missingSnapshotResponse.body).toMatchObject({
+      error: {
+        type: "post_operation_evidence_snapshot_not_found",
+      },
+    });
+    expect(missingMissionResponse.status).toBe(404);
+    expect(missingMissionResponse.body).toMatchObject({
+      error: {
+        type: "mission_not_found",
+      },
+    });
+    expect(await countRows(missionId)).toEqual(before);
+  });
 });


### PR DESCRIPTION
Implements #39 by adding a mission-scoped post-operation audit export endpoint backed by the stored completion evidence snapshot.

## What changed

- Added `GET /missions/:missionId/post-operation/evidence-snapshots/:snapshotId/export`.
- Added a stable JSON export package with `exportType`, `formatVersion`, `generatedAt`, mission/snapshot metadata, and the stored completion snapshot.
- Added repository/service/controller support for mission-scoped post-operation snapshot lookup.
- Added a dedicated 404 error for missing or cross-mission post-operation snapshots.
- Kept the export path read-only: it packages existing evidence and does not recalculate readiness, mutate mission state, append lifecycle events, or alter evidence rows.
- Updated the next build step toward regulator-ready rendered audit reports.

## Verification

- `npm ci`
- `.\node_modules\.bin\vitest.cmd run src/tests/audit-evidence.test.ts`
- `.\node_modules\.bin\vitest.cmd run src/tests/audit-evidence.test.ts src/tests/mission-planning.test.ts src/tests/mission-lifecycle.test.ts src/tests/mission.transition-matrix.integration.test.ts`
- `.\node_modules\.bin\vitest.cmd run`
- `git diff --check`
- `node scripts/check-next-build-step-pr.mjs origin/main`
- `node scripts/validate-save-point.mjs fsms-save-point.json`

Closes #39.
