### PR TITLE
Add SMS framework reference tables

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add immutable post-operation audit report archive records so generated regulator-ready reports can be retained and traced after sign-off.",
+ "nextBuildStep": "Add SMS control mapping records so FSMS platform, pilot, risk, airspace, mission gate, and audit controls can be linked to SMS elements.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -50,6 +50,10 @@ import { MissionPlanningRepository } from "./mission-planning/mission-planning.r
 import { MissionPlanningService } from "./mission-planning/mission-planning.service";
 import { MissionPlanningController } from "./mission-planning/mission-planning.controller";
 import { createMissionPlanningRouter } from "./mission-planning/mission-planning.routes";
+import { SmsFrameworkRepository } from "./sms-framework/sms-framework.repository";
+import { SmsFrameworkService } from "./sms-framework/sms-framework.service";
+import { SmsFrameworkController } from "./sms-framework/sms-framework.controller";
+import { createSmsFrameworkRouter } from "./sms-framework/sms-framework.routes";
 
 dotenv.config({
   path: path.resolve(process.cwd(), ".env"),
@@ -159,8 +163,15 @@ const missionPlanningService = new MissionPlanningService(
 const missionPlanningController = new MissionPlanningController(
   missionPlanningService,
 );
+const smsFrameworkRepository = new SmsFrameworkRepository();
+const smsFrameworkService = new SmsFrameworkService(
+  pool,
+  smsFrameworkRepository,
+);
+const smsFrameworkController = new SmsFrameworkController(smsFrameworkService);
 
 app.use("/mission-plans", createMissionPlanningRouter(missionPlanningController));
+app.use("/sms", createSmsFrameworkRouter(smsFrameworkController));
 app.use("/missions", createMissionRouter(missionController));
 app.use("/missions", createMissionRiskRouter(missionRiskController));
 app.use("/missions", createAirspaceComplianceRouter(airspaceComplianceController));

--- a/src/migrations/018_create_sms_framework_reference.sql
+++ b/src/migrations/018_create_sms_framework_reference.sql
@@ -1,0 +1,189 @@
+create table if not exists sms_framework_sources (
+  code text primary key,
+  title text not null,
+  source_type text not null,
+  version_label text null,
+  source_url text null,
+  notes text null,
+  display_order int not null unique
+);
+
+create table if not exists sms_pillars (
+  code text primary key,
+  title text not null,
+  display_order int not null unique,
+  source_code text not null references sms_framework_sources(code)
+);
+
+create table if not exists sms_elements (
+  code text primary key,
+  pillar_code text not null references sms_pillars(code),
+  element_number text not null,
+  title text not null,
+  display_order int not null unique,
+  source_code text not null references sms_framework_sources(code),
+  constraint sms_elements_pillar_number_uniq
+    unique (pillar_code, element_number)
+);
+
+insert into sms_framework_sources (
+  code,
+  title,
+  source_type,
+  version_label,
+  source_url,
+  notes,
+  display_order
+)
+values
+  (
+    'UAV_SMS_WORKBOOK',
+    'UAV SMS 4 Pillars and 12 Elements workbook',
+    'internal_reference',
+    null,
+    null,
+    'Internal SMS framework reference supplied by the project owner.',
+    1
+  ),
+  (
+    'CAA_CAP_722A_2022',
+    'CAA CAP 722A: Unmanned Aircraft System Operations in UK Airspace - Operating Safety Cases',
+    'external_guidance_reference',
+    'Version 2, 07-Dec-2022',
+    'https://www.caa.co.uk/data-and-publications/publications/documents/content/cap-722a/',
+    'Recorded as source guidance and version context only; not executable compliance logic.',
+    2
+  )
+on conflict (code) do update
+set
+  title = excluded.title,
+  source_type = excluded.source_type,
+  version_label = excluded.version_label,
+  source_url = excluded.source_url,
+  notes = excluded.notes,
+  display_order = excluded.display_order;
+
+insert into sms_pillars (code, title, display_order, source_code)
+values
+  ('SAFETY_POLICY_AND_GOALS', 'Safety Policy and Goals', 1, 'UAV_SMS_WORKBOOK'),
+  ('SAFETY_RISK_MANAGEMENT', 'Safety Risk Management', 2, 'UAV_SMS_WORKBOOK'),
+  ('SAFETY_ASSURANCE', 'Safety Assurance', 3, 'UAV_SMS_WORKBOOK'),
+  ('PROMOTION_OF_SAFETY', 'Promotion of Safety', 4, 'UAV_SMS_WORKBOOK')
+on conflict (code) do update
+set
+  title = excluded.title,
+  display_order = excluded.display_order,
+  source_code = excluded.source_code;
+
+insert into sms_elements (
+  code,
+  pillar_code,
+  element_number,
+  title,
+  display_order,
+  source_code
+)
+values
+  (
+    'MANAGEMENT_COMMITMENT_AND_RESPONSIBILITY',
+    'SAFETY_POLICY_AND_GOALS',
+    '1.1',
+    'Commitment and Responsibility of the Management',
+    1,
+    'UAV_SMS_WORKBOOK'
+  ),
+  (
+    'ULTIMATE_SAFETY_RESPONSIBILITY',
+    'SAFETY_POLICY_AND_GOALS',
+    '1.2',
+    'The ultimate responsibility for the safety',
+    2,
+    'UAV_SMS_WORKBOOK'
+  ),
+  (
+    'KEY_SAFETY_STAFF_IDENTIFICATION',
+    'SAFETY_POLICY_AND_GOALS',
+    '1.3',
+    'Identification of the key safety staff',
+    3,
+    'UAV_SMS_WORKBOOK'
+  ),
+  (
+    'EMERGENCY_RESPONSE_PLANNING',
+    'SAFETY_POLICY_AND_GOALS',
+    '1.4',
+    'Coordinating the planning of procedures in the case of emergency; Emergency Response Plan (ERP)',
+    4,
+    'UAV_SMS_WORKBOOK'
+  ),
+  (
+    'SMS_DOCUMENTATION',
+    'SAFETY_POLICY_AND_GOALS',
+    '1.5',
+    'SMS documentation',
+    5,
+    'UAV_SMS_WORKBOOK'
+  ),
+  (
+    'RISK_HAZARD_DETECTION_AND_IDENTIFICATION',
+    'SAFETY_RISK_MANAGEMENT',
+    '2.1',
+    'Risk/hazard detection and identification',
+    6,
+    'UAV_SMS_WORKBOOK'
+  ),
+  (
+    'RISK_ASSESSMENT_AND_MITIGATION',
+    'SAFETY_RISK_MANAGEMENT',
+    '2.2',
+    'Assessment and mitigation of risks',
+    7,
+    'UAV_SMS_WORKBOOK'
+  ),
+  (
+    'SAFETY_PERFORMANCE_MONITORING',
+    'SAFETY_ASSURANCE',
+    '3.1',
+    'Monitoring and Measurement of Safety Performance',
+    8,
+    'UAV_SMS_WORKBOOK'
+  ),
+  (
+    'CHANGE_MANAGEMENT',
+    'SAFETY_ASSURANCE',
+    '3.2',
+    'Managing Changes',
+    9,
+    'UAV_SMS_WORKBOOK'
+  ),
+  (
+    'SMS_CONTINUOUS_IMPROVEMENT',
+    'SAFETY_ASSURANCE',
+    '3.3',
+    'Continuous improvement of SMS',
+    10,
+    'UAV_SMS_WORKBOOK'
+  ),
+  (
+    'SAFETY_TRAINING_AND_EDUCATION',
+    'PROMOTION_OF_SAFETY',
+    '4.1',
+    'Training and education',
+    11,
+    'UAV_SMS_WORKBOOK'
+  ),
+  (
+    'SAFETY_COMMUNICATION',
+    'PROMOTION_OF_SAFETY',
+    '4.2',
+    'Safety communication',
+    12,
+    'UAV_SMS_WORKBOOK'
+  )
+on conflict (code) do update
+set
+  pillar_code = excluded.pillar_code,
+  element_number = excluded.element_number,
+  title = excluded.title,
+  display_order = excluded.display_order,
+  source_code = excluded.source_code;

--- a/src/sms-framework/sms-framework.controller.ts
+++ b/src/sms-framework/sms-framework.controller.ts
@@ -1,0 +1,19 @@
+import type { NextFunction, Request, Response } from "express";
+import { SmsFrameworkService } from "./sms-framework.service";
+
+export class SmsFrameworkController {
+  constructor(private readonly smsFrameworkService: SmsFrameworkService) {}
+
+  getFramework = async (
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const framework = await this.smsFrameworkService.getFramework();
+      res.status(200).json({ framework });
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/sms-framework/sms-framework.repository.ts
+++ b/src/sms-framework/sms-framework.repository.ts
@@ -1,0 +1,103 @@
+import type { PoolClient, QueryResultRow } from "pg";
+import type {
+  SmsElement,
+  SmsFrameworkSource,
+  SmsPillar,
+} from "./sms-framework.types";
+
+interface SmsFrameworkSourceRow extends QueryResultRow {
+  code: string;
+  title: string;
+  source_type: string;
+  version_label: string | null;
+  source_url: string | null;
+  notes: string | null;
+  display_order: number;
+}
+
+interface SmsPillarRow extends QueryResultRow {
+  code: string;
+  title: string;
+  display_order: number;
+  source_code: string;
+}
+
+interface SmsElementRow extends QueryResultRow {
+  code: string;
+  pillar_code: string;
+  element_number: string;
+  title: string;
+  display_order: number;
+  source_code: string;
+}
+
+const toSource = (row: SmsFrameworkSourceRow): SmsFrameworkSource => ({
+  code: row.code,
+  title: row.title,
+  sourceType: row.source_type,
+  versionLabel: row.version_label,
+  sourceUrl: row.source_url,
+  notes: row.notes,
+  displayOrder: row.display_order,
+});
+
+const toPillar = (row: SmsPillarRow, elements: SmsElement[]): SmsPillar => ({
+  code: row.code,
+  title: row.title,
+  displayOrder: row.display_order,
+  sourceCode: row.source_code,
+  elements,
+});
+
+const toElement = (row: SmsElementRow): SmsElement => ({
+  code: row.code,
+  pillarCode: row.pillar_code,
+  elementNumber: row.element_number,
+  title: row.title,
+  displayOrder: row.display_order,
+  sourceCode: row.source_code,
+});
+
+export class SmsFrameworkRepository {
+  async listSources(tx: PoolClient): Promise<SmsFrameworkSource[]> {
+    const result = await tx.query<SmsFrameworkSourceRow>(
+      `
+      select *
+      from sms_framework_sources
+      order by display_order asc
+      `,
+    );
+
+    return result.rows.map(toSource);
+  }
+
+  async listPillars(tx: PoolClient): Promise<SmsPillar[]> {
+    const pillars = await tx.query<SmsPillarRow>(
+      `
+      select *
+      from sms_pillars
+      order by display_order asc
+      `,
+    );
+    const elements = await this.listElements(tx);
+
+    return pillars.rows.map((pillar) =>
+      toPillar(
+        pillar,
+        elements.filter((element) => element.pillarCode === pillar.code),
+      ),
+    );
+  }
+
+  private async listElements(tx: PoolClient): Promise<SmsElement[]> {
+    const result = await tx.query<SmsElementRow>(
+      `
+      select *
+      from sms_elements
+      order by display_order asc
+      `,
+    );
+
+    return result.rows.map(toElement);
+  }
+}

--- a/src/sms-framework/sms-framework.routes.ts
+++ b/src/sms-framework/sms-framework.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { SmsFrameworkController } from "./sms-framework.controller";
+
+export function createSmsFrameworkRouter(
+  controller: SmsFrameworkController,
+): Router {
+  const router = Router();
+
+  router.get("/framework", controller.getFramework);
+
+  return router;
+}

--- a/src/sms-framework/sms-framework.service.ts
+++ b/src/sms-framework/sms-framework.service.ts
@@ -1,0 +1,26 @@
+import type { Pool } from "pg";
+import { SmsFrameworkRepository } from "./sms-framework.repository";
+import type { SmsFramework } from "./sms-framework.types";
+
+export class SmsFrameworkService {
+  constructor(
+    private readonly pool: Pool,
+    private readonly smsFrameworkRepository: SmsFrameworkRepository,
+  ) {}
+
+  async getFramework(): Promise<SmsFramework> {
+    const client = await this.pool.connect();
+
+    try {
+      const sources = await this.smsFrameworkRepository.listSources(client);
+      const pillars = await this.smsFrameworkRepository.listPillars(client);
+
+      return {
+        sources,
+        pillars,
+      };
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/src/sms-framework/sms-framework.types.ts
+++ b/src/sms-framework/sms-framework.types.ts
@@ -1,0 +1,31 @@
+export interface SmsFrameworkSource {
+  code: string;
+  title: string;
+  sourceType: string;
+  versionLabel: string | null;
+  sourceUrl: string | null;
+  notes: string | null;
+  displayOrder: number;
+}
+
+export interface SmsElement {
+  code: string;
+  pillarCode: string;
+  elementNumber: string;
+  title: string;
+  displayOrder: number;
+  sourceCode: string;
+}
+
+export interface SmsPillar {
+  code: string;
+  title: string;
+  displayOrder: number;
+  sourceCode: string;
+  elements: SmsElement[];
+}
+
+export interface SmsFramework {
+  sources: SmsFrameworkSource[];
+  pillars: SmsPillar[];
+}

--- a/src/tests/sms-framework.test.ts
+++ b/src/tests/sms-framework.test.ts
@@ -1,0 +1,162 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import request from "supertest";
+import app, { pool } from "../app";
+import { runMigrations } from "../migrations/runMigrations";
+
+const countFrameworkRows = async () => {
+  const result = await pool.query(
+    `
+    select
+      (select count(*)::int from sms_framework_sources) as source_count,
+      (select count(*)::int from sms_pillars) as pillar_count,
+      (select count(*)::int from sms_elements) as element_count
+    `,
+  );
+
+  return result.rows[0] as {
+    source_count: number;
+    pillar_count: number;
+    element_count: number;
+  };
+};
+
+describe("SMS framework reference data", () => {
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("lists the seeded SMS sources, pillars, and elements in stable order", async () => {
+    const before = await countFrameworkRows();
+
+    const response = await request(app).get("/sms/framework");
+
+    expect(response.status).toBe(200);
+    expect(response.body.framework.sources).toEqual([
+      expect.objectContaining({
+        code: "UAV_SMS_WORKBOOK",
+        sourceType: "internal_reference",
+        title: "UAV SMS 4 Pillars and 12 Elements workbook",
+      }),
+      expect.objectContaining({
+        code: "CAA_CAP_722A_2022",
+        sourceType: "external_guidance_reference",
+        versionLabel: "Version 2, 07-Dec-2022",
+      }),
+    ]);
+    expect(
+      response.body.framework.pillars.map(
+        (pillar: { code: string }) => pillar.code,
+      ),
+    ).toEqual([
+      "SAFETY_POLICY_AND_GOALS",
+      "SAFETY_RISK_MANAGEMENT",
+      "SAFETY_ASSURANCE",
+      "PROMOTION_OF_SAFETY",
+    ]);
+    expect(
+      response.body.framework.pillars.flatMap(
+        (pillar: { elements: unknown[] }) => pillar.elements,
+      ),
+    ).toHaveLength(12);
+    expect(await countFrameworkRows()).toEqual(before);
+  });
+
+  it("groups the 12 SMS elements under the 4 SMS pillars", async () => {
+    const response = await request(app).get("/sms/framework");
+
+    expect(response.status).toBe(200);
+    expect(response.body.framework.pillars).toEqual([
+      expect.objectContaining({
+        code: "SAFETY_POLICY_AND_GOALS",
+        elements: [
+          expect.objectContaining({
+            code: "MANAGEMENT_COMMITMENT_AND_RESPONSIBILITY",
+            elementNumber: "1.1",
+          }),
+          expect.objectContaining({
+            code: "ULTIMATE_SAFETY_RESPONSIBILITY",
+            elementNumber: "1.2",
+          }),
+          expect.objectContaining({
+            code: "KEY_SAFETY_STAFF_IDENTIFICATION",
+            elementNumber: "1.3",
+          }),
+          expect.objectContaining({
+            code: "EMERGENCY_RESPONSE_PLANNING",
+            elementNumber: "1.4",
+          }),
+          expect.objectContaining({
+            code: "SMS_DOCUMENTATION",
+            elementNumber: "1.5",
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        code: "SAFETY_RISK_MANAGEMENT",
+        elements: [
+          expect.objectContaining({
+            code: "RISK_HAZARD_DETECTION_AND_IDENTIFICATION",
+            elementNumber: "2.1",
+          }),
+          expect.objectContaining({
+            code: "RISK_ASSESSMENT_AND_MITIGATION",
+            elementNumber: "2.2",
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        code: "SAFETY_ASSURANCE",
+        elements: [
+          expect.objectContaining({
+            code: "SAFETY_PERFORMANCE_MONITORING",
+            elementNumber: "3.1",
+          }),
+          expect.objectContaining({
+            code: "CHANGE_MANAGEMENT",
+            elementNumber: "3.2",
+          }),
+          expect.objectContaining({
+            code: "SMS_CONTINUOUS_IMPROVEMENT",
+            elementNumber: "3.3",
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        code: "PROMOTION_OF_SAFETY",
+        elements: [
+          expect.objectContaining({
+            code: "SAFETY_TRAINING_AND_EDUCATION",
+            elementNumber: "4.1",
+          }),
+          expect.objectContaining({
+            code: "SAFETY_COMMUNICATION",
+            elementNumber: "4.2",
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("keeps CAP722A as source context rather than executable compliance logic", async () => {
+    const response = await request(app).get("/sms/framework");
+
+    expect(response.status).toBe(200);
+    expect(response.body.framework.sources).toContainEqual(
+      expect.objectContaining({
+        code: "CAA_CAP_722A_2022",
+        sourceType: "external_guidance_reference",
+        notes:
+          "Recorded as source guidance and version context only; not executable compliance logic.",
+      }),
+    );
+    expect(response.body.framework.pillars).not.toContainEqual(
+      expect.objectContaining({
+        sourceCode: "CAA_CAP_722A_2022",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
What changed:

Added migration-backed SMS reference tables for sources, pillars, and elements
Seeded CAP722A as source/version context only, not executable compliance logic
Seeded the 4 SMS pillars and 12 SMS elements from the workbook and
Added the SMS framework repository/read model
Added GET /sms/framework and wired it into the app
Added tests for seeded data, grouping, ordering, CAP722A handling, and read-only behavior, ,
Advanced the save point to SMS control mapping records
Verification:

./node_modules/.bin/vitest.cmd run src/tests/sms-framework.test.ts passed: 3 tests.
./node_modules/.bin/vitest.cmd run passed: 209 tests across 19 files.
node scripts/validate-save-point.mjs fsms-save-point.json passed.
node scripts/check-next-build-step-pr.mjs origin/main passed.
git diff --check passed.
npm run build still fails because the repo has no root tsconfig.json; this is the existing project setup issue.