### PR TITLE
Add post-operation audit PDF generation endpoint

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add post-operation audit PDF generation endpoint so rendered completion reports can be downloaded for regulator review.",
+ "nextBuildStep": "Add accountable-manager signature block to post-operation audit PDF reports for formal review sign-off.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.controller.ts
+++ b/src/audit-evidence/audit-evidence.controller.ts
@@ -144,4 +144,29 @@ export class AuditEvidenceController {
       next(error);
     }
   };
+
+  generatePostOperationEvidencePdf = async (
+    req: Request<PostOperationSnapshotParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const pdf =
+        await this.auditEvidenceService.generatePostOperationEvidencePdf(
+          req.params.missionId,
+          req.params.snapshotId,
+        );
+      res
+        .status(200)
+        .setHeader("Content-Type", pdf.contentType)
+        .setHeader(
+          "Content-Disposition",
+          `attachment; filename="${pdf.fileName}"`,
+        )
+        .setHeader("Content-Length", pdf.content.byteLength.toString())
+        .send(pdf.content);
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/audit-evidence/audit-evidence.routes.ts
+++ b/src/audit-evidence/audit-evidence.routes.ts
@@ -38,6 +38,10 @@ export function createAuditEvidenceRouter(
     "/:missionId/post-operation/evidence-snapshots/:snapshotId/export/render",
     controller.renderPostOperationEvidenceSnapshot,
   );
+  router.get(
+    "/:missionId/post-operation/evidence-snapshots/:snapshotId/export/render/pdf",
+    controller.generatePostOperationEvidencePdf,
+  );
 
   return router;
 }

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -17,6 +17,7 @@ import type {
   MissionLifecycleEvidenceEvent,
   PostOperationCompletionSnapshot,
   PostOperationEvidenceExportPackage,
+  PostOperationEvidencePdf,
   PostOperationEvidenceRenderedReport,
   PostOperationEvidenceSnapshot,
 } from "./audit-evidence.types";
@@ -289,6 +290,27 @@ export class AuditEvidenceService {
     };
   }
 
+  async generatePostOperationEvidencePdf(
+    missionId: string,
+    snapshotId: string,
+  ): Promise<PostOperationEvidencePdf> {
+    const renderedReport = await this.renderPostOperationEvidenceSnapshot(
+      missionId,
+      snapshotId,
+    );
+    const content = this.buildSimplePdf([
+      renderedReport.report.title,
+      "",
+      renderedReport.report.plainText,
+    ]);
+
+    return {
+      fileName: `mission-${missionId}-post-operation-evidence-${snapshotId}.pdf`,
+      contentType: "application/pdf",
+      content,
+    };
+  }
+
   private async buildPostOperationCompletionSnapshot(
     client: Awaited<ReturnType<Pool["connect"]>>,
     mission: { missionId: string; missionPlanId: string | null; status: string },
@@ -493,5 +515,72 @@ export class AuditEvidenceService {
     }
 
     return `${site.lat}, ${site.lng}`;
+  }
+
+  private buildSimplePdf(blocks: string[]): Buffer {
+    const lines = blocks
+      .join("\n")
+      .split("\n")
+      .flatMap((line) => this.wrapPdfText(line, 92));
+    const textCommands = lines
+      .map((line, index) => {
+        const operator = index === 0 ? "Td" : "T*";
+        const leading = index === 0 ? "72 760" : "";
+        return `${leading} ${operator} (${this.escapePdfText(line)}) Tj`.trim();
+      })
+      .join("\n");
+    const stream = `BT\n/F1 10 Tf\n12 TL\n${textCommands}\nET`;
+    const objects = [
+      "<< /Type /Catalog /Pages 2 0 R >>",
+      "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+      "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+      "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+      `<< /Length ${Buffer.byteLength(stream, "latin1")} >>\nstream\n${stream}\nendstream`,
+    ];
+    let pdf = "%PDF-1.4\n";
+    const offsets = [0];
+
+    objects.forEach((object, index) => {
+      offsets.push(Buffer.byteLength(pdf, "latin1"));
+      pdf += `${index + 1} 0 obj\n${object}\nendobj\n`;
+    });
+
+    const xrefOffset = Buffer.byteLength(pdf, "latin1");
+    pdf += `xref\n0 ${objects.length + 1}\n`;
+    pdf += "0000000000 65535 f \n";
+    pdf += offsets
+      .slice(1)
+      .map((offset) => `${String(offset).padStart(10, "0")} 00000 n \n`)
+      .join("");
+    pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n`;
+    pdf += `startxref\n${xrefOffset}\n%%EOF\n`;
+
+    return Buffer.from(pdf, "latin1");
+  }
+
+  private wrapPdfText(line: string, maxLength: number): string[] {
+    if (line.length <= maxLength) {
+      return [line];
+    }
+
+    const wrapped: string[] = [];
+    let remaining = line;
+
+    while (remaining.length > maxLength) {
+      const breakAt = remaining.lastIndexOf(" ", maxLength);
+      const splitAt = breakAt > 0 ? breakAt : maxLength;
+      wrapped.push(remaining.slice(0, splitAt));
+      remaining = remaining.slice(splitAt).trimStart();
+    }
+
+    wrapped.push(remaining);
+    return wrapped;
+  }
+
+  private escapePdfText(value: string): string {
+    return value
+      .replace(/\\/g, "\\\\")
+      .replace(/\(/g, "\\(")
+      .replace(/\)/g, "\\)");
   }
 }

--- a/src/audit-evidence/audit-evidence.types.ts
+++ b/src/audit-evidence/audit-evidence.types.ts
@@ -124,3 +124,9 @@ export interface PostOperationEvidenceRenderedReport {
     plainText: string;
   };
 }
+
+export interface PostOperationEvidencePdf {
+  fileName: string;
+  contentType: "application/pdf";
+  content: Buffer;
+}

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -4,6 +4,14 @@ import request from "supertest";
 import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
+const parseBinaryResponse = (res: NodeJS.ReadableStream, callback: (error: Error | null, body?: Buffer) => void) => {
+  const chunks: Buffer[] = [];
+
+  res.on("data", (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+  res.on("end", () => callback(null, Buffer.concat(chunks)));
+  res.on("error", (error: Error) => callback(error));
+};
+
 const clearTables = async () => {
   await pool.query("delete from post_operation_evidence_snapshots");
   await pool.query("delete from mission_planning_approval_handoffs");
@@ -1011,6 +1019,90 @@ describe("audit evidence snapshots", () => {
     );
     const missingMissionResponse = await request(app).get(
       `/missions/${randomUUID()}/post-operation/evidence-snapshots/${randomUUID()}/export/render`,
+    );
+
+    expect(missingSnapshotResponse.status).toBe(404);
+    expect(missingSnapshotResponse.body).toMatchObject({
+      error: {
+        type: "post_operation_evidence_snapshot_not_found",
+      },
+    });
+    expect(missingMissionResponse.status).toBe(404);
+    expect(missingMissionResponse.body).toMatchObject({
+      error: {
+        type: "mission_not_found",
+      },
+    });
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("generates a post-operation audit PDF download without mutating audit state", async () => {
+    const { missionId, dispatchLink } = await createCompletedMission();
+    const snapshotResponse = await request(app)
+      .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
+      .send({ createdBy: "accountable-manager" });
+
+    expect(snapshotResponse.status).toBe(201);
+    const before = await countRows(missionId);
+
+    const response = await request(app)
+      .get(
+        `/missions/${missionId}/post-operation/evidence-snapshots/${snapshotResponse.body.snapshot.id}/export/render/pdf`,
+      )
+      .buffer(true)
+      .parse(parseBinaryResponse);
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("application/pdf");
+    expect(response.headers["content-disposition"]).toContain("attachment");
+    expect(response.headers["content-disposition"]).toContain(
+      `mission-${missionId}-post-operation-evidence-${snapshotResponse.body.snapshot.id}.pdf`,
+    );
+    expect(Buffer.isBuffer(response.body)).toBe(true);
+    expect(response.body.toString("latin1", 0, 8)).toBe("%PDF-1.4");
+    expect(response.body.toString("latin1")).toContain(
+      `Post-operation completion evidence for mission ${missionId}`,
+    );
+    expect(response.body.toString("latin1")).toContain(
+      `Dispatch evidence link ID: ${dispatchLink.id}`,
+    );
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("does not generate PDFs for post-operation snapshots from another mission", async () => {
+    const first = await createCompletedMission();
+    const second = await createCompletedMission();
+    const secondSnapshot = await request(app)
+      .post(`/missions/${second.missionId}/post-operation/evidence-snapshots`)
+      .send({});
+
+    expect(secondSnapshot.status).toBe(201);
+    const firstBefore = await countRows(first.missionId);
+    const secondBefore = await countRows(second.missionId);
+
+    const response = await request(app).get(
+      `/missions/${first.missionId}/post-operation/evidence-snapshots/${secondSnapshot.body.snapshot.id}/export/render/pdf`,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "post_operation_evidence_snapshot_not_found",
+      },
+    });
+    expect(await countRows(first.missionId)).toEqual(firstBefore);
+    expect(await countRows(second.missionId)).toEqual(secondBefore);
+  });
+
+  it("returns 404 for unknown post-operation PDF missions and snapshots", async () => {
+    const { missionId } = await createCompletedMission();
+    const before = await countRows(missionId);
+
+    const missingSnapshotResponse = await request(app).get(
+      `/missions/${missionId}/post-operation/evidence-snapshots/${randomUUID()}/export/render/pdf`,
+    );
+    const missingMissionResponse = await request(app).get(
+      `/missions/${randomUUID()}/post-operation/evidence-snapshots/${randomUUID()}/export/render/pdf`,
     );
 
     expect(missingSnapshotResponse.status).toBe(404);


### PR DESCRIPTION
Implements #43 by adding a downloadable PDF artifact for rendered post-operation completion audit reports.

## What changed

- Added `GET /missions/:missionId/post-operation/evidence-snapshots/:snapshotId/export/render/pdf`.
- Added a dependency-free PDF generator that uses the existing rendered report as the source of truth.
- The PDF download includes the rendered post-operation report title and report fields, including mission/snapshot metadata, completion state, approval evidence, dispatch evidence, vehicle id, launch site, and planning handoff readiness.
- Added attachment response headers with a stable mission/snapshot-scoped filename.
- Kept PDF generation read-only: it does not mutate mission state, lifecycle events, evidence snapshots, decision evidence links, export packages, or rendered report data.
- Updated the next build step toward accountable-manager sign-off blocks.

## Verification

- `npm ci`
- `.\node_modules\.bin\vitest.cmd run src/tests/audit-evidence.test.ts`
- `.\node_modules\.bin\vitest.cmd run src/tests/audit-evidence.test.ts src/tests/mission-planning.test.ts src/tests/mission-lifecycle.test.ts src/tests/mission.transition-matrix.integration.test.ts`
- `.\node_modules\.bin\vitest.cmd run`
- `git diff --check`
- `node scripts/check-next-build-step-pr.mjs origin/main`
- `node scripts/validate-save-point.mjs fsms-save-point.json`

Closes #43.
