### PR TITLE
Add SMS control mapping context to audit evidence outputs

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add migration-backed SMS control mapping context to audit evidence outputs so generated reports show which SMS elements each FSMS assurance control supports.",
+ "nextBuildStep": "Add SMS control mapping context to mission readiness audit snapshots so planning and approval evidence can show supported SMS elements.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.repository.ts
+++ b/src/audit-evidence/audit-evidence.repository.ts
@@ -3,6 +3,7 @@ import type { PoolClient, QueryResultRow } from "pg";
 import type { MissionReadinessCheck } from "../missions/mission-readiness.types";
 import type {
   AuditEvidenceSnapshot,
+  AuditReportSmsControlMapping,
   MissionDecisionEvidenceLink,
   MissionLifecycleEvidenceEvent,
   PlanningApprovalHandoffEvidence,
@@ -118,6 +119,13 @@ interface CreatePostOperationAuditSignoffRow {
   createdBy: string | null;
 }
 
+interface AuditReportSmsControlMappingRow extends QueryResultRow {
+  code: string;
+  title: string;
+  control_area: string;
+  sms_elements: string[] | null;
+}
+
 const toAuditEvidenceSnapshot = (
   row: AuditEvidenceSnapshotRow,
 ): AuditEvidenceSnapshot => ({
@@ -198,6 +206,15 @@ const toPostOperationAuditSignoff = (
   signatureReference: row.signature_reference,
   createdBy: row.created_by,
   createdAt: row.created_at.toISOString(),
+});
+
+const toAuditReportSmsControlMapping = (
+  row: AuditReportSmsControlMappingRow,
+): AuditReportSmsControlMapping => ({
+  code: row.code,
+  title: row.title,
+  controlArea: row.control_area,
+  smsElements: row.sms_elements ?? [],
 });
 
 export class AuditEvidenceRepository {
@@ -579,6 +596,50 @@ export class AuditEvidenceRepository {
     return result.rows[0]
       ? toPostOperationAuditSignoff(result.rows[0])
       : null;
+  }
+
+  async listSmsControlMappingsForAuditReport(
+    tx: PoolClient,
+  ): Promise<AuditReportSmsControlMapping[]> {
+    const result = await tx.query<AuditReportSmsControlMappingRow>(
+      `
+      select
+        controls.code,
+        controls.title,
+        controls.control_area,
+        coalesce(
+          array_agg(
+            elements.element_number || ' ' || elements.title
+            order by mappings.display_order asc
+          ) filter (where elements.code is not null),
+          array[]::text[]
+        ) as sms_elements
+      from sms_controls controls
+      left join sms_control_element_mappings mappings
+        on mappings.control_code = controls.code
+      left join sms_elements elements
+        on elements.code = mappings.element_code
+      where controls.code in (
+        'PLATFORM_READINESS_MAINTENANCE',
+        'PILOT_READINESS',
+        'MISSION_RISK_ASSESSMENT',
+        'AIRSPACE_COMPLIANCE',
+        'MISSION_READINESS_GATE',
+        'MISSION_APPROVAL_GUARD',
+        'MISSION_DISPATCH_GUARD',
+        'AUDIT_EVIDENCE_SNAPSHOTS',
+        'POST_OPERATION_REPORT_SIGNOFF'
+      )
+      group by
+        controls.code,
+        controls.title,
+        controls.control_area,
+        controls.display_order
+      order by controls.display_order asc
+      `,
+    );
+
+    return result.rows.map(toAuditReportSmsControlMapping);
   }
 
   async decisionEvidenceLinkReferencesReadinessSnapshot(

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -11,6 +11,7 @@ import { AuditEvidenceRepository } from "./audit-evidence.repository";
 import type {
   AuditEvidenceSnapshot,
   AuditReportSection,
+  AuditReportSmsControlMapping,
   CreateAuditEvidenceSnapshotInput,
   CreateMissionDecisionEvidenceLinkInput,
   CreatePostOperationAuditSignoffInput,
@@ -283,9 +284,11 @@ export class AuditEvidenceService {
       evidenceExport.missionId,
       evidenceExport.snapshotId,
     );
+    const smsControlMappings = await this.getSmsControlMappingsForAuditReport();
     const sections = this.buildPostOperationReportSections(
       evidenceExport,
       signoff,
+      smsControlMappings,
     );
 
     return {
@@ -417,6 +420,20 @@ export class AuditEvidenceService {
     }
   }
 
+  private async getSmsControlMappingsForAuditReport(): Promise<
+    AuditReportSmsControlMapping[]
+  > {
+    const client = await this.pool.connect();
+
+    try {
+      return await this.auditEvidenceRepository.listSmsControlMappingsForAuditReport(
+        client,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
   private async buildPostOperationCompletionSnapshot(
     client: Awaited<ReturnType<Pool["connect"]>>,
     mission: { missionId: string; missionPlanId: string | null; status: string },
@@ -489,6 +506,7 @@ export class AuditEvidenceService {
   private buildPostOperationReportSections(
     evidenceExport: PostOperationEvidenceExportPackage,
     signoff: PostOperationAuditSignoff | null,
+    smsControlMappings: AuditReportSmsControlMapping[],
   ): AuditReportSection[] {
     const snapshot = evidenceExport.completionSnapshot;
     const pendingSignoff = "Pending sign-off";
@@ -613,6 +631,24 @@ export class AuditEvidenceService {
             value: signoff?.createdAt ?? pendingSignoff,
           },
         ],
+      },
+      {
+        heading: "SMS assurance context",
+        fields:
+          smsControlMappings.length > 0
+            ? smsControlMappings.map((mapping) => ({
+                label: mapping.title,
+                value:
+                  mapping.smsElements.length > 0
+                    ? mapping.smsElements.join("; ")
+                    : "No SMS element mapping recorded",
+              }))
+            : [
+                {
+                  label: "SMS control mappings",
+                  value: "No SMS control mappings recorded",
+                },
+              ],
       },
     ];
   }

--- a/src/audit-evidence/audit-evidence.types.ts
+++ b/src/audit-evidence/audit-evidence.types.ts
@@ -140,6 +140,13 @@ export interface AuditReportSection {
   fields: AuditReportField[];
 }
 
+export interface AuditReportSmsControlMapping {
+  code: string;
+  title: string;
+  controlArea: string;
+  smsElements: string[];
+}
+
 export interface PostOperationEvidenceRenderedReport {
   renderType: "post_operation_completion_evidence_report";
   formatVersion: 1;

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -300,6 +300,21 @@ const countRows = async (missionId: string) => {
   };
 };
 
+const countSmsMappingRows = async () => {
+  const result = await pool.query(
+    `
+    select
+      (select count(*)::int from sms_controls) as control_count,
+      (select count(*)::int from sms_control_element_mappings) as mapping_count
+    `,
+  );
+
+  return result.rows[0] as {
+    control_count: number;
+    mapping_count: number;
+  };
+};
+
 describe("audit evidence snapshots", () => {
   beforeAll(async () => {
     await runMigrations(pool);
@@ -994,6 +1009,21 @@ describe("audit evidence snapshots", () => {
               { label: "Sign-off recorded at", value: "Pending sign-off" },
             ]),
           },
+          {
+            heading: "SMS assurance context",
+            fields: expect.arrayContaining([
+              expect.objectContaining({
+                label: "Platform readiness and maintenance controls",
+                value: expect.stringContaining(
+                  "2.2 Assessment and mitigation of risks",
+                ),
+              }),
+              expect.objectContaining({
+                label: "Post-operation report and sign-off controls",
+                value: expect.stringContaining("1.2 The ultimate responsibility"),
+              }),
+            ]),
+          },
         ],
       },
     });
@@ -1009,6 +1039,15 @@ describe("audit evidence snapshots", () => {
     );
     expect(response.body.report.report.plainText).toContain(
       "Review decision/status: Pending sign-off",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "SMS assurance context",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Platform readiness and maintenance controls",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Post-operation report and sign-off controls",
     );
     expect(await countRows(missionId)).toEqual(before);
   });
@@ -1071,6 +1110,60 @@ describe("audit evidence snapshots", () => {
       `Sign-off record ID: ${signoffResponse.body.signoff.id}`,
     );
     expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("adds SMS control mapping context to rendered reports without mutating reference data", async () => {
+    const { missionId } = await createCompletedMission();
+    const snapshotResponse = await request(app)
+      .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
+      .send({});
+
+    expect(snapshotResponse.status).toBe(201);
+    const beforeMission = await countRows(missionId);
+    const beforeMappings = await countSmsMappingRows();
+
+    const response = await request(app).get(
+      `/missions/${missionId}/post-operation/evidence-snapshots/${snapshotResponse.body.snapshot.id}/export/render`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.report.report.sections).toContainEqual({
+      heading: "SMS assurance context",
+      fields: expect.arrayContaining([
+        {
+          label: "Platform readiness and maintenance controls",
+          value: expect.stringContaining(
+            "3.1 Monitoring and Measurement of Safety Performance",
+          ),
+        },
+        {
+          label: "Pilot readiness controls",
+          value: expect.stringContaining("4.1 Training and education"),
+        },
+        {
+          label: "Mission risk controls",
+          value: expect.stringContaining(
+            "2.1 Risk/hazard detection and identification",
+          ),
+        },
+        {
+          label: "Airspace compliance controls",
+          value: expect.stringContaining(
+            "2.1 Risk/hazard detection and identification",
+          ),
+        },
+        {
+          label: "Mission readiness gate controls",
+          value: expect.stringContaining("1.5 SMS documentation"),
+        },
+        {
+          label: "Post-operation report and sign-off controls",
+          value: expect.stringContaining("3.3 Continuous improvement of SMS"),
+        },
+      ]),
+    });
+    expect(await countRows(missionId)).toEqual(beforeMission);
+    expect(await countSmsMappingRows()).toEqual(beforeMappings);
   });
 
   it("does not leak stored sign-offs from other post-operation snapshots", async () => {
@@ -1212,6 +1305,13 @@ describe("audit evidence snapshots", () => {
     expect(response.body.toString("latin1")).toContain(
       "Review decision/status: Pending sign-off",
     );
+    expect(response.body.toString("latin1")).toContain(
+      "SMS assurance context",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Mission readiness gate controls",
+    );
+    expect(response.body.toString("latin1")).toContain("1.5 SMS documentation");
     expect(await countRows(missionId)).toEqual(before);
   });
 
@@ -1259,6 +1359,9 @@ describe("audit evidence snapshots", () => {
     expect(pdfText).toContain(
       `Sign-off record ID: ${signoffResponse.body.signoff.id}`,
     );
+    expect(pdfText).toContain("SMS assurance context");
+    expect(pdfText).toContain("Post-operation report and sign-off controls");
+    expect(pdfText).toContain("3.3 Continuous improvement of SMS");
     expect(await countRows(missionId)).toEqual(before);
   });
 


### PR DESCRIPTION
Implements #57 by adding read-only SMS control mapping context to post-operation rendered and PDF audit evidence outputs.

## What changed
- Added audit report SMS control mapping read model.
- Post-operation rendered reports now include an “SMS assurance context” section using seeded SMS control mappings.
- Post-operation PDFs include the same SMS mapping context through the rendered report plaintext.
- Missing/unmapped controls degrade with “No SMS element mapping recorded” / “No SMS control mappings recorded”.
- Added tests for rendered report output, PDF output, and no mutation of mission/SMS mapping reference data.
- Advanced save point to adding SMS context to mission readiness audit snapshots.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/audit-evidence.test.ts` passed: 37 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 213 tests across 19 files.
- `node scripts/validate-save-point.mjs fsms-save-point.json` passed.
- `node scripts/check-next-build-step-pr.mjs origin/main` passed.
- `git diff --check` passed.
- `npm run build` still exits with TypeScript help text because the repo does not currently have a root `tsconfig.json`.

Closes #57.
