### PR TITLE
Add air safety meeting schedule records with quarterly compliance status

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add SMS control mapping context to mission approval and dispatch evidence responses so operational gates expose supported SMS elements from linked readiness snapshots.",
+ "nextBuildStep": "Add migration-backed safety event capture records so SOP breaches, training needs, maintenance concerns, and post-operation findings can trigger safety review workflows.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/air-safety-meetings/air-safety-meeting.controller.ts
+++ b/src/air-safety-meetings/air-safety-meeting.controller.ts
@@ -1,0 +1,52 @@
+import type { NextFunction, Request, Response } from "express";
+import { AirSafetyMeetingService } from "./air-safety-meeting.service";
+
+export class AirSafetyMeetingController {
+  constructor(
+    private readonly airSafetyMeetingService: AirSafetyMeetingService,
+  ) {}
+
+  createAirSafetyMeeting = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const meeting =
+        await this.airSafetyMeetingService.createAirSafetyMeeting(req.body);
+      res.status(201).json({ meeting });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listAirSafetyMeetings = async (
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const meetings =
+        await this.airSafetyMeetingService.listAirSafetyMeetings();
+      res.status(200).json({ meetings });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getQuarterlyCompliance = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const compliance =
+        await this.airSafetyMeetingService.getQuarterlyCompliance({
+          asOf: req.query.asOf,
+        });
+      res.status(200).json({ compliance });
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/air-safety-meetings/air-safety-meeting.errors.ts
+++ b/src/air-safety-meetings/air-safety-meeting.errors.ts
@@ -1,0 +1,4 @@
+export class AirSafetyMeetingValidationError extends Error {
+  readonly statusCode = 400;
+  readonly code = "AIR_SAFETY_MEETING_VALIDATION_FAILED";
+}

--- a/src/air-safety-meetings/air-safety-meeting.repository.ts
+++ b/src/air-safety-meetings/air-safety-meeting.repository.ts
@@ -1,0 +1,161 @@
+import { randomUUID } from "crypto";
+import type { PoolClient, QueryResultRow } from "pg";
+import type {
+  AirSafetyMeeting,
+  AirSafetyMeetingStatus,
+  AirSafetyMeetingType,
+} from "./air-safety-meeting.types";
+
+interface AirSafetyMeetingRow extends QueryResultRow {
+  id: string;
+  meeting_type: AirSafetyMeetingType;
+  scheduled_period_start: Date | string | null;
+  scheduled_period_end: Date | string | null;
+  due_at: Date;
+  held_at: Date | null;
+  status: AirSafetyMeetingStatus;
+  chairperson: string | null;
+  attendees: string[];
+  agenda: string[];
+  minutes: string | null;
+  created_by: string | null;
+  created_at: Date;
+  closed_at: Date | null;
+}
+
+interface CreateAirSafetyMeetingRow {
+  meetingType: AirSafetyMeetingType;
+  scheduledPeriodStart: string | null;
+  scheduledPeriodEnd: string | null;
+  dueAt: Date;
+  heldAt: Date | null;
+  status: AirSafetyMeetingStatus;
+  chairperson: string | null;
+  attendees: string[];
+  agenda: string[];
+  minutes: string | null;
+  createdBy: string | null;
+}
+
+const toDateOnly = (value: Date | string | null): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value === "string") {
+    return value.slice(0, 10);
+  }
+
+  const year = value.getFullYear();
+  const month = String(value.getMonth() + 1).padStart(2, "0");
+  const day = String(value.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const toAirSafetyMeeting = (row: AirSafetyMeetingRow): AirSafetyMeeting => ({
+  id: row.id,
+  meetingType: row.meeting_type,
+  scheduledPeriodStart: toDateOnly(row.scheduled_period_start),
+  scheduledPeriodEnd: toDateOnly(row.scheduled_period_end),
+  dueAt: row.due_at.toISOString(),
+  heldAt: row.held_at?.toISOString() ?? null,
+  status: row.status,
+  chairperson: row.chairperson,
+  attendees: row.attendees,
+  agenda: row.agenda,
+  minutes: row.minutes,
+  createdBy: row.created_by,
+  createdAt: row.created_at.toISOString(),
+  closedAt: row.closed_at?.toISOString() ?? null,
+});
+
+export class AirSafetyMeetingRepository {
+  async insertAirSafetyMeeting(
+    tx: PoolClient,
+    input: CreateAirSafetyMeetingRow,
+  ): Promise<AirSafetyMeeting> {
+    const result = await tx.query<AirSafetyMeetingRow>(
+      `
+      insert into air_safety_meetings (
+        id,
+        meeting_type,
+        scheduled_period_start,
+        scheduled_period_end,
+        due_at,
+        held_at,
+        status,
+        chairperson,
+        attendees,
+        agenda,
+        minutes,
+        created_by,
+        closed_at
+      )
+      values (
+        $1,
+        $2,
+        $3,
+        $4,
+        $5,
+        $6,
+        $7,
+        $8,
+        $9::jsonb,
+        $10::jsonb,
+        $11,
+        $12,
+        case when $7 in ('completed', 'cancelled') then now() else null end
+      )
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.meetingType,
+        input.scheduledPeriodStart,
+        input.scheduledPeriodEnd,
+        input.dueAt,
+        input.heldAt,
+        input.status,
+        input.chairperson,
+        JSON.stringify(input.attendees),
+        JSON.stringify(input.agenda),
+        input.minutes,
+        input.createdBy,
+      ],
+    );
+
+    return toAirSafetyMeeting(result.rows[0]);
+  }
+
+  async listAirSafetyMeetings(tx: PoolClient): Promise<AirSafetyMeeting[]> {
+    const result = await tx.query<AirSafetyMeetingRow>(
+      `
+      select *
+      from air_safety_meetings
+      order by due_at desc, created_at desc, id desc
+      `,
+    );
+
+    return result.rows.map(toAirSafetyMeeting);
+  }
+
+  async getLatestCompletedQuarterlyMeeting(
+    tx: PoolClient,
+    asOf: Date,
+  ): Promise<AirSafetyMeeting | null> {
+    const result = await tx.query<AirSafetyMeetingRow>(
+      `
+      select *
+      from air_safety_meetings
+      where meeting_type = 'quarterly_air_safety_review'
+        and status = 'completed'
+        and held_at <= $1
+      order by held_at desc, created_at desc, id desc
+      limit 1
+      `,
+      [asOf],
+    );
+
+    return result.rows[0] ? toAirSafetyMeeting(result.rows[0]) : null;
+  }
+}

--- a/src/air-safety-meetings/air-safety-meeting.routes.ts
+++ b/src/air-safety-meetings/air-safety-meeting.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import { AirSafetyMeetingController } from "./air-safety-meeting.controller";
+
+export function createAirSafetyMeetingRouter(
+  controller: AirSafetyMeetingController,
+): Router {
+  const router = Router();
+
+  router.post("/", controller.createAirSafetyMeeting);
+  router.get("/", controller.listAirSafetyMeetings);
+  router.get("/quarterly-compliance", controller.getQuarterlyCompliance);
+
+  return router;
+}

--- a/src/air-safety-meetings/air-safety-meeting.service.ts
+++ b/src/air-safety-meetings/air-safety-meeting.service.ts
@@ -1,0 +1,144 @@
+import type { Pool } from "pg";
+import { AirSafetyMeetingRepository } from "./air-safety-meeting.repository";
+import type {
+  AirSafetyMeeting,
+  CreateAirSafetyMeetingInput,
+  QuarterlyAirSafetyMeetingCompliance,
+  QuarterlyComplianceStatus,
+} from "./air-safety-meeting.types";
+import {
+  validateCreateAirSafetyMeetingInput,
+  validateQuarterlyComplianceQuery,
+} from "./air-safety-meeting.validators";
+
+const QUARTERLY_REQUIREMENT_MONTHS = 3;
+const DUE_SOON_WINDOW_DAYS = 30;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export class AirSafetyMeetingService {
+  constructor(
+    private readonly pool: Pool,
+    private readonly airSafetyMeetingRepository: AirSafetyMeetingRepository,
+  ) {}
+
+  async createAirSafetyMeeting(
+    input: CreateAirSafetyMeetingInput | undefined,
+  ): Promise<AirSafetyMeeting> {
+    const validated = validateCreateAirSafetyMeetingInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      return await this.airSafetyMeetingRepository.insertAirSafetyMeeting(
+        client,
+        validated,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  async listAirSafetyMeetings(): Promise<AirSafetyMeeting[]> {
+    const client = await this.pool.connect();
+
+    try {
+      return await this.airSafetyMeetingRepository.listAirSafetyMeetings(client);
+    } finally {
+      client.release();
+    }
+  }
+
+  async getQuarterlyCompliance(input: {
+    asOf?: unknown;
+  }): Promise<QuarterlyAirSafetyMeetingCompliance> {
+    const asOf = validateQuarterlyComplianceQuery(input);
+    const client = await this.pool.connect();
+
+    try {
+      const lastCompletedMeeting =
+        await this.airSafetyMeetingRepository.getLatestCompletedQuarterlyMeeting(
+          client,
+          asOf,
+        );
+
+      return this.buildQuarterlyCompliance(asOf, lastCompletedMeeting);
+    } finally {
+      client.release();
+    }
+  }
+
+  private buildQuarterlyCompliance(
+    asOf: Date,
+    lastCompletedMeeting: AirSafetyMeeting | null,
+  ): QuarterlyAirSafetyMeetingCompliance {
+    if (!lastCompletedMeeting?.heldAt) {
+      return {
+        status: "overdue",
+        requirement: "quarterly_air_safety_meeting",
+        requirementMonths: QUARTERLY_REQUIREMENT_MONTHS,
+        dueSoonWindowDays: DUE_SOON_WINDOW_DAYS,
+        asOf: asOf.toISOString(),
+        lastCompletedMeeting: null,
+        nextDueAt: null,
+        message:
+          "No completed quarterly air safety meeting is recorded; the quarterly requirement is overdue",
+      };
+    }
+
+    const nextDueAt = this.addUtcMonths(
+      new Date(lastCompletedMeeting.heldAt),
+      QUARTERLY_REQUIREMENT_MONTHS,
+    );
+    const status = this.getQuarterlyComplianceStatus(asOf, nextDueAt);
+
+    return {
+      status,
+      requirement: "quarterly_air_safety_meeting",
+      requirementMonths: QUARTERLY_REQUIREMENT_MONTHS,
+      dueSoonWindowDays: DUE_SOON_WINDOW_DAYS,
+      asOf: asOf.toISOString(),
+      lastCompletedMeeting,
+      nextDueAt: nextDueAt.toISOString(),
+      message: this.getQuarterlyComplianceMessage(status, nextDueAt),
+    };
+  }
+
+  private getQuarterlyComplianceStatus(
+    asOf: Date,
+    nextDueAt: Date,
+  ): QuarterlyComplianceStatus {
+    if (nextDueAt.getTime() < asOf.getTime()) {
+      return "overdue";
+    }
+
+    const daysUntilDue = Math.ceil(
+      (nextDueAt.getTime() - asOf.getTime()) / DAY_MS,
+    );
+
+    if (daysUntilDue <= DUE_SOON_WINDOW_DAYS) {
+      return "due_soon";
+    }
+
+    return "compliant";
+  }
+
+  private getQuarterlyComplianceMessage(
+    status: QuarterlyComplianceStatus,
+    nextDueAt: Date,
+  ): string {
+    if (status === "overdue") {
+      return `Quarterly air safety meeting is overdue; next due date was ${nextDueAt.toISOString()}`;
+    }
+
+    if (status === "due_soon") {
+      return `Quarterly air safety meeting is due soon by ${nextDueAt.toISOString()}`;
+    }
+
+    return `Quarterly air safety meeting requirement is compliant until ${nextDueAt.toISOString()}`;
+  }
+
+  private addUtcMonths(value: Date, months: number): Date {
+    const result = new Date(value.getTime());
+    result.setUTCMonth(result.getUTCMonth() + months);
+    return result;
+  }
+}

--- a/src/air-safety-meetings/air-safety-meeting.types.ts
+++ b/src/air-safety-meetings/air-safety-meeting.types.ts
@@ -1,0 +1,59 @@
+export type AirSafetyMeetingType =
+  | "quarterly_air_safety_review"
+  | "event_triggered_safety_review"
+  | "sop_breach_review"
+  | "training_review"
+  | "maintenance_safety_review"
+  | "accountable_manager_review";
+
+export type AirSafetyMeetingStatus =
+  | "scheduled"
+  | "completed"
+  | "cancelled";
+
+export type QuarterlyComplianceStatus =
+  | "compliant"
+  | "due_soon"
+  | "overdue";
+
+export interface CreateAirSafetyMeetingInput {
+  meetingType?: AirSafetyMeetingType;
+  scheduledPeriodStart?: string | null;
+  scheduledPeriodEnd?: string | null;
+  dueAt?: string;
+  heldAt?: string | null;
+  status?: AirSafetyMeetingStatus;
+  chairperson?: string | null;
+  attendees?: string[];
+  agenda?: string[];
+  minutes?: string | null;
+  createdBy?: string | null;
+}
+
+export interface AirSafetyMeeting {
+  id: string;
+  meetingType: AirSafetyMeetingType;
+  scheduledPeriodStart: string | null;
+  scheduledPeriodEnd: string | null;
+  dueAt: string;
+  heldAt: string | null;
+  status: AirSafetyMeetingStatus;
+  chairperson: string | null;
+  attendees: string[];
+  agenda: string[];
+  minutes: string | null;
+  createdBy: string | null;
+  createdAt: string;
+  closedAt: string | null;
+}
+
+export interface QuarterlyAirSafetyMeetingCompliance {
+  status: QuarterlyComplianceStatus;
+  requirement: "quarterly_air_safety_meeting";
+  requirementMonths: 3;
+  dueSoonWindowDays: 30;
+  asOf: string;
+  lastCompletedMeeting: AirSafetyMeeting | null;
+  nextDueAt: string | null;
+  message: string;
+}

--- a/src/air-safety-meetings/air-safety-meeting.validators.ts
+++ b/src/air-safety-meetings/air-safety-meeting.validators.ts
@@ -1,0 +1,167 @@
+import { AirSafetyMeetingValidationError } from "./air-safety-meeting.errors";
+import type {
+  AirSafetyMeetingStatus,
+  AirSafetyMeetingType,
+  CreateAirSafetyMeetingInput,
+} from "./air-safety-meeting.types";
+
+const MEETING_TYPES = new Set<AirSafetyMeetingType>([
+  "quarterly_air_safety_review",
+  "event_triggered_safety_review",
+  "sop_breach_review",
+  "training_review",
+  "maintenance_safety_review",
+  "accountable_manager_review",
+]);
+
+const MEETING_STATUSES = new Set<AirSafetyMeetingStatus>([
+  "scheduled",
+  "completed",
+  "cancelled",
+]);
+
+function optionalTrimmed(value: unknown, fieldName: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    throw new AirSafetyMeetingValidationError(`${fieldName} must be a string`);
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function requiredDate(value: unknown, fieldName: string): Date {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    throw new AirSafetyMeetingValidationError(
+      `${fieldName} must be a valid ISO timestamp`,
+    );
+  }
+
+  return new Date(value);
+}
+
+function optionalDate(value: unknown, fieldName: string): Date | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+
+  return requiredDate(value, fieldName);
+}
+
+function optionalDateOnly(value: unknown, fieldName: string): string | null {
+  const normalized = optionalTrimmed(value, fieldName);
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
+    throw new AirSafetyMeetingValidationError(
+      `${fieldName} must be a YYYY-MM-DD date`,
+    );
+  }
+
+  const parsed = Date.parse(`${normalized}T00:00:00.000Z`);
+  if (Number.isNaN(parsed)) {
+    throw new AirSafetyMeetingValidationError(
+      `${fieldName} must be a valid date`,
+    );
+  }
+
+  return normalized;
+}
+
+function optionalStringArray(value: unknown, fieldName: string): string[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new AirSafetyMeetingValidationError(`${fieldName} must be an array`);
+  }
+
+  return value
+    .map((item, index) => {
+      if (typeof item !== "string") {
+        throw new AirSafetyMeetingValidationError(
+          `${fieldName}[${index}] must be a string`,
+        );
+      }
+
+      return item.trim();
+    })
+    .filter(Boolean);
+}
+
+export function validateCreateAirSafetyMeetingInput(
+  input: CreateAirSafetyMeetingInput | undefined,
+) {
+  if (!input || typeof input !== "object") {
+    throw new AirSafetyMeetingValidationError("Request body must be an object");
+  }
+
+  const meetingType = input.meetingType ?? "quarterly_air_safety_review";
+  if (!MEETING_TYPES.has(meetingType)) {
+    throw new AirSafetyMeetingValidationError("meetingType is not supported");
+  }
+
+  const heldAt = optionalDate(input.heldAt, "heldAt");
+  const status = input.status ?? (heldAt ? "completed" : "scheduled");
+  if (!MEETING_STATUSES.has(status)) {
+    throw new AirSafetyMeetingValidationError("status is not supported");
+  }
+
+  if (status === "completed" && !heldAt) {
+    throw new AirSafetyMeetingValidationError(
+      "heldAt is required for completed meetings",
+    );
+  }
+
+  if (status === "cancelled" && heldAt) {
+    throw new AirSafetyMeetingValidationError(
+      "cancelled meetings cannot have heldAt",
+    );
+  }
+
+  const scheduledPeriodStart = optionalDateOnly(
+    input.scheduledPeriodStart,
+    "scheduledPeriodStart",
+  );
+  const scheduledPeriodEnd = optionalDateOnly(
+    input.scheduledPeriodEnd,
+    "scheduledPeriodEnd",
+  );
+
+  if (
+    scheduledPeriodStart &&
+    scheduledPeriodEnd &&
+    scheduledPeriodEnd < scheduledPeriodStart
+  ) {
+    throw new AirSafetyMeetingValidationError(
+      "scheduledPeriodEnd must be on or after scheduledPeriodStart",
+    );
+  }
+
+  return {
+    meetingType,
+    scheduledPeriodStart,
+    scheduledPeriodEnd,
+    dueAt: requiredDate(input.dueAt, "dueAt"),
+    heldAt,
+    status,
+    chairperson: optionalTrimmed(input.chairperson, "chairperson"),
+    attendees: optionalStringArray(input.attendees, "attendees"),
+    agenda: optionalStringArray(input.agenda, "agenda"),
+    minutes: optionalTrimmed(input.minutes, "minutes"),
+    createdBy: optionalTrimmed(input.createdBy, "createdBy"),
+  };
+}
+
+export function validateQuarterlyComplianceQuery(input: {
+  asOf?: unknown;
+}): Date {
+  return optionalDate(input.asOf, "asOf") ?? new Date();
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -54,6 +54,10 @@ import { SmsFrameworkRepository } from "./sms-framework/sms-framework.repository
 import { SmsFrameworkService } from "./sms-framework/sms-framework.service";
 import { SmsFrameworkController } from "./sms-framework/sms-framework.controller";
 import { createSmsFrameworkRouter } from "./sms-framework/sms-framework.routes";
+import { AirSafetyMeetingRepository } from "./air-safety-meetings/air-safety-meeting.repository";
+import { AirSafetyMeetingService } from "./air-safety-meetings/air-safety-meeting.service";
+import { AirSafetyMeetingController } from "./air-safety-meetings/air-safety-meeting.controller";
+import { createAirSafetyMeetingRouter } from "./air-safety-meetings/air-safety-meeting.routes";
 
 dotenv.config({
   path: path.resolve(process.cwd(), ".env"),
@@ -169,9 +173,21 @@ const smsFrameworkService = new SmsFrameworkService(
   smsFrameworkRepository,
 );
 const smsFrameworkController = new SmsFrameworkController(smsFrameworkService);
+const airSafetyMeetingRepository = new AirSafetyMeetingRepository();
+const airSafetyMeetingService = new AirSafetyMeetingService(
+  pool,
+  airSafetyMeetingRepository,
+);
+const airSafetyMeetingController = new AirSafetyMeetingController(
+  airSafetyMeetingService,
+);
 
 app.use("/mission-plans", createMissionPlanningRouter(missionPlanningController));
 app.use("/sms", createSmsFrameworkRouter(smsFrameworkController));
+app.use(
+  "/air-safety-meetings",
+  createAirSafetyMeetingRouter(airSafetyMeetingController),
+);
 app.use("/missions", createMissionRouter(missionController));
 app.use("/missions", createMissionRiskRouter(missionRiskController));
 app.use("/missions", createAirspaceComplianceRouter(airspaceComplianceController));

--- a/src/migrations/020_create_air_safety_meetings.sql
+++ b/src/migrations/020_create_air_safety_meetings.sql
@@ -1,0 +1,41 @@
+create table if not exists air_safety_meetings (
+  id uuid primary key,
+  meeting_type text not null check (
+    meeting_type in (
+      'quarterly_air_safety_review',
+      'event_triggered_safety_review',
+      'sop_breach_review',
+      'training_review',
+      'maintenance_safety_review',
+      'accountable_manager_review'
+    )
+  ),
+  scheduled_period_start date,
+  scheduled_period_end date,
+  due_at timestamptz not null,
+  held_at timestamptz,
+  status text not null check (status in ('scheduled', 'completed', 'cancelled')),
+  chairperson text,
+  attendees jsonb not null default '[]'::jsonb,
+  agenda jsonb not null default '[]'::jsonb,
+  minutes text,
+  created_by text,
+  created_at timestamptz not null default now(),
+  closed_at timestamptz,
+  constraint air_safety_meetings_completed_held_at_chk
+    check (status <> 'completed' or held_at is not null),
+  constraint air_safety_meetings_cancelled_held_at_chk
+    check (status <> 'cancelled' or held_at is null),
+  constraint air_safety_meetings_period_order_chk
+    check (
+      scheduled_period_start is null
+      or scheduled_period_end is null
+      or scheduled_period_end >= scheduled_period_start
+    )
+);
+
+create index if not exists idx_air_safety_meetings_type_status_held
+  on air_safety_meetings (meeting_type, status, held_at desc);
+
+create index if not exists idx_air_safety_meetings_due
+  on air_safety_meetings (due_at asc);

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -1,0 +1,195 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import app, { pool } from "../app";
+import { runMigrations } from "../migrations/runMigrations";
+
+const clearTables = async () => {
+  await pool.query("delete from air_safety_meetings");
+};
+
+const createCompletedQuarterlyMeeting = async (heldAt: string) => {
+  const response = await request(app).post("/air-safety-meetings").send({
+    meetingType: "quarterly_air_safety_review",
+    dueAt: heldAt,
+    heldAt,
+    status: "completed",
+    chairperson: "Head of Flight Safety",
+    attendees: ["Accountable Manager", "Chief Pilot"],
+    agenda: ["Review safety events", "Review open safety actions"],
+    minutes: "Quarterly review completed.",
+    createdBy: "safety-admin",
+  });
+
+  expect(response.status).toBe(201);
+  return response.body.meeting;
+};
+
+describe("air safety meetings", () => {
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  beforeEach(async () => {
+    await clearTables();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("creates and lists quarterly air safety meeting records", async () => {
+    const response = await request(app).post("/air-safety-meetings").send({
+      dueAt: "2026-06-30T10:00:00.000Z",
+      scheduledPeriodStart: "2026-04-01",
+      scheduledPeriodEnd: "2026-06-30",
+      chairperson: " Safety Manager ",
+      attendees: [" Accountable Manager ", "Chief Pilot", ""],
+      agenda: ["Review SOP breaches", "Training needs"],
+      createdBy: " safety-admin ",
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.meeting).toMatchObject({
+      meetingType: "quarterly_air_safety_review",
+      scheduledPeriodStart: "2026-04-01",
+      scheduledPeriodEnd: "2026-06-30",
+      dueAt: "2026-06-30T10:00:00.000Z",
+      heldAt: null,
+      status: "scheduled",
+      chairperson: "Safety Manager",
+      attendees: ["Accountable Manager", "Chief Pilot"],
+      agenda: ["Review SOP breaches", "Training needs"],
+      createdBy: "safety-admin",
+    });
+    expect(response.body.meeting.id).toEqual(expect.any(String));
+    expect(response.body.meeting.createdAt).toEqual(expect.any(String));
+
+    const listResponse = await request(app).get("/air-safety-meetings");
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.meetings).toHaveLength(1);
+    expect(listResponse.body.meetings[0]).toEqual(response.body.meeting);
+  });
+
+  it("reports overdue quarterly compliance when no completed quarterly meeting exists", async () => {
+    const response = await request(app).get(
+      "/air-safety-meetings/quarterly-compliance?asOf=2026-04-01T00:00:00.000Z",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.compliance).toMatchObject({
+      status: "overdue",
+      requirement: "quarterly_air_safety_meeting",
+      requirementMonths: 3,
+      dueSoonWindowDays: 30,
+      asOf: "2026-04-01T00:00:00.000Z",
+      lastCompletedMeeting: null,
+      nextDueAt: null,
+    });
+  });
+
+  it("reports compliant quarterly status when the next review is more than 30 days away", async () => {
+    const meeting = await createCompletedQuarterlyMeeting(
+      "2026-01-01T10:00:00.000Z",
+    );
+
+    const response = await request(app).get(
+      "/air-safety-meetings/quarterly-compliance?asOf=2026-02-01T10:00:00.000Z",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.compliance).toMatchObject({
+      status: "compliant",
+      lastCompletedMeeting: {
+        id: meeting.id,
+        meetingType: "quarterly_air_safety_review",
+        status: "completed",
+      },
+      nextDueAt: "2026-04-01T10:00:00.000Z",
+    });
+  });
+
+  it("reports due soon when the next quarterly review is within 30 days", async () => {
+    await createCompletedQuarterlyMeeting("2026-01-01T10:00:00.000Z");
+
+    const response = await request(app).get(
+      "/air-safety-meetings/quarterly-compliance?asOf=2026-03-10T10:00:00.000Z",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.compliance).toMatchObject({
+      status: "due_soon",
+      nextDueAt: "2026-04-01T10:00:00.000Z",
+    });
+  });
+
+  it("reports overdue when the latest quarterly review is older than 3 months", async () => {
+    await createCompletedQuarterlyMeeting("2026-01-01T10:00:00.000Z");
+
+    const response = await request(app).get(
+      "/air-safety-meetings/quarterly-compliance?asOf=2026-04-02T10:00:00.000Z",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.compliance).toMatchObject({
+      status: "overdue",
+      nextDueAt: "2026-04-01T10:00:00.000Z",
+    });
+  });
+
+  it("does not allow event-triggered meetings to automatically satisfy quarterly compliance", async () => {
+    const eventMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "event_triggered_safety_review",
+      dueAt: "2026-03-20T09:00:00.000Z",
+      heldAt: "2026-03-20T09:00:00.000Z",
+      status: "completed",
+      chairperson: "Safety Manager",
+      agenda: ["SOP breach review"],
+      minutes: "Event review held.",
+    });
+
+    expect(eventMeeting.status).toBe(201);
+
+    const response = await request(app).get(
+      "/air-safety-meetings/quarterly-compliance?asOf=2026-03-21T00:00:00.000Z",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.compliance).toMatchObject({
+      status: "overdue",
+      lastCompletedMeeting: null,
+      nextDueAt: null,
+    });
+  });
+
+  it("rejects invalid air safety meeting records", async () => {
+    const completedWithoutHeldAt = await request(app)
+      .post("/air-safety-meetings")
+      .send({
+        dueAt: "2026-06-30T10:00:00.000Z",
+        status: "completed",
+      });
+    const unsupportedType = await request(app)
+      .post("/air-safety-meetings")
+      .send({
+        meetingType: "daily_standup",
+        dueAt: "2026-06-30T10:00:00.000Z",
+      });
+    const invalidQuery = await request(app).get(
+      "/air-safety-meetings/quarterly-compliance?asOf=not-a-date",
+    );
+
+    expect(completedWithoutHeldAt.status).toBe(400);
+    expect(completedWithoutHeldAt.body.error).toMatchObject({
+      type: "air_safety_meeting_validation_failed",
+    });
+    expect(unsupportedType.status).toBe(400);
+    expect(unsupportedType.body.error).toMatchObject({
+      type: "air_safety_meeting_validation_failed",
+    });
+    expect(invalidQuery.status).toBe(400);
+    expect(invalidQuery.body.error).toMatchObject({
+      type: "air_safety_meeting_validation_failed",
+    });
+  });
+});


### PR DESCRIPTION
Implements #63 by adding migration-backed air safety meeting records and quarterly compliance status reporting.

## What changed
- Added `air_safety_meetings` migration with quarterly and event-triggered meeting types.
- Added an `air-safety-meetings` backend module with create, list, and quarterly compliance endpoints.
- Added quarterly compliance calculation with `compliant`, `due_soon`, and `overdue` states.
- Quarterly compliance is based only on completed `quarterly_air_safety_review` meetings.
- Event-triggered meetings are structurally separate and do not automatically satisfy the quarterly requirement.
- Added validation for meeting type, status, date fields, attendees, agenda, and compliance query date.
- Advanced the save point to migration-backed safety event capture records.

## Endpoints
- `POST /air-safety-meetings`
- `GET /air-safety-meetings`
- `GET /air-safety-meetings/quarterly-compliance?asOf=...`

## Verification
- `./node_modules/.bin/vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 7 tests.
- `./node_modules/.bin/vitest.cmd run` passed: 220 tests across 20 files.
- `node scripts/validate-save-point.mjs fsms-save-point.json` passed.
- `git diff --check` passed.
- `node scripts/check-next-build-step-pr.mjs origin/main` could not complete locally because Windows sandboxing blocked the script's internal `cmd.exe`/`git diff` call; the next build step now includes the migration signal required for this diff.
- `npm.cmd run build` still exits with TypeScript help text because the repo does not currently have a root `tsconfig.json`.

Closes #63.
