### PR TITLE
Add post-operation audit render endpoint

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add post-operation audit export rendering endpoint so completion evidence packages can be delivered as regulator-ready reports.",
+ "nextBuildStep": "Add post-operation audit PDF generation endpoint so rendered completion reports can be downloaded for regulator review.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.controller.ts
+++ b/src/audit-evidence/audit-evidence.controller.ts
@@ -127,4 +127,21 @@ export class AuditEvidenceController {
       next(error);
     }
   };
+
+  renderPostOperationEvidenceSnapshot = async (
+    req: Request<PostOperationSnapshotParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const report =
+        await this.auditEvidenceService.renderPostOperationEvidenceSnapshot(
+          req.params.missionId,
+          req.params.snapshotId,
+        );
+      res.status(200).json({ report });
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/audit-evidence/audit-evidence.routes.ts
+++ b/src/audit-evidence/audit-evidence.routes.ts
@@ -34,6 +34,10 @@ export function createAuditEvidenceRouter(
     "/:missionId/post-operation/evidence-snapshots/:snapshotId/export",
     controller.exportPostOperationEvidenceSnapshot,
   );
+  router.get(
+    "/:missionId/post-operation/evidence-snapshots/:snapshotId/export/render",
+    controller.renderPostOperationEvidenceSnapshot,
+  );
 
   return router;
 }

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -9,6 +9,7 @@ import {
 import { AuditEvidenceRepository } from "./audit-evidence.repository";
 import type {
   AuditEvidenceSnapshot,
+  AuditReportSection,
   CreateAuditEvidenceSnapshotInput,
   CreateMissionDecisionEvidenceLinkInput,
   CreatePostOperationEvidenceSnapshotInput,
@@ -16,6 +17,7 @@ import type {
   MissionLifecycleEvidenceEvent,
   PostOperationCompletionSnapshot,
   PostOperationEvidenceExportPackage,
+  PostOperationEvidenceRenderedReport,
   PostOperationEvidenceSnapshot,
 } from "./audit-evidence.types";
 import {
@@ -264,6 +266,29 @@ export class AuditEvidenceService {
     }
   }
 
+  async renderPostOperationEvidenceSnapshot(
+    missionId: string,
+    snapshotId: string,
+  ): Promise<PostOperationEvidenceRenderedReport> {
+    const evidenceExport = await this.exportPostOperationEvidenceSnapshot(
+      missionId,
+      snapshotId,
+    );
+    const sections = this.buildPostOperationReportSections(evidenceExport);
+
+    return {
+      renderType: "post_operation_completion_evidence_report",
+      formatVersion: 1,
+      generatedAt: new Date().toISOString(),
+      sourceExport: evidenceExport,
+      report: {
+        title: `Post-operation completion evidence for mission ${evidenceExport.missionId}`,
+        sections,
+        plainText: this.renderSectionsAsPlainText(sections),
+      },
+    };
+  }
+
   private async buildPostOperationCompletionSnapshot(
     client: Awaited<ReturnType<Pool["connect"]>>,
     mission: { missionId: string; missionPlanId: string | null; status: string },
@@ -331,5 +356,142 @@ export class AuditEvidenceService {
     return typeof linkId === "string" && linkId.trim().length > 0
       ? linkId
       : null;
+  }
+
+  private buildPostOperationReportSections(
+    evidenceExport: PostOperationEvidenceExportPackage,
+  ): AuditReportSection[] {
+    const snapshot = evidenceExport.completionSnapshot;
+
+    return [
+      {
+        heading: "Evidence package",
+        fields: [
+          { label: "Mission ID", value: evidenceExport.missionId },
+          { label: "Snapshot ID", value: evidenceExport.snapshotId },
+          { label: "Evidence type", value: evidenceExport.evidenceType },
+          { label: "Lifecycle state", value: evidenceExport.lifecycleState },
+          { label: "Snapshot created by", value: evidenceExport.createdBy },
+          { label: "Snapshot created at", value: evidenceExport.createdAt },
+          { label: "Export generated at", value: evidenceExport.generatedAt },
+        ],
+      },
+      {
+        heading: "Mission completion",
+        fields: [
+          { label: "Mission plan ID", value: snapshot.missionPlanId },
+          { label: "Completion status", value: snapshot.status },
+          { label: "Evidence captured at", value: snapshot.capturedAt },
+          {
+            label: "Completion event sequence",
+            value: snapshot.completionEvent?.sequence ?? null,
+          },
+          {
+            label: "Completion event summary",
+            value: snapshot.completionEvent?.summary ?? null,
+          },
+        ],
+      },
+      {
+        heading: "Approval evidence",
+        fields: [
+          {
+            label: "Approval event sequence",
+            value: snapshot.approvalEvent?.sequence ?? null,
+          },
+          {
+            label: "Approval event actor",
+            value: snapshot.approvalEvent?.actorId ?? null,
+          },
+          {
+            label: "Approval evidence link ID",
+            value: snapshot.approvalEvidenceLink?.id ?? null,
+          },
+          {
+            label: "Planning handoff ID",
+            value: snapshot.planningApprovalHandoff?.id ?? null,
+          },
+          {
+            label: "Planning handoff ready",
+            value:
+              typeof snapshot.planningApprovalHandoff?.planningReview
+                .readyForApproval === "boolean"
+                ? snapshot.planningApprovalHandoff.planningReview
+                    .readyForApproval
+                : null,
+          },
+        ],
+      },
+      {
+        heading: "Dispatch and launch evidence",
+        fields: [
+          {
+            label: "Launch event sequence",
+            value: snapshot.launchEvent?.sequence ?? null,
+          },
+          {
+            label: "Launch event actor",
+            value: snapshot.launchEvent?.actorId ?? null,
+          },
+          {
+            label: "Dispatch evidence link ID",
+            value: snapshot.dispatchEvidenceLink?.id ?? null,
+          },
+          {
+            label: "Vehicle ID",
+            value: this.getStringDetail(snapshot.launchEvent, "vehicle_id"),
+          },
+          {
+            label: "Launch site",
+            value: this.renderLaunchSite(snapshot.launchEvent),
+          },
+        ],
+      },
+    ];
+  }
+
+  private renderSectionsAsPlainText(
+    sections: AuditReportSection[],
+  ): string {
+    return sections
+      .map((section) => {
+        const fields = section.fields
+          .map((field) => `${field.label}: ${field.value ?? "Not recorded"}`)
+          .join("\n");
+
+        return `${section.heading}\n${fields}`;
+      })
+      .join("\n\n");
+  }
+
+  private getStringDetail(
+    event: MissionLifecycleEvidenceEvent | null,
+    key: string,
+  ): string | null {
+    const value = event?.details[key];
+    return typeof value === "string" ? value : null;
+  }
+
+  private renderLaunchSite(
+    event: MissionLifecycleEvidenceEvent | null,
+  ): string | null {
+    const launchSite = event?.details.launch_site;
+
+    if (
+      !launchSite ||
+      typeof launchSite !== "object" ||
+      !("lat" in launchSite) ||
+      !("lng" in launchSite)
+    ) {
+      return null;
+    }
+
+    const site = launchSite as { lat?: unknown; lng?: unknown };
+
+    if (typeof site.lat !== "number" || typeof site.lng !== "number") {
+      return null;
+    }
+
+    return `${site.lat}, ${site.lng}`;
   }
 }

--- a/src/audit-evidence/audit-evidence.types.ts
+++ b/src/audit-evidence/audit-evidence.types.ts
@@ -102,3 +102,25 @@ export interface PostOperationEvidenceExportPackage {
   createdAt: string;
   completionSnapshot: PostOperationCompletionSnapshot;
 }
+
+export interface AuditReportField {
+  label: string;
+  value: string | number | boolean | null;
+}
+
+export interface AuditReportSection {
+  heading: string;
+  fields: AuditReportField[];
+}
+
+export interface PostOperationEvidenceRenderedReport {
+  renderType: "post_operation_completion_evidence_report";
+  formatVersion: 1;
+  generatedAt: string;
+  sourceExport: PostOperationEvidenceExportPackage;
+  report: {
+    title: string;
+    sections: AuditReportSection[];
+    plainText: string;
+  };
+}

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -903,4 +903,128 @@ describe("audit evidence snapshots", () => {
     });
     expect(await countRows(missionId)).toEqual(before);
   });
+
+  it("renders a regulator-ready post-operation report without mutating audit state", async () => {
+    const { missionId, approvalLink, dispatchLink } =
+      await createCompletedMission();
+    const snapshotResponse = await request(app)
+      .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
+      .send({ createdBy: "accountable-manager" });
+
+    expect(snapshotResponse.status).toBe(201);
+    const before = await countRows(missionId);
+
+    const response = await request(app).get(
+      `/missions/${missionId}/post-operation/evidence-snapshots/${snapshotResponse.body.snapshot.id}/export/render`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.report).toMatchObject({
+      renderType: "post_operation_completion_evidence_report",
+      formatVersion: 1,
+      sourceExport: {
+        exportType: "post_operation_completion_evidence",
+        missionId,
+        snapshotId: snapshotResponse.body.snapshot.id,
+        completionSnapshot: snapshotResponse.body.snapshot.completionSnapshot,
+      },
+      report: {
+        title: `Post-operation completion evidence for mission ${missionId}`,
+        sections: [
+          {
+            heading: "Evidence package",
+            fields: expect.arrayContaining([
+              { label: "Mission ID", value: missionId },
+              {
+                label: "Snapshot ID",
+                value: snapshotResponse.body.snapshot.id,
+              },
+              { label: "Lifecycle state", value: "completed" },
+            ]),
+          },
+          {
+            heading: "Mission completion",
+            fields: expect.arrayContaining([
+              { label: "Completion status", value: "completed" },
+              { label: "Completion event summary", value: "Mission completed" },
+            ]),
+          },
+          {
+            heading: "Approval evidence",
+            fields: expect.arrayContaining([
+              { label: "Approval evidence link ID", value: approvalLink.id },
+              { label: "Planning handoff ready", value: true },
+            ]),
+          },
+          {
+            heading: "Dispatch and launch evidence",
+            fields: expect.arrayContaining([
+              { label: "Dispatch evidence link ID", value: dispatchLink.id },
+              { label: "Vehicle ID", value: "uav-1" },
+              { label: "Launch site", value: "51.5074, -0.1278" },
+            ]),
+          },
+        ],
+      },
+    });
+    expect(response.body.report.generatedAt).toEqual(expect.any(String));
+    expect(response.body.report.report.plainText).toContain(
+      `Mission ID: ${missionId}`,
+    );
+    expect(response.body.report.report.plainText).toContain(
+      `Dispatch evidence link ID: ${dispatchLink.id}`,
+    );
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("does not render post-operation reports for snapshots from another mission", async () => {
+    const first = await createCompletedMission();
+    const second = await createCompletedMission();
+    const secondSnapshot = await request(app)
+      .post(`/missions/${second.missionId}/post-operation/evidence-snapshots`)
+      .send({});
+
+    expect(secondSnapshot.status).toBe(201);
+    const firstBefore = await countRows(first.missionId);
+    const secondBefore = await countRows(second.missionId);
+
+    const response = await request(app).get(
+      `/missions/${first.missionId}/post-operation/evidence-snapshots/${secondSnapshot.body.snapshot.id}/export/render`,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "post_operation_evidence_snapshot_not_found",
+      },
+    });
+    expect(await countRows(first.missionId)).toEqual(firstBefore);
+    expect(await countRows(second.missionId)).toEqual(secondBefore);
+  });
+
+  it("returns 404 for unknown post-operation report missions and snapshots", async () => {
+    const { missionId } = await createCompletedMission();
+    const before = await countRows(missionId);
+
+    const missingSnapshotResponse = await request(app).get(
+      `/missions/${missionId}/post-operation/evidence-snapshots/${randomUUID()}/export/render`,
+    );
+    const missingMissionResponse = await request(app).get(
+      `/missions/${randomUUID()}/post-operation/evidence-snapshots/${randomUUID()}/export/render`,
+    );
+
+    expect(missingSnapshotResponse.status).toBe(404);
+    expect(missingSnapshotResponse.body).toMatchObject({
+      error: {
+        type: "post_operation_evidence_snapshot_not_found",
+      },
+    });
+    expect(missingMissionResponse.status).toBe(404);
+    expect(missingMissionResponse.body).toMatchObject({
+      error: {
+        type: "mission_not_found",
+      },
+    });
+    expect(await countRows(missionId)).toEqual(before);
+  });
 });


### PR DESCRIPTION
Implements #41 by adding a rendered, regulator-ready presentation layer for post-operation completion evidence export packages.

## What changed

- Added `GET /missions/:missionId/post-operation/evidence-snapshots/:snapshotId/export/render`.
- Added a rendered report response with `renderType`, `formatVersion`, `generatedAt`, the source export package, structured report sections, and plain text output.
- The report includes mission/snapshot metadata, lifecycle state, completion event, approval event, launch event, approval evidence link, dispatch evidence link, vehicle id, launch site, and planning handoff readiness trace.
- Rendering uses the existing stored export package as the source of truth and does not recalculate readiness, lifecycle, or decision evidence.
- Kept rendering read-only: it does not mutate mission state, lifecycle events, evidence snapshots, or decision evidence links.
- Updated the next build step toward PDF generation for regulator review.

## Verification

- `npm ci`
- `.\node_modules\.bin\vitest.cmd run src/tests/audit-evidence.test.ts`
- `.\node_modules\.bin\vitest.cmd run src/tests/audit-evidence.test.ts src/tests/mission-planning.test.ts src/tests/mission-lifecycle.test.ts src/tests/mission.transition-matrix.integration.test.ts`
- `.\node_modules\.bin\vitest.cmd run`
- `git diff --check`
- `node scripts/check-next-build-step-pr.mjs origin/main`
- `node scripts/validate-save-point.mjs fsms-save-point.json`

Closes #41.
