### PR TITLE
Add safety event capture records

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add migration-backed safety event capture records so SOP breaches, training needs, maintenance concerns, and post-operation findings can trigger safety review workflows.",
+ "nextBuildStep": "Add migration-backed safety event meeting trigger logic so serious events, SOP breaches, training needs, and maintenance concerns can require flight safety review.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -58,6 +58,10 @@ import { AirSafetyMeetingRepository } from "./air-safety-meetings/air-safety-mee
 import { AirSafetyMeetingService } from "./air-safety-meetings/air-safety-meeting.service";
 import { AirSafetyMeetingController } from "./air-safety-meetings/air-safety-meeting.controller";
 import { createAirSafetyMeetingRouter } from "./air-safety-meetings/air-safety-meeting.routes";
+import { SafetyEventRepository } from "./safety-events/safety-event.repository";
+import { SafetyEventService } from "./safety-events/safety-event.service";
+import { SafetyEventController } from "./safety-events/safety-event.controller";
+import { createSafetyEventRouter } from "./safety-events/safety-event.routes";
 
 dotenv.config({
   path: path.resolve(process.cwd(), ".env"),
@@ -181,6 +185,9 @@ const airSafetyMeetingService = new AirSafetyMeetingService(
 const airSafetyMeetingController = new AirSafetyMeetingController(
   airSafetyMeetingService,
 );
+const safetyEventRepository = new SafetyEventRepository();
+const safetyEventService = new SafetyEventService(pool, safetyEventRepository);
+const safetyEventController = new SafetyEventController(safetyEventService);
 
 app.use("/mission-plans", createMissionPlanningRouter(missionPlanningController));
 app.use("/sms", createSmsFrameworkRouter(smsFrameworkController));
@@ -188,6 +195,7 @@ app.use(
   "/air-safety-meetings",
   createAirSafetyMeetingRouter(airSafetyMeetingController),
 );
+app.use("/safety-events", createSafetyEventRouter(safetyEventController));
 app.use("/missions", createMissionRouter(missionController));
 app.use("/missions", createMissionRiskRouter(missionRiskController));
 app.use("/missions", createAirspaceComplianceRouter(airspaceComplianceController));

--- a/src/migrations/021_create_safety_events.sql
+++ b/src/migrations/021_create_safety_events.sql
@@ -1,0 +1,62 @@
+create table if not exists safety_events (
+  id uuid primary key,
+  event_type text not null check (
+    event_type in (
+      'sop_breach',
+      'training_need',
+      'maintenance_concern',
+      'airspace_deviation',
+      'mission_planning_issue',
+      'platform_readiness_issue',
+      'pilot_readiness_issue',
+      'operational_incident',
+      'near_miss',
+      'post_operation_finding'
+    )
+  ),
+  severity text not null check (
+    severity in ('low', 'medium', 'high', 'critical')
+  ),
+  status text not null check (
+    status in ('open', 'under_review', 'closed')
+  ),
+  mission_id uuid references missions(id) on delete set null,
+  platform_id uuid references platforms(id) on delete set null,
+  pilot_id uuid references pilots(id) on delete set null,
+  post_operation_evidence_snapshot_id uuid
+    references post_operation_evidence_snapshots(id) on delete set null,
+  air_safety_meeting_id uuid
+    references air_safety_meetings(id) on delete set null,
+  reported_by text,
+  event_occurred_at timestamptz not null,
+  reported_at timestamptz not null default now(),
+  summary text not null,
+  description text,
+  immediate_action_taken text,
+  sop_reference text,
+  meeting_required boolean not null default false,
+  sop_review_required boolean not null default false,
+  training_required boolean not null default false,
+  maintenance_review_required boolean not null default false,
+  accountable_manager_review_required boolean not null default false,
+  regulator_reportable_review_required boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_safety_events_type_status
+  on safety_events (event_type, status, event_occurred_at desc);
+
+create index if not exists idx_safety_events_mission
+  on safety_events (mission_id, event_occurred_at desc)
+  where mission_id is not null;
+
+create index if not exists idx_safety_events_review_flags
+  on safety_events (
+    meeting_required,
+    sop_review_required,
+    training_required,
+    maintenance_review_required,
+    accountable_manager_review_required,
+    regulator_reportable_review_required
+  );

--- a/src/safety-events/safety-event.controller.ts
+++ b/src/safety-events/safety-event.controller.ts
@@ -1,0 +1,32 @@
+import type { NextFunction, Request, Response } from "express";
+import { SafetyEventService } from "./safety-event.service";
+
+export class SafetyEventController {
+  constructor(private readonly safetyEventService: SafetyEventService) {}
+
+  createSafetyEvent = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const event = await this.safetyEventService.createSafetyEvent(req.body);
+      res.status(201).json({ event });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listSafetyEvents = async (
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const events = await this.safetyEventService.listSafetyEvents();
+      res.status(200).json({ events });
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/safety-events/safety-event.errors.ts
+++ b/src/safety-events/safety-event.errors.ts
@@ -1,0 +1,13 @@
+export class SafetyEventValidationError extends Error {
+  readonly statusCode = 400;
+  readonly code = "SAFETY_EVENT_VALIDATION_FAILED";
+}
+
+export class SafetyEventReferenceNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "SAFETY_EVENT_REFERENCE_NOT_FOUND";
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/safety-events/safety-event.repository.ts
+++ b/src/safety-events/safety-event.repository.ts
@@ -1,0 +1,184 @@
+import { randomUUID } from "crypto";
+import type { PoolClient, QueryResultRow } from "pg";
+import type {
+  SafetyEvent,
+  SafetyEventSeverity,
+  SafetyEventStatus,
+  SafetyEventType,
+} from "./safety-event.types";
+
+interface SafetyEventRow extends QueryResultRow {
+  id: string;
+  event_type: SafetyEventType;
+  severity: SafetyEventSeverity;
+  status: SafetyEventStatus;
+  mission_id: string | null;
+  platform_id: string | null;
+  pilot_id: string | null;
+  post_operation_evidence_snapshot_id: string | null;
+  air_safety_meeting_id: string | null;
+  reported_by: string | null;
+  event_occurred_at: Date;
+  reported_at: Date;
+  summary: string;
+  description: string | null;
+  immediate_action_taken: string | null;
+  sop_reference: string | null;
+  meeting_required: boolean;
+  sop_review_required: boolean;
+  training_required: boolean;
+  maintenance_review_required: boolean;
+  accountable_manager_review_required: boolean;
+  regulator_reportable_review_required: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface CreateSafetyEventRow {
+  eventType: SafetyEventType;
+  severity: SafetyEventSeverity;
+  status: SafetyEventStatus;
+  missionId: string | null;
+  platformId: string | null;
+  pilotId: string | null;
+  postOperationEvidenceSnapshotId: string | null;
+  airSafetyMeetingId: string | null;
+  reportedBy: string | null;
+  eventOccurredAt: Date;
+  summary: string;
+  description: string | null;
+  immediateActionTaken: string | null;
+  sopReference: string | null;
+  meetingRequired: boolean;
+  sopReviewRequired: boolean;
+  trainingRequired: boolean;
+  maintenanceReviewRequired: boolean;
+  accountableManagerReviewRequired: boolean;
+  regulatorReportableReviewRequired: boolean;
+}
+
+const toSafetyEvent = (row: SafetyEventRow): SafetyEvent => ({
+  id: row.id,
+  eventType: row.event_type,
+  severity: row.severity,
+  status: row.status,
+  missionId: row.mission_id,
+  platformId: row.platform_id,
+  pilotId: row.pilot_id,
+  postOperationEvidenceSnapshotId: row.post_operation_evidence_snapshot_id,
+  airSafetyMeetingId: row.air_safety_meeting_id,
+  reportedBy: row.reported_by,
+  eventOccurredAt: row.event_occurred_at.toISOString(),
+  reportedAt: row.reported_at.toISOString(),
+  summary: row.summary,
+  description: row.description,
+  immediateActionTaken: row.immediate_action_taken,
+  sopReference: row.sop_reference,
+  meetingRequired: row.meeting_required,
+  sopReviewRequired: row.sop_review_required,
+  trainingRequired: row.training_required,
+  maintenanceReviewRequired: row.maintenance_review_required,
+  accountableManagerReviewRequired: row.accountable_manager_review_required,
+  regulatorReportableReviewRequired: row.regulator_reportable_review_required,
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
+});
+
+export class SafetyEventRepository {
+  async insertSafetyEvent(
+    tx: PoolClient,
+    input: CreateSafetyEventRow,
+  ): Promise<SafetyEvent> {
+    const result = await tx.query<SafetyEventRow>(
+      `
+      insert into safety_events (
+        id,
+        event_type,
+        severity,
+        status,
+        mission_id,
+        platform_id,
+        pilot_id,
+        post_operation_evidence_snapshot_id,
+        air_safety_meeting_id,
+        reported_by,
+        event_occurred_at,
+        summary,
+        description,
+        immediate_action_taken,
+        sop_reference,
+        meeting_required,
+        sop_review_required,
+        training_required,
+        maintenance_review_required,
+        accountable_manager_review_required,
+        regulator_reportable_review_required
+      )
+      values (
+        $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+        $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21
+      )
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.eventType,
+        input.severity,
+        input.status,
+        input.missionId,
+        input.platformId,
+        input.pilotId,
+        input.postOperationEvidenceSnapshotId,
+        input.airSafetyMeetingId,
+        input.reportedBy,
+        input.eventOccurredAt,
+        input.summary,
+        input.description,
+        input.immediateActionTaken,
+        input.sopReference,
+        input.meetingRequired,
+        input.sopReviewRequired,
+        input.trainingRequired,
+        input.maintenanceReviewRequired,
+        input.accountableManagerReviewRequired,
+        input.regulatorReportableReviewRequired,
+      ],
+    );
+
+    return toSafetyEvent(result.rows[0]);
+  }
+
+  async listSafetyEvents(tx: PoolClient): Promise<SafetyEvent[]> {
+    const result = await tx.query<SafetyEventRow>(
+      `
+      select *
+      from safety_events
+      order by event_occurred_at desc, reported_at desc, id desc
+      `,
+    );
+
+    return result.rows.map(toSafetyEvent);
+  }
+
+  async referenceExists(
+    tx: PoolClient,
+    tableName:
+      | "missions"
+      | "platforms"
+      | "pilots"
+      | "post_operation_evidence_snapshots"
+      | "air_safety_meetings",
+    id: string,
+  ): Promise<boolean> {
+    const result = await tx.query(
+      `
+      select 1
+      from ${tableName}
+      where id = $1
+      `,
+      [id],
+    );
+
+    return result.rowCount === 1;
+  }
+}

--- a/src/safety-events/safety-event.routes.ts
+++ b/src/safety-events/safety-event.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { SafetyEventController } from "./safety-event.controller";
+
+export function createSafetyEventRouter(
+  controller: SafetyEventController,
+): Router {
+  const router = Router();
+
+  router.post("/", controller.createSafetyEvent);
+  router.get("/", controller.listSafetyEvents);
+
+  return router;
+}

--- a/src/safety-events/safety-event.service.ts
+++ b/src/safety-events/safety-event.service.ts
@@ -1,0 +1,98 @@
+import type { Pool } from "pg";
+import {
+  SafetyEventReferenceNotFoundError,
+} from "./safety-event.errors";
+import { SafetyEventRepository } from "./safety-event.repository";
+import type {
+  CreateSafetyEventInput,
+  SafetyEvent,
+} from "./safety-event.types";
+import { validateCreateSafetyEventInput } from "./safety-event.validators";
+
+export class SafetyEventService {
+  constructor(
+    private readonly pool: Pool,
+    private readonly safetyEventRepository: SafetyEventRepository,
+  ) {}
+
+  async createSafetyEvent(
+    input: CreateSafetyEventInput | undefined,
+  ): Promise<SafetyEvent> {
+    const validated = validateCreateSafetyEventInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      await this.validateReferences(client, validated);
+      return await this.safetyEventRepository.insertSafetyEvent(
+        client,
+        validated,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  async listSafetyEvents(): Promise<SafetyEvent[]> {
+    const client = await this.pool.connect();
+
+    try {
+      return await this.safetyEventRepository.listSafetyEvents(client);
+    } finally {
+      client.release();
+    }
+  }
+
+  private async validateReferences(
+    client: Awaited<ReturnType<Pool["connect"]>>,
+    input: ReturnType<typeof validateCreateSafetyEventInput>,
+  ): Promise<void> {
+    await this.validateReference(client, "missions", input.missionId, "mission");
+    await this.validateReference(
+      client,
+      "platforms",
+      input.platformId,
+      "platform",
+    );
+    await this.validateReference(client, "pilots", input.pilotId, "pilot");
+    await this.validateReference(
+      client,
+      "post_operation_evidence_snapshots",
+      input.postOperationEvidenceSnapshotId,
+      "post-operation evidence snapshot",
+    );
+    await this.validateReference(
+      client,
+      "air_safety_meetings",
+      input.airSafetyMeetingId,
+      "air safety meeting",
+    );
+  }
+
+  private async validateReference(
+    client: Awaited<ReturnType<Pool["connect"]>>,
+    tableName:
+      | "missions"
+      | "platforms"
+      | "pilots"
+      | "post_operation_evidence_snapshots"
+      | "air_safety_meetings",
+    id: string | null,
+    label: string,
+  ): Promise<void> {
+    if (!id) {
+      return;
+    }
+
+    const exists = await this.safetyEventRepository.referenceExists(
+      client,
+      tableName,
+      id,
+    );
+
+    if (!exists) {
+      throw new SafetyEventReferenceNotFoundError(
+        `Safety event references missing ${label}: ${id}`,
+      );
+    }
+  }
+}

--- a/src/safety-events/safety-event.types.ts
+++ b/src/safety-events/safety-event.types.ts
@@ -1,0 +1,65 @@
+export type SafetyEventType =
+  | "sop_breach"
+  | "training_need"
+  | "maintenance_concern"
+  | "airspace_deviation"
+  | "mission_planning_issue"
+  | "platform_readiness_issue"
+  | "pilot_readiness_issue"
+  | "operational_incident"
+  | "near_miss"
+  | "post_operation_finding";
+
+export type SafetyEventSeverity = "low" | "medium" | "high" | "critical";
+
+export type SafetyEventStatus = "open" | "under_review" | "closed";
+
+export interface CreateSafetyEventInput {
+  eventType?: SafetyEventType;
+  severity?: SafetyEventSeverity;
+  status?: SafetyEventStatus;
+  missionId?: string | null;
+  platformId?: string | null;
+  pilotId?: string | null;
+  postOperationEvidenceSnapshotId?: string | null;
+  airSafetyMeetingId?: string | null;
+  reportedBy?: string | null;
+  eventOccurredAt?: string;
+  summary?: string;
+  description?: string | null;
+  immediateActionTaken?: string | null;
+  sopReference?: string | null;
+  meetingRequired?: boolean;
+  sopReviewRequired?: boolean;
+  trainingRequired?: boolean;
+  maintenanceReviewRequired?: boolean;
+  accountableManagerReviewRequired?: boolean;
+  regulatorReportableReviewRequired?: boolean;
+}
+
+export interface SafetyEvent {
+  id: string;
+  eventType: SafetyEventType;
+  severity: SafetyEventSeverity;
+  status: SafetyEventStatus;
+  missionId: string | null;
+  platformId: string | null;
+  pilotId: string | null;
+  postOperationEvidenceSnapshotId: string | null;
+  airSafetyMeetingId: string | null;
+  reportedBy: string | null;
+  eventOccurredAt: string;
+  reportedAt: string;
+  summary: string;
+  description: string | null;
+  immediateActionTaken: string | null;
+  sopReference: string | null;
+  meetingRequired: boolean;
+  sopReviewRequired: boolean;
+  trainingRequired: boolean;
+  maintenanceReviewRequired: boolean;
+  accountableManagerReviewRequired: boolean;
+  regulatorReportableReviewRequired: boolean;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/safety-events/safety-event.validators.ts
+++ b/src/safety-events/safety-event.validators.ts
@@ -1,0 +1,168 @@
+import { SafetyEventValidationError } from "./safety-event.errors";
+import type {
+  CreateSafetyEventInput,
+  SafetyEventSeverity,
+  SafetyEventStatus,
+  SafetyEventType,
+} from "./safety-event.types";
+
+const EVENT_TYPES = new Set<SafetyEventType>([
+  "sop_breach",
+  "training_need",
+  "maintenance_concern",
+  "airspace_deviation",
+  "mission_planning_issue",
+  "platform_readiness_issue",
+  "pilot_readiness_issue",
+  "operational_incident",
+  "near_miss",
+  "post_operation_finding",
+]);
+
+const SEVERITIES = new Set<SafetyEventSeverity>([
+  "low",
+  "medium",
+  "high",
+  "critical",
+]);
+
+const STATUSES = new Set<SafetyEventStatus>([
+  "open",
+  "under_review",
+  "closed",
+]);
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function optionalTrimmed(value: unknown, fieldName: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    throw new SafetyEventValidationError(`${fieldName} must be a string`);
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function requiredTrimmed(value: unknown, fieldName: string): string {
+  const normalized = optionalTrimmed(value, fieldName);
+
+  if (!normalized) {
+    throw new SafetyEventValidationError(`${fieldName} is required`);
+  }
+
+  return normalized;
+}
+
+function optionalUuid(value: unknown, fieldName: string): string | null {
+  const normalized = optionalTrimmed(value, fieldName);
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (!UUID_RE.test(normalized)) {
+    throw new SafetyEventValidationError(`${fieldName} must be a valid UUID`);
+  }
+
+  return normalized;
+}
+
+function requiredDate(value: unknown, fieldName: string): Date {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    throw new SafetyEventValidationError(
+      `${fieldName} must be a valid ISO timestamp`,
+    );
+  }
+
+  return new Date(value);
+}
+
+function optionalBoolean(value: unknown, fieldName: string): boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+
+  if (typeof value !== "boolean") {
+    throw new SafetyEventValidationError(`${fieldName} must be a boolean`);
+  }
+
+  return value;
+}
+
+export function validateCreateSafetyEventInput(
+  input: CreateSafetyEventInput | undefined,
+) {
+  if (!input || typeof input !== "object") {
+    throw new SafetyEventValidationError("Request body must be an object");
+  }
+
+  const eventType = input.eventType;
+  if (!eventType || !EVENT_TYPES.has(eventType)) {
+    throw new SafetyEventValidationError("eventType is required and supported");
+  }
+
+  const severity = input.severity;
+  if (!severity || !SEVERITIES.has(severity)) {
+    throw new SafetyEventValidationError("severity is required and supported");
+  }
+
+  const status = input.status ?? "open";
+  if (!STATUSES.has(status)) {
+    throw new SafetyEventValidationError("status is not supported");
+  }
+
+  return {
+    eventType,
+    severity,
+    status,
+    missionId: optionalUuid(input.missionId, "missionId"),
+    platformId: optionalUuid(input.platformId, "platformId"),
+    pilotId: optionalUuid(input.pilotId, "pilotId"),
+    postOperationEvidenceSnapshotId: optionalUuid(
+      input.postOperationEvidenceSnapshotId,
+      "postOperationEvidenceSnapshotId",
+    ),
+    airSafetyMeetingId: optionalUuid(
+      input.airSafetyMeetingId,
+      "airSafetyMeetingId",
+    ),
+    reportedBy: optionalTrimmed(input.reportedBy, "reportedBy"),
+    eventOccurredAt: requiredDate(input.eventOccurredAt, "eventOccurredAt"),
+    summary: requiredTrimmed(input.summary, "summary"),
+    description: optionalTrimmed(input.description, "description"),
+    immediateActionTaken: optionalTrimmed(
+      input.immediateActionTaken,
+      "immediateActionTaken",
+    ),
+    sopReference: optionalTrimmed(input.sopReference, "sopReference"),
+    meetingRequired: optionalBoolean(
+      input.meetingRequired,
+      "meetingRequired",
+    ),
+    sopReviewRequired: optionalBoolean(
+      input.sopReviewRequired,
+      "sopReviewRequired",
+    ),
+    trainingRequired: optionalBoolean(
+      input.trainingRequired,
+      "trainingRequired",
+    ),
+    maintenanceReviewRequired: optionalBoolean(
+      input.maintenanceReviewRequired,
+      "maintenanceReviewRequired",
+    ),
+    accountableManagerReviewRequired: optionalBoolean(
+      input.accountableManagerReviewRequired,
+      "accountableManagerReviewRequired",
+    ),
+    regulatorReportableReviewRequired: optionalBoolean(
+      input.regulatorReportableReviewRequired,
+      "regulatorReportableReviewRequired",
+    ),
+  };
+}

--- a/src/tests/safety-events.test.ts
+++ b/src/tests/safety-events.test.ts
@@ -1,0 +1,337 @@
+import { randomUUID } from "crypto";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import app, { pool } from "../app";
+import { runMigrations } from "../migrations/runMigrations";
+
+const clearTables = async () => {
+  await pool.query("delete from safety_events");
+  await pool.query("delete from post_operation_audit_signoffs");
+  await pool.query("delete from post_operation_evidence_snapshots");
+  await pool.query("delete from air_safety_meetings");
+  await pool.query("delete from mission_planning_approval_handoffs");
+  await pool.query("delete from mission_decision_evidence_links");
+  await pool.query("delete from audit_evidence_snapshots");
+  await pool.query("delete from airspace_compliance_inputs");
+  await pool.query("delete from mission_risk_inputs");
+  await pool.query("delete from mission_events");
+  await pool.query("delete from missions");
+  await pool.query("delete from pilot_readiness_evidence");
+  await pool.query("delete from pilots");
+  await pool.query("delete from maintenance_records");
+  await pool.query("delete from maintenance_schedules");
+  await pool.query("delete from platforms");
+};
+
+const countRows = async (ids: {
+  missionId?: string;
+  platformId?: string;
+  pilotId?: string;
+  meetingId?: string;
+}) => {
+  const result = await pool.query(
+    `
+    select
+      (select count(*)::int from safety_events) as safety_event_count,
+      (select count(*)::int from missions where ($1::uuid is null or id = $1)) as mission_count,
+      (select count(*)::int from platforms where ($2::uuid is null or id = $2)) as platform_count,
+      (select count(*)::int from pilots where ($3::uuid is null or id = $3)) as pilot_count,
+      (select count(*)::int from air_safety_meetings where ($4::uuid is null or id = $4)) as meeting_count,
+      (select count(*)::int from mission_events where ($1::uuid is null or mission_id = $1)) as mission_event_count
+    `,
+    [
+      ids.missionId ?? null,
+      ids.platformId ?? null,
+      ids.pilotId ?? null,
+      ids.meetingId ?? null,
+    ],
+  );
+
+  return result.rows[0] as {
+    safety_event_count: number;
+    mission_count: number;
+    platform_count: number;
+    pilot_count: number;
+    meeting_count: number;
+    mission_event_count: number;
+  };
+};
+
+const createPlatform = async () => {
+  const response = await request(app).post("/platforms").send({
+    name: "Safety Event UAV",
+    status: "active",
+  });
+
+  expect(response.status).toBe(201);
+  return response.body.platform as { id: string };
+};
+
+const createPilot = async () => {
+  const response = await request(app).post("/pilots").send({
+    displayName: "Safety Event Pilot",
+    status: "active",
+  });
+
+  expect(response.status).toBe(201);
+  return response.body.pilot as { id: string };
+};
+
+const insertMission = async (params: {
+  platformId?: string | null;
+  pilotId?: string | null;
+}) => {
+  const missionId = randomUUID();
+
+  await pool.query(
+    `
+    insert into missions (
+      id,
+      status,
+      mission_plan_id,
+      platform_id,
+      pilot_id,
+      last_event_sequence_no
+    )
+    values ($1, 'completed', 'safety-event-plan', $2, $3, 0)
+    `,
+    [missionId, params.platformId ?? null, params.pilotId ?? null],
+  );
+
+  return missionId;
+};
+
+const insertPostOperationSnapshot = async (missionId: string) => {
+  const snapshotId = randomUUID();
+
+  await pool.query(
+    `
+    insert into post_operation_evidence_snapshots (
+      id,
+      mission_id,
+      lifecycle_state,
+      completion_snapshot,
+      created_by
+    )
+    values ($1, $2, 'completed', $3::jsonb, 'safety-reviewer')
+    `,
+    [
+      snapshotId,
+      missionId,
+      JSON.stringify({
+        missionId,
+        status: "completed",
+        capturedAt: "2026-04-01T10:00:00.000Z",
+      }),
+    ],
+  );
+
+  return snapshotId;
+};
+
+const createAirSafetyMeeting = async () => {
+  const response = await request(app).post("/air-safety-meetings").send({
+    meetingType: "event_triggered_safety_review",
+    dueAt: "2026-04-15T10:00:00.000Z",
+    chairperson: "Safety Manager",
+  });
+
+  expect(response.status).toBe(201);
+  return response.body.meeting as { id: string };
+};
+
+describe("safety events", () => {
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  beforeEach(async () => {
+    await clearTables();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("captures and lists SOP breach safety events with review triggers", async () => {
+    const response = await request(app).post("/safety-events").send({
+      eventType: "sop_breach",
+      severity: "high",
+      eventOccurredAt: "2026-04-10T09:30:00.000Z",
+      reportedBy: " chief pilot ",
+      summary: " Launch checklist step missed ",
+      description: "Pilot skipped second-person checklist confirmation.",
+      immediateActionTaken: "Mission paused and checklist restarted.",
+      sopReference: "OPS-SOP-LAUNCH-001",
+      meetingRequired: true,
+      sopReviewRequired: true,
+      trainingRequired: true,
+      accountableManagerReviewRequired: true,
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.event).toMatchObject({
+      eventType: "sop_breach",
+      severity: "high",
+      status: "open",
+      missionId: null,
+      platformId: null,
+      pilotId: null,
+      reportedBy: "chief pilot",
+      eventOccurredAt: "2026-04-10T09:30:00.000Z",
+      summary: "Launch checklist step missed",
+      description: "Pilot skipped second-person checklist confirmation.",
+      immediateActionTaken: "Mission paused and checklist restarted.",
+      sopReference: "OPS-SOP-LAUNCH-001",
+      meetingRequired: true,
+      sopReviewRequired: true,
+      trainingRequired: true,
+      maintenanceReviewRequired: false,
+      accountableManagerReviewRequired: true,
+      regulatorReportableReviewRequired: false,
+    });
+    expect(response.body.event.id).toEqual(expect.any(String));
+    expect(response.body.event.reportedAt).toEqual(expect.any(String));
+
+    const listResponse = await request(app).get("/safety-events");
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.events).toHaveLength(1);
+    expect(listResponse.body.events[0]).toEqual(response.body.event);
+  });
+
+  it("captures linked post-operation safety findings without mutating linked records", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    const snapshotId = await insertPostOperationSnapshot(missionId);
+    const meeting = await createAirSafetyMeeting();
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      meetingId: meeting.id,
+    });
+
+    const response = await request(app).post("/safety-events").send({
+      eventType: "post_operation_finding",
+      severity: "medium",
+      status: "under_review",
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      postOperationEvidenceSnapshotId: snapshotId,
+      airSafetyMeetingId: meeting.id,
+      eventOccurredAt: "2026-04-12T11:00:00.000Z",
+      reportedBy: "accountable-manager",
+      summary: "Post-operation review identified training follow-up",
+      trainingRequired: true,
+      meetingRequired: true,
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.event).toMatchObject({
+      eventType: "post_operation_finding",
+      severity: "medium",
+      status: "under_review",
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      postOperationEvidenceSnapshotId: snapshotId,
+      airSafetyMeetingId: meeting.id,
+      trainingRequired: true,
+      meetingRequired: true,
+    });
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      meetingId: meeting.id,
+    })).toEqual({
+      ...before,
+      safety_event_count: before.safety_event_count + 1,
+    });
+  });
+
+  it("captures maintenance concerns and regulator-reportable review flags", async () => {
+    const platform = await createPlatform();
+
+    const response = await request(app).post("/safety-events").send({
+      eventType: "maintenance_concern",
+      severity: "critical",
+      platformId: platform.id,
+      eventOccurredAt: "2026-04-12T12:00:00.000Z",
+      summary: "Battery swelling found after landing",
+      immediateActionTaken: "Platform grounded pending engineering review.",
+      maintenanceReviewRequired: true,
+      accountableManagerReviewRequired: true,
+      regulatorReportableReviewRequired: true,
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.event).toMatchObject({
+      eventType: "maintenance_concern",
+      severity: "critical",
+      platformId: platform.id,
+      maintenanceReviewRequired: true,
+      accountableManagerReviewRequired: true,
+      regulatorReportableReviewRequired: true,
+    });
+  });
+
+  it("rejects invalid safety events", async () => {
+    const missingType = await request(app).post("/safety-events").send({
+      severity: "high",
+      eventOccurredAt: "2026-04-10T09:30:00.000Z",
+      summary: "Missing type",
+    });
+    const badFlag = await request(app).post("/safety-events").send({
+      eventType: "training_need",
+      severity: "medium",
+      eventOccurredAt: "2026-04-10T09:30:00.000Z",
+      summary: "Training issue",
+      trainingRequired: "yes",
+    });
+    const badUuid = await request(app).post("/safety-events").send({
+      eventType: "training_need",
+      severity: "medium",
+      eventOccurredAt: "2026-04-10T09:30:00.000Z",
+      summary: "Training issue",
+      pilotId: "not-a-uuid",
+    });
+
+    expect(missingType.status).toBe(400);
+    expect(missingType.body.error).toMatchObject({
+      type: "safety_event_validation_failed",
+    });
+    expect(badFlag.status).toBe(400);
+    expect(badFlag.body.error).toMatchObject({
+      type: "safety_event_validation_failed",
+    });
+    expect(badUuid.status).toBe(400);
+    expect(badUuid.body.error).toMatchObject({
+      type: "safety_event_validation_failed",
+    });
+  });
+
+  it("rejects missing optional references without side effects", async () => {
+    const before = await countRows({});
+
+    const response = await request(app).post("/safety-events").send({
+      eventType: "pilot_readiness_issue",
+      severity: "medium",
+      eventOccurredAt: "2026-04-10T09:30:00.000Z",
+      summary: "Pilot currency concern",
+      pilotId: randomUUID(),
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toMatchObject({
+      type: "safety_event_reference_not_found",
+    });
+    expect(await countRows({})).toEqual(before);
+  });
+});


### PR DESCRIPTION
What changed:

Added migration-backed safety_events table in 021_create_safety_events.sql (line 1).
Added POST /safety-events and GET /safety-events, wired in app.ts (line 198).
Added validation and reference checking for linked mission, platform, pilot, post-operation evidence snapshot, and air safety meeting records in safety-event.service.ts (line 18).
Added test coverage for SOP breaches, maintenance concerns, post-operation findings, invalid input, missing references, and no side effects in safety-events.test.ts (line 156).
Advanced the save point to the next logical task: migration-backed safety event meeting trigger logic in fsms-save-point.json (line 92).