### PR TITLE
Add accountable manager signoff endpoint

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add migration-backed accountable-manager sign-off creation endpoint so formal post-operation PDF approvals can be recorded.",
+ "nextBuildStep": "Connect stored accountable-manager sign-offs into rendered and PDF post-operation audit reports.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.controller.ts
+++ b/src/audit-evidence/audit-evidence.controller.ts
@@ -169,4 +169,22 @@ export class AuditEvidenceController {
       next(error);
     }
   };
+
+  createPostOperationAuditSignoff = async (
+    req: Request<PostOperationSnapshotParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const signoff =
+        await this.auditEvidenceService.createPostOperationAuditSignoff(
+          req.params.missionId,
+          req.params.snapshotId,
+          req.body,
+        );
+      res.status(201).json({ signoff });
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/audit-evidence/audit-evidence.errors.ts
+++ b/src/audit-evidence/audit-evidence.errors.ts
@@ -40,3 +40,14 @@ export class PostOperationEvidenceSnapshotNotFoundError extends Error {
     super(`Post-operation evidence snapshot not found for mission: ${snapshotId}`);
   }
 }
+
+export class PostOperationAuditSignoffAlreadyExistsError extends Error {
+  readonly statusCode = 409;
+  readonly code = "POST_OPERATION_AUDIT_SIGNOFF_ALREADY_EXISTS";
+
+  constructor(snapshotId: string) {
+    super(
+      `Post-operation audit sign-off already exists for snapshot: ${snapshotId}`,
+    );
+  }
+}

--- a/src/audit-evidence/audit-evidence.repository.ts
+++ b/src/audit-evidence/audit-evidence.repository.ts
@@ -6,6 +6,7 @@ import type {
   MissionDecisionEvidenceLink,
   MissionLifecycleEvidenceEvent,
   PlanningApprovalHandoffEvidence,
+  PostOperationAuditSignoff,
   PostOperationCompletionSnapshot,
   PostOperationEvidenceSnapshot,
 } from "./audit-evidence.types";
@@ -93,6 +94,30 @@ interface CreatePostOperationEvidenceSnapshotRow {
   createdBy: string | null;
 }
 
+interface PostOperationAuditSignoffRow extends QueryResultRow {
+  id: string;
+  mission_id: string;
+  post_operation_evidence_snapshot_id: string;
+  accountable_manager_name: string;
+  accountable_manager_role: string;
+  review_decision: PostOperationAuditSignoff["reviewDecision"];
+  signed_at: Date;
+  signature_reference: string | null;
+  created_by: string | null;
+  created_at: Date;
+}
+
+interface CreatePostOperationAuditSignoffRow {
+  missionId: string;
+  postOperationEvidenceSnapshotId: string;
+  accountableManagerName: string;
+  accountableManagerRole: string;
+  reviewDecision: PostOperationAuditSignoff["reviewDecision"];
+  signedAt: string;
+  signatureReference: string | null;
+  createdBy: string | null;
+}
+
 const toAuditEvidenceSnapshot = (
   row: AuditEvidenceSnapshotRow,
 ): AuditEvidenceSnapshot => ({
@@ -156,6 +181,21 @@ const toPostOperationEvidenceSnapshot = (
   evidenceType: row.evidence_type,
   lifecycleState: row.lifecycle_state,
   completionSnapshot: row.completion_snapshot,
+  createdBy: row.created_by,
+  createdAt: row.created_at.toISOString(),
+});
+
+const toPostOperationAuditSignoff = (
+  row: PostOperationAuditSignoffRow,
+): PostOperationAuditSignoff => ({
+  id: row.id,
+  missionId: row.mission_id,
+  postOperationEvidenceSnapshotId: row.post_operation_evidence_snapshot_id,
+  accountableManagerName: row.accountable_manager_name,
+  accountableManagerRole: row.accountable_manager_role,
+  reviewDecision: row.review_decision,
+  signedAt: row.signed_at.toISOString(),
+  signatureReference: row.signature_reference,
   createdBy: row.created_by,
   createdAt: row.created_at.toISOString(),
 });
@@ -466,6 +506,58 @@ export class AuditEvidenceRepository {
     return result.rows[0]
       ? toPostOperationEvidenceSnapshot(result.rows[0])
       : null;
+  }
+
+  async postOperationAuditSignoffExistsForSnapshot(
+    tx: PoolClient,
+    snapshotId: string,
+  ): Promise<boolean> {
+    const result = await tx.query(
+      `
+      select 1
+      from post_operation_audit_signoffs
+      where post_operation_evidence_snapshot_id = $1
+      `,
+      [snapshotId],
+    );
+
+    return result.rowCount === 1;
+  }
+
+  async insertPostOperationAuditSignoff(
+    tx: PoolClient,
+    input: CreatePostOperationAuditSignoffRow,
+  ): Promise<PostOperationAuditSignoff> {
+    const result = await tx.query<PostOperationAuditSignoffRow>(
+      `
+      insert into post_operation_audit_signoffs (
+        id,
+        mission_id,
+        post_operation_evidence_snapshot_id,
+        accountable_manager_name,
+        accountable_manager_role,
+        review_decision,
+        signed_at,
+        signature_reference,
+        created_by
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.missionId,
+        input.postOperationEvidenceSnapshotId,
+        input.accountableManagerName,
+        input.accountableManagerRole,
+        input.reviewDecision,
+        input.signedAt,
+        input.signatureReference,
+        input.createdBy,
+      ],
+    );
+
+    return toPostOperationAuditSignoff(result.rows[0]);
   }
 
   async decisionEvidenceLinkReferencesReadinessSnapshot(

--- a/src/audit-evidence/audit-evidence.routes.ts
+++ b/src/audit-evidence/audit-evidence.routes.ts
@@ -42,6 +42,10 @@ export function createAuditEvidenceRouter(
     "/:missionId/post-operation/evidence-snapshots/:snapshotId/export/render/pdf",
     controller.generatePostOperationEvidencePdf,
   );
+  router.post(
+    "/:missionId/post-operation/evidence-snapshots/:snapshotId/signoffs",
+    controller.createPostOperationAuditSignoff,
+  );
 
   return router;
 }

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -4,6 +4,7 @@ import {
   AuditEvidenceMissionNotCompletedError,
   AuditEvidenceMissionNotFoundError,
   AuditEvidenceSnapshotNotFoundError,
+  PostOperationAuditSignoffAlreadyExistsError,
   PostOperationEvidenceSnapshotNotFoundError,
 } from "./audit-evidence.errors";
 import { AuditEvidenceRepository } from "./audit-evidence.repository";
@@ -12,9 +13,11 @@ import type {
   AuditReportSection,
   CreateAuditEvidenceSnapshotInput,
   CreateMissionDecisionEvidenceLinkInput,
+  CreatePostOperationAuditSignoffInput,
   CreatePostOperationEvidenceSnapshotInput,
   MissionDecisionEvidenceLink,
   MissionLifecycleEvidenceEvent,
+  PostOperationAuditSignoff,
   PostOperationCompletionSnapshot,
   PostOperationEvidenceExportPackage,
   PostOperationEvidencePdf,
@@ -24,6 +27,7 @@ import type {
 import {
   validateCreateAuditEvidenceSnapshotInput,
   validateCreateMissionDecisionEvidenceLinkInput,
+  validateCreatePostOperationAuditSignoffInput,
   validateCreatePostOperationEvidenceSnapshotInput,
 } from "./audit-evidence.validators";
 
@@ -309,6 +313,84 @@ export class AuditEvidenceService {
       contentType: "application/pdf",
       content,
     };
+  }
+
+  async createPostOperationAuditSignoff(
+    missionId: string,
+    snapshotId: string,
+    input: CreatePostOperationAuditSignoffInput | undefined,
+  ): Promise<PostOperationAuditSignoff> {
+    const validated = validateCreatePostOperationAuditSignoffInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      await client.query("BEGIN");
+
+      const exists = await this.auditEvidenceRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new AuditEvidenceMissionNotFoundError(missionId);
+      }
+
+      const snapshot =
+        await this.auditEvidenceRepository.getPostOperationEvidenceSnapshotForMission(
+          client,
+          missionId,
+          snapshotId,
+        );
+
+      if (!snapshot) {
+        throw new PostOperationEvidenceSnapshotNotFoundError(snapshotId);
+      }
+
+      const signoffExists =
+        await this.auditEvidenceRepository.postOperationAuditSignoffExistsForSnapshot(
+          client,
+          snapshotId,
+        );
+
+      if (signoffExists) {
+        throw new PostOperationAuditSignoffAlreadyExistsError(snapshotId);
+      }
+
+      const signoff =
+        await this.auditEvidenceRepository.insertPostOperationAuditSignoff(
+          client,
+          {
+            missionId,
+            postOperationEvidenceSnapshotId: snapshot.id,
+            accountableManagerName: validated.accountableManagerName,
+            accountableManagerRole: validated.accountableManagerRole,
+            reviewDecision: validated.reviewDecision,
+            signedAt: validated.signedAt,
+            signatureReference: validated.signatureReference,
+            createdBy: validated.createdBy,
+          },
+        );
+
+      await client.query("COMMIT");
+      return signoff;
+    } catch (error) {
+      await client.query("ROLLBACK");
+      if (this.isUniqueViolation(error)) {
+        throw new PostOperationAuditSignoffAlreadyExistsError(snapshotId);
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  private isUniqueViolation(error: unknown): boolean {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: unknown }).code === "23505"
+    );
   }
 
   private async buildPostOperationCompletionSnapshot(

--- a/src/audit-evidence/audit-evidence.types.ts
+++ b/src/audit-evidence/audit-evidence.types.ts
@@ -6,11 +6,25 @@ export type PostOperationEvidenceType = "post_operation_completion";
 
 export type MissionDecisionType = "approval" | "dispatch";
 
+export type PostOperationAuditSignoffDecision =
+  | "approved"
+  | "rejected"
+  | "requires_follow_up";
+
 export interface CreateAuditEvidenceSnapshotInput {
   createdBy?: string | null;
 }
 
 export interface CreatePostOperationEvidenceSnapshotInput {
+  createdBy?: string | null;
+}
+
+export interface CreatePostOperationAuditSignoffInput {
+  accountableManagerName?: string;
+  accountableManagerRole?: string;
+  reviewDecision?: PostOperationAuditSignoffDecision;
+  signedAt?: string;
+  signatureReference?: string | null;
   createdBy?: string | null;
 }
 
@@ -86,6 +100,19 @@ export interface PostOperationEvidenceSnapshot {
   evidenceType: PostOperationEvidenceType;
   lifecycleState: string;
   completionSnapshot: PostOperationCompletionSnapshot;
+  createdBy: string | null;
+  createdAt: string;
+}
+
+export interface PostOperationAuditSignoff {
+  id: string;
+  missionId: string;
+  postOperationEvidenceSnapshotId: string;
+  accountableManagerName: string;
+  accountableManagerRole: string;
+  reviewDecision: PostOperationAuditSignoffDecision;
+  signedAt: string;
+  signatureReference: string | null;
   createdBy: string | null;
   createdAt: string;
 }

--- a/src/audit-evidence/audit-evidence.validators.ts
+++ b/src/audit-evidence/audit-evidence.validators.ts
@@ -2,11 +2,18 @@ import { AuditEvidenceValidationError } from "./audit-evidence.errors";
 import type {
   CreateAuditEvidenceSnapshotInput,
   CreateMissionDecisionEvidenceLinkInput,
+  CreatePostOperationAuditSignoffInput,
   CreatePostOperationEvidenceSnapshotInput,
   MissionDecisionType,
+  PostOperationAuditSignoffDecision,
 } from "./audit-evidence.types";
 
 const DECISION_TYPES = new Set<MissionDecisionType>(["approval", "dispatch"]);
+const SIGNOFF_DECISIONS = new Set<PostOperationAuditSignoffDecision>([
+  "approved",
+  "rejected",
+  "requires_follow_up",
+]);
 
 function optionalTrimmed(value: unknown, fieldName: string): string | null {
   if (value === undefined || value === null) {
@@ -73,6 +80,31 @@ function requiredDecisionType(value: unknown): MissionDecisionType {
   return value as MissionDecisionType;
 }
 
+function requiredSignoffDecision(value: unknown): PostOperationAuditSignoffDecision {
+  if (
+    typeof value !== "string" ||
+    !SIGNOFF_DECISIONS.has(value as PostOperationAuditSignoffDecision)
+  ) {
+    throw new AuditEvidenceValidationError("reviewDecision is not supported");
+  }
+
+  return value as PostOperationAuditSignoffDecision;
+}
+
+function requiredIsoDate(value: unknown, fieldName: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new AuditEvidenceValidationError(`${fieldName} is required`);
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new AuditEvidenceValidationError(`${fieldName} must be a valid date`);
+  }
+
+  return parsed.toISOString();
+}
+
 export function validateCreateMissionDecisionEvidenceLinkInput(
   input: CreateMissionDecisionEvidenceLinkInput | undefined,
 ) {
@@ -83,6 +115,32 @@ export function validateCreateMissionDecisionEvidenceLinkInput(
   return {
     snapshotId: requiredString(input.snapshotId, "snapshotId"),
     decisionType: requiredDecisionType(input.decisionType),
+    createdBy: optionalTrimmed(input.createdBy, "createdBy"),
+  };
+}
+
+export function validateCreatePostOperationAuditSignoffInput(
+  input: CreatePostOperationAuditSignoffInput | undefined,
+) {
+  if (!input || typeof input !== "object") {
+    throw new AuditEvidenceValidationError("Request body must be an object");
+  }
+
+  return {
+    accountableManagerName: requiredString(
+      input.accountableManagerName,
+      "accountableManagerName",
+    ),
+    accountableManagerRole: requiredString(
+      input.accountableManagerRole,
+      "accountableManagerRole",
+    ),
+    reviewDecision: requiredSignoffDecision(input.reviewDecision),
+    signedAt: requiredIsoDate(input.signedAt, "signedAt"),
+    signatureReference: optionalTrimmed(
+      input.signatureReference,
+      "signatureReference",
+    ),
     createdBy: optionalTrimmed(input.createdBy, "createdBy"),
   };
 }

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -1160,6 +1160,185 @@ describe("audit evidence snapshots", () => {
     expect(await countRows(missionId)).toEqual(before);
   });
 
+  it("creates accountable-manager sign-offs through the post-operation snapshot endpoint", async () => {
+    const { missionId } = await createCompletedMission();
+    const snapshotResponse = await request(app)
+      .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
+      .send({ createdBy: "accountable-manager" });
+
+    expect(snapshotResponse.status).toBe(201);
+    const before = await countRows(missionId);
+
+    const response = await request(app)
+      .post(
+        `/missions/${missionId}/post-operation/evidence-snapshots/${snapshotResponse.body.snapshot.id}/signoffs`,
+      )
+      .send({
+        accountableManagerName: " Alex Accountable ",
+        accountableManagerRole: " Accountable Manager ",
+        reviewDecision: "approved",
+        signedAt: "2026-04-18T18:00:00.000Z",
+        signatureReference: " signature://accountable-manager/alex ",
+        createdBy: " audit-admin ",
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.signoff).toMatchObject({
+      missionId,
+      postOperationEvidenceSnapshotId: snapshotResponse.body.snapshot.id,
+      accountableManagerName: "Alex Accountable",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "approved",
+      signedAt: "2026-04-18T18:00:00.000Z",
+      signatureReference: "signature://accountable-manager/alex",
+      createdBy: "audit-admin",
+    });
+    expect(response.body.signoff.id).toEqual(expect.any(String));
+    expect(response.body.signoff.createdAt).toEqual(expect.any(String));
+    expect(await countRows(missionId)).toEqual({
+      ...before,
+      post_operation_signoff_count: before.post_operation_signoff_count + 1,
+    });
+  });
+
+  it("rejects duplicate accountable-manager sign-offs for the same snapshot", async () => {
+    const { missionId } = await createCompletedMission();
+    const snapshotResponse = await request(app)
+      .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
+      .send({});
+
+    expect(snapshotResponse.status).toBe(201);
+    const endpoint = `/missions/${missionId}/post-operation/evidence-snapshots/${snapshotResponse.body.snapshot.id}/signoffs`;
+    const firstResponse = await request(app).post(endpoint).send({
+      accountableManagerName: "Alex Accountable",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "approved",
+      signedAt: "2026-04-18T18:00:00.000Z",
+    });
+    const beforeDuplicate = await countRows(missionId);
+    const duplicateResponse = await request(app).post(endpoint).send({
+      accountableManagerName: "Alex Accountable",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "approved",
+      signedAt: "2026-04-18T18:00:00.000Z",
+    });
+
+    expect(firstResponse.status).toBe(201);
+    expect(duplicateResponse.status).toBe(409);
+    expect(duplicateResponse.body).toMatchObject({
+      error: {
+        type: "post_operation_audit_signoff_already_exists",
+      },
+    });
+    expect(await countRows(missionId)).toEqual(beforeDuplicate);
+  });
+
+  it("does not create accountable-manager sign-offs for another mission's snapshot", async () => {
+    const first = await createCompletedMission();
+    const second = await createCompletedMission();
+    const secondSnapshot = await request(app)
+      .post(`/missions/${second.missionId}/post-operation/evidence-snapshots`)
+      .send({});
+
+    expect(secondSnapshot.status).toBe(201);
+    const firstBefore = await countRows(first.missionId);
+    const secondBefore = await countRows(second.missionId);
+
+    const response = await request(app)
+      .post(
+        `/missions/${first.missionId}/post-operation/evidence-snapshots/${secondSnapshot.body.snapshot.id}/signoffs`,
+      )
+      .send({
+        accountableManagerName: "Alex Accountable",
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "approved",
+        signedAt: "2026-04-18T18:00:00.000Z",
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "post_operation_evidence_snapshot_not_found",
+      },
+    });
+    expect(await countRows(first.missionId)).toEqual(firstBefore);
+    expect(await countRows(second.missionId)).toEqual(secondBefore);
+  });
+
+  it("rejects invalid accountable-manager sign-off requests", async () => {
+    const { missionId } = await createCompletedMission();
+    const snapshotResponse = await request(app)
+      .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
+      .send({});
+
+    expect(snapshotResponse.status).toBe(201);
+    const endpoint = `/missions/${missionId}/post-operation/evidence-snapshots/${snapshotResponse.body.snapshot.id}/signoffs`;
+    const before = await countRows(missionId);
+
+    const missingNameResponse = await request(app).post(endpoint).send({
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "approved",
+      signedAt: "2026-04-18T18:00:00.000Z",
+    });
+    const invalidDecisionResponse = await request(app).post(endpoint).send({
+      accountableManagerName: "Alex Accountable",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "maybe",
+      signedAt: "2026-04-18T18:00:00.000Z",
+    });
+    const invalidDateResponse = await request(app).post(endpoint).send({
+      accountableManagerName: "Alex Accountable",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "approved",
+      signedAt: "not-a-date",
+    });
+
+    expect(missingNameResponse.status).toBe(400);
+    expect(invalidDecisionResponse.status).toBe(400);
+    expect(invalidDateResponse.status).toBe(400);
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("returns 404 for unknown sign-off missions and snapshots", async () => {
+    const { missionId } = await createCompletedMission();
+    const before = await countRows(missionId);
+
+    const missingSnapshotResponse = await request(app)
+      .post(
+        `/missions/${missionId}/post-operation/evidence-snapshots/${randomUUID()}/signoffs`,
+      )
+      .send({
+        accountableManagerName: "Alex Accountable",
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "approved",
+        signedAt: "2026-04-18T18:00:00.000Z",
+      });
+    const missingMissionResponse = await request(app)
+      .post(
+        `/missions/${randomUUID()}/post-operation/evidence-snapshots/${randomUUID()}/signoffs`,
+      )
+      .send({
+        accountableManagerName: "Alex Accountable",
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "approved",
+        signedAt: "2026-04-18T18:00:00.000Z",
+      });
+
+    expect(missingSnapshotResponse.status).toBe(404);
+    expect(missingSnapshotResponse.body).toMatchObject({
+      error: {
+        type: "post_operation_evidence_snapshot_not_found",
+      },
+    });
+    expect(missingMissionResponse.status).toBe(404);
+    expect(missingMissionResponse.body).toMatchObject({
+      error: {
+        type: "mission_not_found",
+      },
+    });
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
   it("stores accountable-manager sign-off records against post-operation evidence snapshots", async () => {
     const { missionId } = await createCompletedMission();
     const snapshotResponse = await request(app)


### PR DESCRIPTION
What Changed
Added the endpoint:

POST /missions/:missionId/post-operation/evidence-snapshots/:snapshotId/signoffs

It records accountable-manager sign-offs against the migrated post_operation_audit_signoffs table, with validation for manager name, role, review decision, signed timestamp, signature reference, and creator metadata. It also rejects duplicate sign-offs with a clean 409 and keeps mission/snapshot isolation intact.