### PR TITLE
Add SMS control mapping context to mission planning approval handoff responses

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add SMS control mapping context to mission planning approval handoff responses so approval evidence can display supported SMS elements from the linked readiness snapshot.",
+ "nextBuildStep": "Add SMS control mapping context to mission approval and dispatch evidence responses so operational gates expose supported SMS elements from linked readiness snapshots.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/mission-planning/mission-planning.service.ts
+++ b/src/mission-planning/mission-planning.service.ts
@@ -2,6 +2,7 @@ import type { Pool } from "pg";
 import { AirspaceComplianceRepository } from "../airspace-compliance/airspace-compliance.repository";
 import { validateCreateAirspaceComplianceInput } from "../airspace-compliance/airspace-compliance.validators";
 import { AuditEvidenceService } from "../audit-evidence/audit-evidence.service";
+import type { AuditReportSmsControlMapping } from "../audit-evidence/audit-evidence.types";
 import { MissionRiskRepository } from "../mission-risk/mission-risk.repository";
 import { validateCreateMissionRiskInput } from "../mission-risk/mission-risk.validators";
 import {
@@ -272,7 +273,15 @@ export class MissionPlanningService {
       review,
       snapshot,
       approvalEvidenceLink,
+      smsControlMappings:
+        this.getSmsControlMappingsFromReadinessSnapshot(snapshot),
     };
+  }
+
+  private getSmsControlMappingsFromReadinessSnapshot(
+    snapshot: MissionPlanningApprovalHandoff["snapshot"],
+  ): AuditReportSmsControlMapping[] {
+    return snapshot.readinessSnapshot.smsControlMappings ?? [];
   }
 
   private async recordApprovalHandoffTrace(input: {

--- a/src/mission-planning/mission-planning.types.ts
+++ b/src/mission-planning/mission-planning.types.ts
@@ -1,6 +1,7 @@
 import type { CreateAirspaceComplianceInput } from "../airspace-compliance/airspace-compliance.types";
 import type {
   AuditEvidenceSnapshot,
+  AuditReportSmsControlMapping,
   MissionDecisionEvidenceLink,
 } from "../audit-evidence/audit-evidence.types";
 import type { CreateMissionRiskInput } from "../mission-risk/mission-risk.types";
@@ -62,4 +63,5 @@ export interface MissionPlanningApprovalHandoff {
   review: MissionPlanningReview;
   snapshot: AuditEvidenceSnapshot;
   approvalEvidenceLink: MissionDecisionEvidenceLink;
+  smsControlMappings: AuditReportSmsControlMapping[];
 }

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -101,6 +101,21 @@ const countRows = async (missionId?: string) => {
   };
 };
 
+const countSmsMappingRows = async () => {
+  const result = await pool.query(
+    `
+    select
+      (select count(*)::int from sms_controls) as control_count,
+      (select count(*)::int from sms_control_element_mappings) as mapping_count
+    `,
+  );
+
+  return result.rows[0] as {
+    control_count: number;
+    mapping_count: number;
+  };
+};
+
 const getMissionStatus = async (missionId: string) => {
   const result = await pool.query<{ status: string }>(
     "select status from missions where id = $1",
@@ -344,6 +359,7 @@ describe("mission planning drafts", () => {
       `/mission-plans/drafts/${createResponse.body.draft.missionId}/review`,
     );
     const beforeCounts = await countRows(createResponse.body.draft.missionId);
+    const beforeSmsMappings = await countSmsMappingRows();
     const handoffResponse = await request(app)
       .post(
         `/mission-plans/drafts/${createResponse.body.draft.missionId}/approval-handoff`,
@@ -370,6 +386,26 @@ describe("mission planning drafts", () => {
       decisionType: "approval",
       createdBy: "planning lead",
     });
+    expect(handoffResponse.body.handoff.smsControlMappings).toEqual(
+      handoffResponse.body.handoff.snapshot.readinessSnapshot.smsControlMappings,
+    );
+    expect(handoffResponse.body.handoff.smsControlMappings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "PLATFORM_READINESS_MAINTENANCE",
+          title: "Platform readiness and maintenance controls",
+          smsElements: expect.arrayContaining([
+            "3.1 Monitoring and Measurement of Safety Performance",
+          ]),
+        }),
+        expect.objectContaining({
+          code: "MISSION_READINESS_GATE",
+          title: "Mission readiness gate controls",
+          smsElements: expect.arrayContaining(["1.5 SMS documentation"]),
+        }),
+      ]),
+    );
+    expect(handoffResponse.body.handoff.smsControlMappings).toHaveLength(9);
     expect(afterReview.body.review).toEqual(beforeReview.body.review);
     expect(afterCounts).toEqual({
       ...beforeCounts,
@@ -377,6 +413,7 @@ describe("mission planning drafts", () => {
       planning_handoff_count: beforeCounts.planning_handoff_count + 1,
       decision_link_count: beforeCounts.decision_link_count + 1,
     });
+    expect(await countSmsMappingRows()).toEqual(beforeSmsMappings);
     expect(afterCounts.mission_event_count).toBe(0);
     expect(await getMissionStatus(createResponse.body.draft.missionId)).toBe(
       "draft",


### PR DESCRIPTION
Implements #61 by adding SMS control mapping context to mission planning approval handoff responses from the linked readiness snapshot.

## What changed
- Added `smsControlMappings` to the mission planning approval handoff response contract.
- Handoff responses now read SMS context from `snapshot.readinessSnapshot.smsControlMappings`, using the linked readiness snapshot as the evidence source.
- The existing planning `review` object remains unchanged.
- Added integration coverage proving the response context matches the stored snapshot context and does not mutate SMS reference mappings.
- Advanced the save point to SMS context on mission approval and dispatch evidence responses.

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/mission-planning.test.ts` passed: 18 tests.
- `./node_modules/.bin/vitest.cmd run src/tests/audit-evidence.test.ts` passed: 37 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 213 tests across 19 files.
- `node scripts/validate-save-point.mjs fsms-save-point.json` passed.
- `git diff --check` passed.
- `node scripts/check-next-build-step-pr.mjs origin/main` could not complete locally because Windows sandboxing blocked the script's internal `cmd.exe`/`git diff` call.
- `npm.cmd run build` still exits with TypeScript help text because the repo does not currently have a root `tsconfig.json`.

Closes #61.
