### PR TITLE
Add accountable-manager signature block to post-operation audit PDF reports

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add accountable-manager signature block to post-operation audit PDF reports for formal review sign-off.",
+ "nextBuildStep": "Add accountable-manager sign-off record migration so formal post-operation PDF approvals can be stored and audited.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -469,6 +469,16 @@ export class AuditEvidenceService {
           },
         ],
       },
+      {
+        heading: "Accountable manager sign-off",
+        fields: [
+          { label: "Accountable manager name", value: "Pending sign-off" },
+          { label: "Role/title", value: "Pending sign-off" },
+          { label: "Signature", value: "Pending sign-off" },
+          { label: "Signed date/time", value: "Pending sign-off" },
+          { label: "Review decision/status", value: "Pending sign-off" },
+        ],
+      },
     ];
   }
 

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -972,6 +972,22 @@ describe("audit evidence snapshots", () => {
               { label: "Launch site", value: "51.5074, -0.1278" },
             ]),
           },
+          {
+            heading: "Accountable manager sign-off",
+            fields: [
+              {
+                label: "Accountable manager name",
+                value: "Pending sign-off",
+              },
+              { label: "Role/title", value: "Pending sign-off" },
+              { label: "Signature", value: "Pending sign-off" },
+              { label: "Signed date/time", value: "Pending sign-off" },
+              {
+                label: "Review decision/status",
+                value: "Pending sign-off",
+              },
+            ],
+          },
         ],
       },
     });
@@ -981,6 +997,12 @@ describe("audit evidence snapshots", () => {
     );
     expect(response.body.report.report.plainText).toContain(
       `Dispatch evidence link ID: ${dispatchLink.id}`,
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Accountable manager sign-off",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Review decision/status: Pending sign-off",
     );
     expect(await countRows(missionId)).toEqual(before);
   });
@@ -1065,6 +1087,21 @@ describe("audit evidence snapshots", () => {
     );
     expect(response.body.toString("latin1")).toContain(
       `Dispatch evidence link ID: ${dispatchLink.id}`,
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Accountable manager sign-off",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Accountable manager name: Pending sign-off",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Signature: Pending sign-off",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Signed date/time: Pending sign-off",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Review decision/status: Pending sign-off",
     );
     expect(await countRows(missionId)).toEqual(before);
   });


### PR DESCRIPTION
Implements #45 by adding an accountable-manager sign-off block to post-operation audit reports and their generated PDFs.

## What changed

- Added an `Accountable manager sign-off` section to the rendered post-operation audit report.
- The sign-off section reserves stable fields for accountable manager name, role/title, signature, signed date/time, and review decision/status.
- Because PDFs are generated from the rendered report, the sign-off block is now included in the PDF download artifact without introducing separate sign-off storage.
- Kept the change read-only: no mission state, lifecycle event, evidence snapshot, decision link, export package, rendered report, or sign-off record mutation is introduced.
- Updated the next build step toward a sign-off record migration for formal stored approvals.

## Verification

- `npm ci`
- `.\node_modules\.bin\vitest.cmd run src/tests/audit-evidence.test.ts`
- `.\node_modules\.bin\vitest.cmd run src/tests/audit-evidence.test.ts src/tests/mission-planning.test.ts src/tests/mission-lifecycle.test.ts src/tests/mission.transition-matrix.integration.test.ts`
- `.\node_modules\.bin\vitest.cmd run`
- `git diff --check`
- `node scripts/check-next-build-step-pr.mjs origin/main`
- `node scripts/validate-save-point.mjs fsms-save-point.json`

Closes #45.
