### PR TITLE
Connect signoffs to audit reports

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Connect stored accountable-manager sign-offs into rendered and PDF post-operation audit reports.",
+ "nextBuildStep": "Add immutable post-operation audit report archive records so generated regulator-ready reports can be retained and traced after sign-off.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.repository.ts
+++ b/src/audit-evidence/audit-evidence.repository.ts
@@ -560,6 +560,27 @@ export class AuditEvidenceRepository {
     return toPostOperationAuditSignoff(result.rows[0]);
   }
 
+  async getPostOperationAuditSignoffForSnapshot(
+    tx: PoolClient,
+    missionId: string,
+    snapshotId: string,
+  ): Promise<PostOperationAuditSignoff | null> {
+    const result = await tx.query<PostOperationAuditSignoffRow>(
+      `
+      select *
+      from post_operation_audit_signoffs
+      where mission_id = $1
+        and post_operation_evidence_snapshot_id = $2
+      limit 1
+      `,
+      [missionId, snapshotId],
+    );
+
+    return result.rows[0]
+      ? toPostOperationAuditSignoff(result.rows[0])
+      : null;
+  }
+
   async decisionEvidenceLinkReferencesReadinessSnapshot(
     tx: PoolClient,
     missionId: string,

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -279,7 +279,14 @@ export class AuditEvidenceService {
       missionId,
       snapshotId,
     );
-    const sections = this.buildPostOperationReportSections(evidenceExport);
+    const signoff = await this.getPostOperationAuditSignoff(
+      evidenceExport.missionId,
+      evidenceExport.snapshotId,
+    );
+    const sections = this.buildPostOperationReportSections(
+      evidenceExport,
+      signoff,
+    );
 
     return {
       renderType: "post_operation_completion_evidence_report",
@@ -393,6 +400,23 @@ export class AuditEvidenceService {
     );
   }
 
+  private async getPostOperationAuditSignoff(
+    missionId: string,
+    snapshotId: string,
+  ): Promise<PostOperationAuditSignoff | null> {
+    const client = await this.pool.connect();
+
+    try {
+      return await this.auditEvidenceRepository.getPostOperationAuditSignoffForSnapshot(
+        client,
+        missionId,
+        snapshotId,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
   private async buildPostOperationCompletionSnapshot(
     client: Awaited<ReturnType<Pool["connect"]>>,
     mission: { missionId: string; missionPlanId: string | null; status: string },
@@ -464,8 +488,10 @@ export class AuditEvidenceService {
 
   private buildPostOperationReportSections(
     evidenceExport: PostOperationEvidenceExportPackage,
+    signoff: PostOperationAuditSignoff | null,
   ): AuditReportSection[] {
     const snapshot = evidenceExport.completionSnapshot;
+    const pendingSignoff = "Pending sign-off";
 
     return [
       {
@@ -554,11 +580,38 @@ export class AuditEvidenceService {
       {
         heading: "Accountable manager sign-off",
         fields: [
-          { label: "Accountable manager name", value: "Pending sign-off" },
-          { label: "Role/title", value: "Pending sign-off" },
-          { label: "Signature", value: "Pending sign-off" },
-          { label: "Signed date/time", value: "Pending sign-off" },
-          { label: "Review decision/status", value: "Pending sign-off" },
+          {
+            label: "Accountable manager name",
+            value: signoff?.accountableManagerName ?? pendingSignoff,
+          },
+          {
+            label: "Role/title",
+            value: signoff?.accountableManagerRole ?? pendingSignoff,
+          },
+          {
+            label: "Signature",
+            value: signoff?.signatureReference ?? pendingSignoff,
+          },
+          {
+            label: "Signed date/time",
+            value: signoff?.signedAt ?? pendingSignoff,
+          },
+          {
+            label: "Review decision/status",
+            value: signoff?.reviewDecision ?? pendingSignoff,
+          },
+          {
+            label: "Sign-off record ID",
+            value: signoff?.id ?? pendingSignoff,
+          },
+          {
+            label: "Sign-off recorded by",
+            value: signoff?.createdBy ?? pendingSignoff,
+          },
+          {
+            label: "Sign-off recorded at",
+            value: signoff?.createdAt ?? pendingSignoff,
+          },
         ],
       },
     ];

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -977,7 +977,7 @@ describe("audit evidence snapshots", () => {
           },
           {
             heading: "Accountable manager sign-off",
-            fields: [
+            fields: expect.arrayContaining([
               {
                 label: "Accountable manager name",
                 value: "Pending sign-off",
@@ -989,7 +989,10 @@ describe("audit evidence snapshots", () => {
                 label: "Review decision/status",
                 value: "Pending sign-off",
               },
-            ],
+              { label: "Sign-off record ID", value: "Pending sign-off" },
+              { label: "Sign-off recorded by", value: "Pending sign-off" },
+              { label: "Sign-off recorded at", value: "Pending sign-off" },
+            ]),
           },
         ],
       },
@@ -1008,6 +1011,109 @@ describe("audit evidence snapshots", () => {
       "Review decision/status: Pending sign-off",
     );
     expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("renders stored accountable-manager sign-offs without mutating audit state", async () => {
+    const { missionId } = await createCompletedMission();
+    const snapshotResponse = await request(app)
+      .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
+      .send({ createdBy: "accountable-manager" });
+
+    expect(snapshotResponse.status).toBe(201);
+
+    const signoffResponse = await request(app)
+      .post(
+        `/missions/${missionId}/post-operation/evidence-snapshots/${snapshotResponse.body.snapshot.id}/signoffs`,
+      )
+      .send({
+        accountableManagerName: "Alex Accountable",
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "approved",
+        signedAt: "2026-04-18T18:00:00.000Z",
+        signatureReference: "signature://accountable-manager/alex",
+        createdBy: "audit-admin",
+      });
+
+    expect(signoffResponse.status).toBe(201);
+    const before = await countRows(missionId);
+
+    const response = await request(app).get(
+      `/missions/${missionId}/post-operation/evidence-snapshots/${snapshotResponse.body.snapshot.id}/export/render`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.report.report.sections).toContainEqual({
+      heading: "Accountable manager sign-off",
+      fields: expect.arrayContaining([
+        { label: "Accountable manager name", value: "Alex Accountable" },
+        { label: "Role/title", value: "Accountable Manager" },
+        {
+          label: "Signature",
+          value: "signature://accountable-manager/alex",
+        },
+        { label: "Signed date/time", value: "2026-04-18T18:00:00.000Z" },
+        { label: "Review decision/status", value: "approved" },
+        { label: "Sign-off record ID", value: signoffResponse.body.signoff.id },
+        { label: "Sign-off recorded by", value: "audit-admin" },
+        {
+          label: "Sign-off recorded at",
+          value: signoffResponse.body.signoff.createdAt,
+        },
+      ]),
+    });
+    expect(response.body.report.report.plainText).toContain(
+      "Accountable manager name: Alex Accountable",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Review decision/status: approved",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      `Sign-off record ID: ${signoffResponse.body.signoff.id}`,
+    );
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("does not leak stored sign-offs from other post-operation snapshots", async () => {
+    const first = await createCompletedMission();
+    const second = await createCompletedMission();
+    const firstSnapshot = await request(app)
+      .post(`/missions/${first.missionId}/post-operation/evidence-snapshots`)
+      .send({});
+    const secondSnapshot = await request(app)
+      .post(`/missions/${second.missionId}/post-operation/evidence-snapshots`)
+      .send({});
+
+    expect(firstSnapshot.status).toBe(201);
+    expect(secondSnapshot.status).toBe(201);
+
+    const signoffResponse = await request(app)
+      .post(
+        `/missions/${second.missionId}/post-operation/evidence-snapshots/${secondSnapshot.body.snapshot.id}/signoffs`,
+      )
+      .send({
+        accountableManagerName: "Second Manager",
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "approved",
+        signedAt: "2026-04-18T18:00:00.000Z",
+      });
+
+    expect(signoffResponse.status).toBe(201);
+    const firstBefore = await countRows(first.missionId);
+    const secondBefore = await countRows(second.missionId);
+
+    const response = await request(app).get(
+      `/missions/${first.missionId}/post-operation/evidence-snapshots/${firstSnapshot.body.snapshot.id}/export/render`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.report.report.plainText).toContain(
+      "Accountable manager name: Pending sign-off",
+    );
+    expect(response.body.report.report.plainText).not.toContain(
+      "Second Manager",
+    );
+    expect(await countRows(first.missionId)).toEqual(firstBefore);
+    expect(await countRows(second.missionId)).toEqual(secondBefore);
   });
 
   it("does not render post-operation reports for snapshots from another mission", async () => {
@@ -1105,6 +1211,53 @@ describe("audit evidence snapshots", () => {
     );
     expect(response.body.toString("latin1")).toContain(
       "Review decision/status: Pending sign-off",
+    );
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("includes stored accountable-manager sign-offs in post-operation audit PDFs", async () => {
+    const { missionId } = await createCompletedMission();
+    const snapshotResponse = await request(app)
+      .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
+      .send({});
+
+    expect(snapshotResponse.status).toBe(201);
+
+    const signoffResponse = await request(app)
+      .post(
+        `/missions/${missionId}/post-operation/evidence-snapshots/${snapshotResponse.body.snapshot.id}/signoffs`,
+      )
+      .send({
+        accountableManagerName: "Alex Accountable",
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "approved",
+        signedAt: "2026-04-18T18:00:00.000Z",
+        signatureReference: "signature://accountable-manager/alex",
+        createdBy: "audit-admin",
+      });
+
+    expect(signoffResponse.status).toBe(201);
+    const before = await countRows(missionId);
+
+    const response = await request(app)
+      .get(
+        `/missions/${missionId}/post-operation/evidence-snapshots/${snapshotResponse.body.snapshot.id}/export/render/pdf`,
+      )
+      .buffer(true)
+      .parse(parseBinaryResponse);
+    const pdfText = response.body.toString("latin1");
+
+    expect(response.status).toBe(200);
+    expect(pdfText).toContain("Accountable manager sign-off");
+    expect(pdfText).toContain("Accountable manager name: Alex Accountable");
+    expect(pdfText).toContain("Role/title: Accountable Manager");
+    expect(pdfText).toContain(
+      "Signature: signature://accountable-manager/alex",
+    );
+    expect(pdfText).toContain("Signed date/time: 2026-04-18T18:00:00.000Z");
+    expect(pdfText).toContain("Review decision/status: approved");
+    expect(pdfText).toContain(
+      `Sign-off record ID: ${signoffResponse.body.signoff.id}`,
     );
     expect(await countRows(missionId)).toEqual(before);
   });


### PR DESCRIPTION
What changed:

Added a mission/snapshot-scoped read for stored accountable-manager sign-offs: 【C:/Users/rabbi/Documents/Codex/2026-04-17-i-want-to-continue-a-project/fsms-signoff-report-issue-51/src/audit-evidence/audit-evidence.repository.ts†L563】
Rendered post-operation reports now load the stored sign-off and pass it into report section generation: 【C:/Users/rabbi/Documents/Codex/2026-04-17-i-want-to-continue-a-project/fsms-signoff-report-issue-51/src/audit-evidence/audit-evidence.service.ts†L282】
Sign-off report fields now show stored values when present, otherwise Pending sign-off: 【C:/Users/rabbi/Documents/Codex/2026-04-17-i-want-to-continue-a-project/fsms-signoff-report-issue-51/src/audit-evidence/audit-evidence.service.ts†L489】
Added tests for stored sign-off rendering, no cross-snapshot leakage, and PDF output: 【C:/Users/rabbi/Documents/Codex/2026-04-17-i-want-to-continue-a-project/fsms-signoff-report-issue-51/src/tests/audit-evidence.test.ts†L1016】, 【C:/Users/rabbi/Documents/Codex/2026-04-17-i-want-to-continue-a-project/fsms-signoff-report-issue-51/src/tests/audit-evidence.test.ts†L1076】, 【C:/Users/rabbi/Documents/Codex/2026-04-17-i-want-to-continue-a-project/fsms-signoff-report-issue-51/src/tests/audit-evidence.test.ts†L1218】
Advanced the save point to immutable post-operation report archive records: 【C:/Users/rabbi/Documents/Codex/2026-04-17-i-want-to-continue-a-project/fsms-signoff-report-issue-51/fsms-save-point.json†L92】