### PR TITLE
Add SMS control mapping context to mission readiness audit snapshots

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add SMS control mapping context to mission readiness audit snapshots so planning and approval evidence can show supported SMS elements.",
+ "nextBuildStep": "Add SMS control mapping context to mission planning approval handoff responses so approval evidence can display supported SMS elements from the linked readiness snapshot.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.repository.ts
+++ b/src/audit-evidence/audit-evidence.repository.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from "crypto";
 import type { PoolClient, QueryResultRow } from "pg";
-import type { MissionReadinessCheck } from "../missions/mission-readiness.types";
 import type {
   AuditEvidenceSnapshot,
+  AuditEvidenceReadinessSnapshot,
   AuditReportSmsControlMapping,
   MissionDecisionEvidenceLink,
   MissionLifecycleEvidenceEvent,
@@ -21,14 +21,14 @@ interface AuditEvidenceSnapshotRow extends QueryResultRow {
   blocks_approval: boolean;
   blocks_dispatch: boolean;
   requires_review: boolean;
-  readiness_snapshot: MissionReadinessCheck;
+  readiness_snapshot: AuditEvidenceReadinessSnapshot;
   created_by: string | null;
   created_at: Date;
 }
 
 interface CreateAuditEvidenceSnapshotRow {
   missionId: string;
-  readinessSnapshot: MissionReadinessCheck;
+  readinessSnapshot: AuditEvidenceReadinessSnapshot;
   createdBy: string | null;
 }
 

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -1,4 +1,5 @@
 import type { Pool } from "pg";
+import type { MissionReadinessCheck } from "../missions/mission-readiness.types";
 import { MissionService } from "../missions/mission.service";
 import {
   AuditEvidenceMissionNotCompletedError,
@@ -10,6 +11,7 @@ import {
 import { AuditEvidenceRepository } from "./audit-evidence.repository";
 import type {
   AuditEvidenceSnapshot,
+  AuditEvidenceReadinessSnapshot,
   AuditReportSection,
   AuditReportSmsControlMapping,
   CreateAuditEvidenceSnapshotInput,
@@ -44,12 +46,21 @@ export class AuditEvidenceService {
     input: CreateAuditEvidenceSnapshotInput | undefined,
   ): Promise<AuditEvidenceSnapshot> {
     const validated = validateCreateAuditEvidenceSnapshotInput(input);
-    const readinessSnapshot = await this.missionService.checkMissionReadiness({
+    const readinessCheck = await this.missionService.checkMissionReadiness({
       missionId,
     });
     const client = await this.pool.connect();
 
     try {
+      const smsControlMappings =
+        await this.auditEvidenceRepository.listSmsControlMappingsForAuditReport(
+          client,
+        );
+      const readinessSnapshot = this.buildReadinessEvidenceSnapshot(
+        readinessCheck,
+        smsControlMappings,
+      );
+
       return await this.auditEvidenceRepository.insertReadinessSnapshot(client, {
         missionId,
         readinessSnapshot,
@@ -432,6 +443,16 @@ export class AuditEvidenceService {
     } finally {
       client.release();
     }
+  }
+
+  private buildReadinessEvidenceSnapshot(
+    readinessCheck: MissionReadinessCheck,
+    smsControlMappings: AuditReportSmsControlMapping[],
+  ): AuditEvidenceReadinessSnapshot {
+    return {
+      ...readinessCheck,
+      smsControlMappings,
+    };
   }
 
   private async buildPostOperationCompletionSnapshot(

--- a/src/audit-evidence/audit-evidence.types.ts
+++ b/src/audit-evidence/audit-evidence.types.ts
@@ -34,6 +34,11 @@ export interface CreateMissionDecisionEvidenceLinkInput {
   createdBy?: string | null;
 }
 
+export interface AuditEvidenceReadinessSnapshot
+  extends MissionReadinessCheck {
+  smsControlMappings: AuditReportSmsControlMapping[];
+}
+
 export interface AuditEvidenceSnapshot {
   id: string;
   missionId: string;
@@ -43,7 +48,7 @@ export interface AuditEvidenceSnapshot {
   blocksApproval: boolean;
   blocksDispatch: boolean;
   requiresReview: boolean;
-  readinessSnapshot: MissionReadinessCheck;
+  readinessSnapshot: AuditEvidenceReadinessSnapshot;
   createdBy: string | null;
   createdAt: string;
 }

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -331,6 +331,7 @@ describe("audit evidence snapshots", () => {
   it("captures the current mission readiness gate as reviewable evidence", async () => {
     const { missionId, platformId, pilotId } = await createReadyMission();
     const before = await countRows(missionId);
+    const beforeMappings = await countSmsMappingRows();
 
     const response = await request(app)
       .post(`/missions/${missionId}/readiness/audit-snapshots`)
@@ -371,15 +372,52 @@ describe("audit evidence snapshots", () => {
         airspaceCompliance: {
           result: "pass",
         },
+        smsControlMappings: expect.arrayContaining([
+          expect.objectContaining({
+            code: "PLATFORM_READINESS_MAINTENANCE",
+            title: "Platform readiness and maintenance controls",
+            smsElements: expect.arrayContaining([
+              "3.1 Monitoring and Measurement of Safety Performance",
+            ]),
+          }),
+          expect.objectContaining({
+            code: "PILOT_READINESS",
+            title: "Pilot readiness controls",
+            smsElements: expect.arrayContaining(["4.1 Training and education"]),
+          }),
+          expect.objectContaining({
+            code: "MISSION_RISK_ASSESSMENT",
+            title: "Mission risk controls",
+            smsElements: expect.arrayContaining([
+              "2.1 Risk/hazard detection and identification",
+            ]),
+          }),
+          expect.objectContaining({
+            code: "AIRSPACE_COMPLIANCE",
+            title: "Airspace compliance controls",
+            smsElements: expect.arrayContaining([
+              "2.1 Risk/hazard detection and identification",
+            ]),
+          }),
+          expect.objectContaining({
+            code: "MISSION_READINESS_GATE",
+            title: "Mission readiness gate controls",
+            smsElements: expect.arrayContaining(["1.5 SMS documentation"]),
+          }),
+        ]),
       },
     });
     expect(response.body.snapshot.id).toEqual(expect.any(String));
     expect(response.body.snapshot.createdAt).toEqual(expect.any(String));
+    expect(response.body.snapshot.readinessSnapshot.smsControlMappings).toHaveLength(
+      9,
+    );
 
     expect(await countRows(missionId)).toEqual({
       ...before,
       snapshot_count: before.snapshot_count + 1,
     });
+    expect(await countSmsMappingRows()).toEqual(beforeMappings);
   });
 
   it("keeps snapshots immutable when later source inputs change", async () => {
@@ -426,6 +464,12 @@ describe("audit evidence snapshots", () => {
         airspaceCompliance: {
           result: "pass",
         },
+        smsControlMappings: expect.arrayContaining([
+          expect.objectContaining({
+            code: "MISSION_READINESS_GATE",
+            smsElements: expect.arrayContaining(["1.5 SMS documentation"]),
+          }),
+        ]),
       },
     });
   });


### PR DESCRIPTION
Implements #59 by storing SMS control mapping context inside mission readiness audit snapshots.

## What changed
- Added an audit evidence readiness snapshot type that extends the live mission readiness check with SMS control mappings.
- Mission readiness audit snapshot creation now reads seeded SMS control mappings and stores them inside the immutable `readinessSnapshot` JSON.
- Existing list/read paths return the stored SMS context from the snapshot rather than recalculating it later.
- Added tests covering SMS mappings in readiness snapshots and confirming snapshot creation does not mutate SMS reference records.
- Advanced the save point to mission planning approval handoff responses using SMS context from linked readiness snapshots.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/audit-evidence.test.ts` passed: 37 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 213 tests across 19 files.
- `node scripts/validate-save-point.mjs fsms-save-point.json` passed.
- `git diff --check` passed.
- `node scripts/check-next-build-step-pr.mjs origin/main` could not complete locally because Windows sandboxing prevented/redirected the script's internal `git diff`; manual inspection shows no recognized core areas changed under that script and the next build step starts with `Add`.
- `npm.cmd run build` still exits with TypeScript help text because the repo does not currently have a root `tsconfig.json`.

Closes #59.
