### PR TITLE
Add SMS control mappings

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add SMS control mapping records so FSMS platform, pilot, risk, airspace, mission gate, and audit controls can be linked to SMS elements.",
+ "nextBuildStep": "Add SMS control mapping context to audit evidence outputs so generated reports show which SMS elements each FSMS assurance control supports.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add SMS control mapping context to audit evidence outputs so generated reports show which SMS elements each FSMS assurance control supports.",
+ "nextBuildStep": "Add migration-backed SMS control mapping context to audit evidence outputs so generated reports show which SMS elements each FSMS assurance control supports.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/migrations/019_create_sms_control_mappings.sql
+++ b/src/migrations/019_create_sms_control_mappings.sql
@@ -1,0 +1,221 @@
+create table if not exists sms_controls (
+  code text primary key,
+  title text not null,
+  control_area text not null,
+  description text not null,
+  display_order int not null unique
+);
+
+create table if not exists sms_control_element_mappings (
+  control_code text not null references sms_controls(code) on delete cascade,
+  element_code text not null references sms_elements(code) on delete restrict,
+  rationale text not null,
+  display_order int not null,
+  primary key (control_code, element_code),
+  constraint sms_control_element_mappings_order_uniq
+    unique (control_code, display_order)
+);
+
+insert into sms_controls (
+  code,
+  title,
+  control_area,
+  description,
+  display_order
+)
+values
+  (
+    'PLATFORM_READINESS_MAINTENANCE',
+    'Platform readiness and maintenance controls',
+    'platform',
+    'Checks that UAV platform status and maintenance evidence are suitable before mission use.',
+    1
+  ),
+  (
+    'PILOT_READINESS',
+    'Pilot readiness controls',
+    'pilot',
+    'Checks that operator readiness evidence is current and suitable for mission use.',
+    2
+  ),
+  (
+    'MISSION_RISK_ASSESSMENT',
+    'Mission risk controls',
+    'risk',
+    'Captures operational risk inputs for mission complexity, exposure, weather, airspace, and payload considerations.',
+    3
+  ),
+  (
+    'AIRSPACE_COMPLIANCE',
+    'Airspace compliance controls',
+    'airspace',
+    'Captures operating constraints, airspace class, altitude, restriction, and permission status.',
+    4
+  ),
+  (
+    'MISSION_READINESS_GATE',
+    'Mission readiness gate controls',
+    'mission_gate',
+    'Combines platform, pilot, risk, and airspace readiness into a gate result before approval or dispatch.',
+    5
+  ),
+  (
+    'MISSION_APPROVAL_GUARD',
+    'Mission approval guard controls',
+    'mission_gate',
+    'Requires linked readiness and planning evidence before mission approval state changes.',
+    6
+  ),
+  (
+    'MISSION_DISPATCH_GUARD',
+    'Mission dispatch guard controls',
+    'mission_gate',
+    'Requires linked approval and dispatch evidence before launch state changes.',
+    7
+  ),
+  (
+    'AUDIT_EVIDENCE_SNAPSHOTS',
+    'Audit evidence snapshot controls',
+    'audit',
+    'Preserves readiness and decision evidence as reviewable records.',
+    8
+  ),
+  (
+    'POST_OPERATION_REPORT_SIGNOFF',
+    'Post-operation report and sign-off controls',
+    'audit',
+    'Produces post-operation evidence reports and stores accountable-manager sign-off records.',
+    9
+  )
+on conflict (code) do update
+set
+  title = excluded.title,
+  control_area = excluded.control_area,
+  description = excluded.description,
+  display_order = excluded.display_order;
+
+insert into sms_control_element_mappings (
+  control_code,
+  element_code,
+  rationale,
+  display_order
+)
+values
+  (
+    'PLATFORM_READINESS_MAINTENANCE',
+    'RISK_ASSESSMENT_AND_MITIGATION',
+    'Platform status and maintenance due checks mitigate technical safety risk before mission use.',
+    1
+  ),
+  (
+    'PLATFORM_READINESS_MAINTENANCE',
+    'SAFETY_PERFORMANCE_MONITORING',
+    'Maintenance status provides measurable safety performance evidence for the UAV platform.',
+    2
+  ),
+  (
+    'PILOT_READINESS',
+    'RISK_ASSESSMENT_AND_MITIGATION',
+    'Pilot readiness evidence mitigates operator-related mission risk.',
+    1
+  ),
+  (
+    'PILOT_READINESS',
+    'SAFETY_TRAINING_AND_EDUCATION',
+    'Pilot readiness depends on current authorisation, competence, and training evidence.',
+    2
+  ),
+  (
+    'MISSION_RISK_ASSESSMENT',
+    'RISK_HAZARD_DETECTION_AND_IDENTIFICATION',
+    'Mission risk inputs identify operational hazards before approval or dispatch.',
+    1
+  ),
+  (
+    'MISSION_RISK_ASSESSMENT',
+    'RISK_ASSESSMENT_AND_MITIGATION',
+    'Risk scoring and risk bands support mitigation decisions and gate outcomes.',
+    2
+  ),
+  (
+    'AIRSPACE_COMPLIANCE',
+    'RISK_HAZARD_DETECTION_AND_IDENTIFICATION',
+    'Airspace constraints identify operational hazards and restrictions.',
+    1
+  ),
+  (
+    'AIRSPACE_COMPLIANCE',
+    'RISK_ASSESSMENT_AND_MITIGATION',
+    'Permission and restriction status mitigate airspace operating risk.',
+    2
+  ),
+  (
+    'MISSION_READINESS_GATE',
+    'SAFETY_PERFORMANCE_MONITORING',
+    'The readiness gate measures whether mission inputs satisfy approval and dispatch expectations.',
+    1
+  ),
+  (
+    'MISSION_READINESS_GATE',
+    'SMS_DOCUMENTATION',
+    'Gate results are documented as structured safety evidence.',
+    2
+  ),
+  (
+    'MISSION_APPROVAL_GUARD',
+    'ULTIMATE_SAFETY_RESPONSIBILITY',
+    'Approval guardrails support accountable decision-making before mission state changes.',
+    1
+  ),
+  (
+    'MISSION_APPROVAL_GUARD',
+    'SAFETY_PERFORMANCE_MONITORING',
+    'Approval checks verify gate-ready evidence before approval is recorded.',
+    2
+  ),
+  (
+    'MISSION_DISPATCH_GUARD',
+    'RISK_ASSESSMENT_AND_MITIGATION',
+    'Dispatch checks mitigate launch risk by requiring linked approval and dispatch evidence.',
+    1
+  ),
+  (
+    'MISSION_DISPATCH_GUARD',
+    'SAFETY_PERFORMANCE_MONITORING',
+    'Dispatch evidence confirms the mission remains suitable at launch decision time.',
+    2
+  ),
+  (
+    'AUDIT_EVIDENCE_SNAPSHOTS',
+    'SMS_DOCUMENTATION',
+    'Audit snapshots document readiness, decision, and post-operation evidence.',
+    1
+  ),
+  (
+    'AUDIT_EVIDENCE_SNAPSHOTS',
+    'SMS_CONTINUOUS_IMPROVEMENT',
+    'Reviewable evidence supports later trend review and SMS improvement.',
+    2
+  ),
+  (
+    'POST_OPERATION_REPORT_SIGNOFF',
+    'ULTIMATE_SAFETY_RESPONSIBILITY',
+    'Accountable-manager sign-off records formal review responsibility.',
+    1
+  ),
+  (
+    'POST_OPERATION_REPORT_SIGNOFF',
+    'SMS_DOCUMENTATION',
+    'Generated reports and sign-off records preserve post-operation safety decisions.',
+    2
+  ),
+  (
+    'POST_OPERATION_REPORT_SIGNOFF',
+    'SMS_CONTINUOUS_IMPROVEMENT',
+    'Completed reports provide retained evidence for audit review and improvement.',
+    3
+  )
+on conflict (control_code, element_code) do update
+set
+  rationale = excluded.rationale,
+  display_order = excluded.display_order;

--- a/src/sms-framework/sms-framework.controller.ts
+++ b/src/sms-framework/sms-framework.controller.ts
@@ -16,4 +16,17 @@ export class SmsFrameworkController {
       next(error);
     }
   };
+
+  listControlMappings = async (
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const mappings = await this.smsFrameworkService.listControlMappings();
+      res.status(200).json({ mappings });
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/sms-framework/sms-framework.repository.ts
+++ b/src/sms-framework/sms-framework.repository.ts
@@ -1,5 +1,7 @@
 import type { PoolClient, QueryResultRow } from "pg";
 import type {
+  SmsControlMappedElement,
+  SmsControlMapping,
   SmsElement,
   SmsFrameworkSource,
   SmsPillar,
@@ -31,6 +33,26 @@ interface SmsElementRow extends QueryResultRow {
   source_code: string;
 }
 
+interface SmsControlRow extends QueryResultRow {
+  code: string;
+  title: string;
+  control_area: string;
+  description: string;
+  display_order: number;
+}
+
+interface SmsControlMappedElementRow extends QueryResultRow {
+  control_code: string;
+  element_code: string;
+  pillar_code: string;
+  pillar_title: string;
+  element_number: string;
+  element_title: string;
+  element_display_order: number;
+  rationale: string;
+  mapping_display_order: number;
+}
+
 const toSource = (row: SmsFrameworkSourceRow): SmsFrameworkSource => ({
   code: row.code,
   title: row.title,
@@ -56,6 +78,30 @@ const toElement = (row: SmsElementRow): SmsElement => ({
   title: row.title,
   displayOrder: row.display_order,
   sourceCode: row.source_code,
+});
+
+const toMappedElement = (
+  row: SmsControlMappedElementRow,
+): SmsControlMappedElement => ({
+  code: row.element_code,
+  pillarCode: row.pillar_code,
+  pillarTitle: row.pillar_title,
+  elementNumber: row.element_number,
+  title: row.element_title,
+  displayOrder: row.element_display_order,
+  rationale: row.rationale,
+});
+
+const toControlMapping = (
+  row: SmsControlRow,
+  elements: SmsControlMappedElement[],
+): SmsControlMapping => ({
+  code: row.code,
+  title: row.title,
+  controlArea: row.control_area,
+  description: row.description,
+  displayOrder: row.display_order,
+  elements,
 });
 
 export class SmsFrameworkRepository {
@@ -99,5 +145,44 @@ export class SmsFrameworkRepository {
     );
 
     return result.rows.map(toElement);
+  }
+
+  async listControlMappings(tx: PoolClient): Promise<SmsControlMapping[]> {
+    const controls = await tx.query<SmsControlRow>(
+      `
+      select *
+      from sms_controls
+      order by display_order asc
+      `,
+    );
+    const mappedElements = await tx.query<SmsControlMappedElementRow>(
+      `
+      select
+        mappings.control_code,
+        mappings.element_code,
+        elements.pillar_code,
+        pillars.title as pillar_title,
+        elements.element_number,
+        elements.title as element_title,
+        elements.display_order as element_display_order,
+        mappings.rationale,
+        mappings.display_order as mapping_display_order
+      from sms_control_element_mappings mappings
+      inner join sms_elements elements
+        on elements.code = mappings.element_code
+      inner join sms_pillars pillars
+        on pillars.code = elements.pillar_code
+      order by mappings.control_code asc, mappings.display_order asc
+      `,
+    );
+
+    return controls.rows.map((control) =>
+      toControlMapping(
+        control,
+        mappedElements.rows
+          .filter((element) => element.control_code === control.code)
+          .map(toMappedElement),
+      ),
+    );
   }
 }

--- a/src/sms-framework/sms-framework.routes.ts
+++ b/src/sms-framework/sms-framework.routes.ts
@@ -7,6 +7,7 @@ export function createSmsFrameworkRouter(
   const router = Router();
 
   router.get("/framework", controller.getFramework);
+  router.get("/control-mappings", controller.listControlMappings);
 
   return router;
 }

--- a/src/sms-framework/sms-framework.service.ts
+++ b/src/sms-framework/sms-framework.service.ts
@@ -1,6 +1,9 @@
 import type { Pool } from "pg";
 import { SmsFrameworkRepository } from "./sms-framework.repository";
-import type { SmsFramework } from "./sms-framework.types";
+import type {
+  SmsControlMapping,
+  SmsFramework,
+} from "./sms-framework.types";
 
 export class SmsFrameworkService {
   constructor(
@@ -19,6 +22,16 @@ export class SmsFrameworkService {
         sources,
         pillars,
       };
+    } finally {
+      client.release();
+    }
+  }
+
+  async listControlMappings(): Promise<SmsControlMapping[]> {
+    const client = await this.pool.connect();
+
+    try {
+      return await this.smsFrameworkRepository.listControlMappings(client);
     } finally {
       client.release();
     }

--- a/src/sms-framework/sms-framework.types.ts
+++ b/src/sms-framework/sms-framework.types.ts
@@ -29,3 +29,22 @@ export interface SmsFramework {
   sources: SmsFrameworkSource[];
   pillars: SmsPillar[];
 }
+
+export interface SmsControlMappedElement {
+  code: string;
+  pillarCode: string;
+  pillarTitle: string;
+  elementNumber: string;
+  title: string;
+  displayOrder: number;
+  rationale: string;
+}
+
+export interface SmsControlMapping {
+  code: string;
+  title: string;
+  controlArea: string;
+  description: string;
+  displayOrder: number;
+  elements: SmsControlMappedElement[];
+}

--- a/src/tests/sms-framework.test.ts
+++ b/src/tests/sms-framework.test.ts
@@ -9,7 +9,9 @@ const countFrameworkRows = async () => {
     select
       (select count(*)::int from sms_framework_sources) as source_count,
       (select count(*)::int from sms_pillars) as pillar_count,
-      (select count(*)::int from sms_elements) as element_count
+      (select count(*)::int from sms_elements) as element_count,
+      (select count(*)::int from sms_controls) as control_count,
+      (select count(*)::int from sms_control_element_mappings) as mapping_count
     `,
   );
 
@@ -17,6 +19,8 @@ const countFrameworkRows = async () => {
     source_count: number;
     pillar_count: number;
     element_count: number;
+    control_count: number;
+    mapping_count: number;
   };
 };
 
@@ -158,5 +162,116 @@ describe("SMS framework reference data", () => {
         sourceCode: "CAA_CAP_722A_2022",
       }),
     );
+  });
+
+  it("lists seeded FSMS control mappings with SMS pillar and element context", async () => {
+    const before = await countFrameworkRows();
+
+    const response = await request(app).get("/sms/control-mappings");
+
+    expect(response.status).toBe(200);
+    expect(
+      response.body.mappings.map(
+        (mapping: { code: string }) => mapping.code,
+      ),
+    ).toEqual([
+      "PLATFORM_READINESS_MAINTENANCE",
+      "PILOT_READINESS",
+      "MISSION_RISK_ASSESSMENT",
+      "AIRSPACE_COMPLIANCE",
+      "MISSION_READINESS_GATE",
+      "MISSION_APPROVAL_GUARD",
+      "MISSION_DISPATCH_GUARD",
+      "AUDIT_EVIDENCE_SNAPSHOTS",
+      "POST_OPERATION_REPORT_SIGNOFF",
+    ]);
+    expect(response.body.mappings).toContainEqual(
+      expect.objectContaining({
+        code: "PLATFORM_READINESS_MAINTENANCE",
+        controlArea: "platform",
+        elements: expect.arrayContaining([
+          expect.objectContaining({
+            code: "RISK_ASSESSMENT_AND_MITIGATION",
+            pillarCode: "SAFETY_RISK_MANAGEMENT",
+            pillarTitle: "Safety Risk Management",
+          }),
+          expect.objectContaining({
+            code: "SAFETY_PERFORMANCE_MONITORING",
+            pillarCode: "SAFETY_ASSURANCE",
+            pillarTitle: "Safety Assurance",
+          }),
+        ]),
+      }),
+    );
+    expect(response.body.mappings).toContainEqual(
+      expect.objectContaining({
+        code: "POST_OPERATION_REPORT_SIGNOFF",
+        controlArea: "audit",
+        elements: expect.arrayContaining([
+          expect.objectContaining({
+            code: "ULTIMATE_SAFETY_RESPONSIBILITY",
+            pillarCode: "SAFETY_POLICY_AND_GOALS",
+          }),
+          expect.objectContaining({
+            code: "SMS_DOCUMENTATION",
+            pillarCode: "SAFETY_POLICY_AND_GOALS",
+          }),
+          expect.objectContaining({
+            code: "SMS_CONTINUOUS_IMPROVEMENT",
+            pillarCode: "SAFETY_ASSURANCE",
+          }),
+        ]),
+      }),
+    );
+    expect(await countFrameworkRows()).toEqual(before);
+  });
+
+  it("seeds control mappings for platform, pilot, risk, airspace, gate, and audit controls", async () => {
+    const response = await request(app).get("/sms/control-mappings");
+
+    expect(response.status).toBe(200);
+    expect(response.body.mappings).toEqual([
+      expect.objectContaining({ controlArea: "platform" }),
+      expect.objectContaining({ controlArea: "pilot" }),
+      expect.objectContaining({ controlArea: "risk" }),
+      expect.objectContaining({ controlArea: "airspace" }),
+      expect.objectContaining({ controlArea: "mission_gate" }),
+      expect.objectContaining({ controlArea: "mission_gate" }),
+      expect.objectContaining({ controlArea: "mission_gate" }),
+      expect.objectContaining({ controlArea: "audit" }),
+      expect.objectContaining({ controlArea: "audit" }),
+    ]);
+    expect(
+      response.body.mappings.every(
+        (mapping: { elements: unknown[] }) => mapping.elements.length > 0,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects broken SMS control mapping element links", async () => {
+    const before = await countFrameworkRows();
+
+    await expect(
+      pool.query(
+        `
+        insert into sms_control_element_mappings (
+          control_code,
+          element_code,
+          rationale,
+          display_order
+        )
+        values ($1, $2, $3, $4)
+        `,
+        [
+          "PLATFORM_READINESS_MAINTENANCE",
+          "UNKNOWN_SMS_ELEMENT",
+          "This should fail because the SMS element does not exist.",
+          99,
+        ],
+      ),
+    ).rejects.toMatchObject({
+      code: "23503",
+    });
+    expect(await countFrameworkRows()).toEqual(before);
   });
 });


### PR DESCRIPTION
What changed:

Added sms_controls and sms_control_element_mappings reference tables with seeded FSMS controls and SMS element links: 【C:/Users/rabbi/Documents/Codex/2026-04-17-i-want-to-continue-a-project/fsms-sms-control-mapping-issue-55/src/migrations/019_create_sms_control_mappings.sql†L1】
Added read model types for mapped controls/elements: 【C:/Users/rabbi/Documents/Codex/2026-04-17-i-want-to-continue-a-project/fsms-sms-control-mapping-issue-55/src/sms-framework/sms-framework.types.ts†L33】
Added repository support for listing mappings with pillar/element context: 【C:/Users/rabbi/Documents/Codex/2026-04-17-i-want-to-continue-a-project/fsms-sms-control-mapping-issue-55/src/sms-framework/sms-framework.repository.ts†L150】
Added GET /sms/control-mappings: 【C:/Users/rabbi/Documents/Codex/2026-04-17-i-want-to-continue-a-project/fsms-sms-control-mapping-issue-55/src/sms-framework/sms-framework.routes.ts†L10】
Added tests for seeded mappings, expected control areas, and FK rejection of broken SMS element links: 【C:/Users/rabbi/Documents/Codex/2026-04-17-i-want-to-continue-a-project/fsms-sms-control-mapping-issue-55/src/tests/sms-framework.test.ts†L167】
Advanced the save point to adding SMS mapping context to audit evidence outputs: 【C:/Users/rabbi/Documents/Codex/2026-04-17-i-want-to-continue-a-project/fsms-sms-control-mapping-issue-55/fsms-save-point.json†L92】
Verification:

./node_modules/.bin/vitest.cmd run src/tests/sms-framework.test.ts passed: 6 tests.
./node_modules/.bin/vitest.cmd run passed: 212 tests across 19 files.
node scripts/validate-save-point.mjs fsms-save-point.json passed.
node scripts/check-next-build-step-pr.mjs origin/main passed.
git diff --check passed.
npm run build still fails because the repo has no root tsconfig.json; this is the existing project setup issue.