### PR TITLE
Add safety event meeting trigger logic

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add migration-backed safety event meeting trigger logic so serious events, SOP breaches, training needs, and maintenance concerns can require flight safety review.",
+ "nextBuildStep": "Add migration-backed safety event agenda linkage so triggered safety events can be connected to air safety meeting agenda records.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/migrations/022_create_safety_event_meeting_triggers.sql
+++ b/src/migrations/022_create_safety_event_meeting_triggers.sql
@@ -1,0 +1,30 @@
+create table if not exists safety_event_meeting_triggers (
+  id uuid primary key,
+  safety_event_id uuid not null
+    references safety_events(id) on delete cascade,
+  meeting_required boolean not null,
+  recommended_meeting_type text check (
+    recommended_meeting_type is null or recommended_meeting_type in (
+      'event_triggered_safety_review',
+      'sop_breach_review',
+      'training_review',
+      'maintenance_safety_review',
+      'accountable_manager_review'
+    )
+  ),
+  trigger_reasons jsonb not null default '[]'::jsonb,
+  review_flags jsonb not null default '{}'::jsonb,
+  assessed_by text,
+  assessed_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_safety_event_meeting_triggers_event
+  on safety_event_meeting_triggers (safety_event_id, assessed_at desc);
+
+create index if not exists idx_safety_event_meeting_triggers_required
+  on safety_event_meeting_triggers (
+    meeting_required,
+    recommended_meeting_type,
+    assessed_at desc
+  );

--- a/src/safety-events/safety-event.controller.ts
+++ b/src/safety-events/safety-event.controller.ts
@@ -29,4 +29,35 @@ export class SafetyEventController {
       next(error);
     }
   };
+
+  assessMeetingTrigger = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const trigger = await this.safetyEventService.assessMeetingTrigger(
+        req.params.eventId,
+        req.body,
+      );
+      res.status(201).json({ trigger });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listMeetingTriggers = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const triggers = await this.safetyEventService.listMeetingTriggers(
+        req.params.eventId,
+      );
+      res.status(200).json({ triggers });
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/safety-events/safety-event.errors.ts
+++ b/src/safety-events/safety-event.errors.ts
@@ -11,3 +11,12 @@ export class SafetyEventReferenceNotFoundError extends Error {
     super(message);
   }
 }
+
+export class SafetyEventNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "SAFETY_EVENT_NOT_FOUND";
+
+  constructor(eventId: string) {
+    super(`Safety event not found: ${eventId}`);
+  }
+}

--- a/src/safety-events/safety-event.repository.ts
+++ b/src/safety-events/safety-event.repository.ts
@@ -2,6 +2,9 @@ import { randomUUID } from "crypto";
 import type { PoolClient, QueryResultRow } from "pg";
 import type {
   SafetyEvent,
+  SafetyEventMeetingTrigger,
+  SafetyEventMeetingTriggerReviewFlags,
+  SafetyEventMeetingType,
   SafetyEventSeverity,
   SafetyEventStatus,
   SafetyEventType,
@@ -57,6 +60,27 @@ interface CreateSafetyEventRow {
   regulatorReportableReviewRequired: boolean;
 }
 
+interface SafetyEventMeetingTriggerRow extends QueryResultRow {
+  id: string;
+  safety_event_id: string;
+  meeting_required: boolean;
+  recommended_meeting_type: SafetyEventMeetingType | null;
+  trigger_reasons: string[];
+  review_flags: SafetyEventMeetingTriggerReviewFlags;
+  assessed_by: string | null;
+  assessed_at: Date;
+  created_at: Date;
+}
+
+interface CreateSafetyEventMeetingTriggerRow {
+  safetyEventId: string;
+  meetingRequired: boolean;
+  recommendedMeetingType: SafetyEventMeetingType | null;
+  triggerReasons: string[];
+  reviewFlags: SafetyEventMeetingTriggerReviewFlags;
+  assessedBy: string | null;
+}
+
 const toSafetyEvent = (row: SafetyEventRow): SafetyEvent => ({
   id: row.id,
   eventType: row.event_type,
@@ -82,6 +106,20 @@ const toSafetyEvent = (row: SafetyEventRow): SafetyEvent => ({
   regulatorReportableReviewRequired: row.regulator_reportable_review_required,
   createdAt: row.created_at.toISOString(),
   updatedAt: row.updated_at.toISOString(),
+});
+
+const toSafetyEventMeetingTrigger = (
+  row: SafetyEventMeetingTriggerRow,
+): SafetyEventMeetingTrigger => ({
+  id: row.id,
+  safetyEventId: row.safety_event_id,
+  meetingRequired: row.meeting_required,
+  recommendedMeetingType: row.recommended_meeting_type,
+  triggerReasons: row.trigger_reasons,
+  reviewFlags: row.review_flags,
+  assessedBy: row.assessed_by,
+  assessedAt: row.assessed_at.toISOString(),
+  createdAt: row.created_at.toISOString(),
 });
 
 export class SafetyEventRepository {
@@ -158,6 +196,71 @@ export class SafetyEventRepository {
     );
 
     return result.rows.map(toSafetyEvent);
+  }
+
+  async getSafetyEventById(
+    tx: PoolClient,
+    eventId: string,
+  ): Promise<SafetyEvent | null> {
+    const result = await tx.query<SafetyEventRow>(
+      `
+      select *
+      from safety_events
+      where id = $1
+      `,
+      [eventId],
+    );
+
+    return result.rows[0] ? toSafetyEvent(result.rows[0]) : null;
+  }
+
+  async insertSafetyEventMeetingTrigger(
+    tx: PoolClient,
+    input: CreateSafetyEventMeetingTriggerRow,
+  ): Promise<SafetyEventMeetingTrigger> {
+    const result = await tx.query<SafetyEventMeetingTriggerRow>(
+      `
+      insert into safety_event_meeting_triggers (
+        id,
+        safety_event_id,
+        meeting_required,
+        recommended_meeting_type,
+        trigger_reasons,
+        review_flags,
+        assessed_by
+      )
+      values ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.safetyEventId,
+        input.meetingRequired,
+        input.recommendedMeetingType,
+        JSON.stringify(input.triggerReasons),
+        JSON.stringify(input.reviewFlags),
+        input.assessedBy,
+      ],
+    );
+
+    return toSafetyEventMeetingTrigger(result.rows[0]);
+  }
+
+  async listSafetyEventMeetingTriggers(
+    tx: PoolClient,
+    eventId: string,
+  ): Promise<SafetyEventMeetingTrigger[]> {
+    const result = await tx.query<SafetyEventMeetingTriggerRow>(
+      `
+      select *
+      from safety_event_meeting_triggers
+      where safety_event_id = $1
+      order by assessed_at desc, created_at desc, id desc
+      `,
+      [eventId],
+    );
+
+    return result.rows.map(toSafetyEventMeetingTrigger);
   }
 
   async referenceExists(

--- a/src/safety-events/safety-event.routes.ts
+++ b/src/safety-events/safety-event.routes.ts
@@ -8,6 +8,8 @@ export function createSafetyEventRouter(
 
   router.post("/", controller.createSafetyEvent);
   router.get("/", controller.listSafetyEvents);
+  router.post("/:eventId/meeting-trigger", controller.assessMeetingTrigger);
+  router.get("/:eventId/meeting-triggers", controller.listMeetingTriggers);
 
   return router;
 }

--- a/src/safety-events/safety-event.service.ts
+++ b/src/safety-events/safety-event.service.ts
@@ -1,13 +1,22 @@
 import type { Pool } from "pg";
 import {
+  SafetyEventNotFoundError,
   SafetyEventReferenceNotFoundError,
 } from "./safety-event.errors";
 import { SafetyEventRepository } from "./safety-event.repository";
 import type {
+  AssessSafetyEventMeetingTriggerInput,
   CreateSafetyEventInput,
   SafetyEvent,
+  SafetyEventMeetingTrigger,
+  SafetyEventMeetingTriggerReviewFlags,
+  SafetyEventMeetingType,
 } from "./safety-event.types";
-import { validateCreateSafetyEventInput } from "./safety-event.validators";
+import {
+  validateAssessMeetingTriggerInput,
+  validateCreateSafetyEventInput,
+  validateSafetyEventId,
+} from "./safety-event.validators";
 
 export class SafetyEventService {
   constructor(
@@ -40,6 +49,164 @@ export class SafetyEventService {
     } finally {
       client.release();
     }
+  }
+
+  async assessMeetingTrigger(
+    eventIdInput: unknown,
+    input: AssessSafetyEventMeetingTriggerInput | undefined,
+  ): Promise<SafetyEventMeetingTrigger> {
+    const eventId = validateSafetyEventId(eventIdInput);
+    const validated = validateAssessMeetingTriggerInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      const event = await this.safetyEventRepository.getSafetyEventById(
+        client,
+        eventId,
+      );
+
+      if (!event) {
+        throw new SafetyEventNotFoundError(eventId);
+      }
+
+      const assessment = this.buildMeetingTriggerAssessment(event);
+
+      return await this.safetyEventRepository.insertSafetyEventMeetingTrigger(
+        client,
+        {
+          safetyEventId: event.id,
+          assessedBy: validated.assessedBy,
+          ...assessment,
+        },
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  async listMeetingTriggers(
+    eventIdInput: unknown,
+  ): Promise<SafetyEventMeetingTrigger[]> {
+    const eventId = validateSafetyEventId(eventIdInput);
+    const client = await this.pool.connect();
+
+    try {
+      const event = await this.safetyEventRepository.getSafetyEventById(
+        client,
+        eventId,
+      );
+
+      if (!event) {
+        throw new SafetyEventNotFoundError(eventId);
+      }
+
+      return await this.safetyEventRepository.listSafetyEventMeetingTriggers(
+        client,
+        eventId,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  private buildMeetingTriggerAssessment(event: SafetyEvent): {
+    meetingRequired: boolean;
+    recommendedMeetingType: SafetyEventMeetingType | null;
+    triggerReasons: string[];
+    reviewFlags: SafetyEventMeetingTriggerReviewFlags;
+  } {
+    const triggerReasons: string[] = [];
+    const reviewFlags: SafetyEventMeetingTriggerReviewFlags = {
+      sopReviewRequired: event.sopReviewRequired,
+      trainingRequired: event.trainingRequired,
+      maintenanceReviewRequired: event.maintenanceReviewRequired,
+      accountableManagerReviewRequired: event.accountableManagerReviewRequired,
+      regulatorReportableReviewRequired: event.regulatorReportableReviewRequired,
+    };
+
+    if (event.severity === "high" || event.severity === "critical") {
+      triggerReasons.push(`severity:${event.severity}`);
+    }
+
+    if (event.eventType === "sop_breach") {
+      triggerReasons.push("event_type:sop_breach");
+      reviewFlags.sopReviewRequired = true;
+    }
+
+    if (event.eventType === "training_need") {
+      triggerReasons.push("event_type:training_need");
+      reviewFlags.trainingRequired = true;
+    }
+
+    if (event.eventType === "maintenance_concern") {
+      triggerReasons.push("event_type:maintenance_concern");
+      reviewFlags.maintenanceReviewRequired = true;
+    }
+
+    if (event.meetingRequired) {
+      triggerReasons.push("existing_flag:meeting_required");
+    }
+
+    if (event.sopReviewRequired) {
+      triggerReasons.push("existing_flag:sop_review_required");
+    }
+
+    if (event.trainingRequired) {
+      triggerReasons.push("existing_flag:training_required");
+    }
+
+    if (event.maintenanceReviewRequired) {
+      triggerReasons.push("existing_flag:maintenance_review_required");
+    }
+
+    if (event.accountableManagerReviewRequired) {
+      triggerReasons.push(
+        "existing_flag:accountable_manager_review_required",
+      );
+    }
+
+    if (event.regulatorReportableReviewRequired) {
+      triggerReasons.push(
+        "existing_flag:regulator_reportable_review_required",
+      );
+    }
+
+    const meetingRequired = triggerReasons.length > 0;
+
+    return {
+      meetingRequired,
+      recommendedMeetingType: meetingRequired
+        ? this.getRecommendedMeetingType(event, reviewFlags)
+        : null,
+      triggerReasons,
+      reviewFlags,
+    };
+  }
+
+  private getRecommendedMeetingType(
+    event: SafetyEvent,
+    reviewFlags: SafetyEventMeetingTriggerReviewFlags,
+  ): SafetyEventMeetingType {
+    if (
+      reviewFlags.accountableManagerReviewRequired ||
+      event.severity === "critical"
+    ) {
+      return "accountable_manager_review";
+    }
+
+    if (reviewFlags.maintenanceReviewRequired) {
+      return "maintenance_safety_review";
+    }
+
+    if (reviewFlags.sopReviewRequired) {
+      return "sop_breach_review";
+    }
+
+    if (reviewFlags.trainingRequired) {
+      return "training_review";
+    }
+
+    return "event_triggered_safety_review";
   }
 
   private async validateReferences(

--- a/src/safety-events/safety-event.types.ts
+++ b/src/safety-events/safety-event.types.ts
@@ -63,3 +63,34 @@ export interface SafetyEvent {
   createdAt: string;
   updatedAt: string;
 }
+
+export type SafetyEventMeetingType =
+  | "event_triggered_safety_review"
+  | "sop_breach_review"
+  | "training_review"
+  | "maintenance_safety_review"
+  | "accountable_manager_review";
+
+export interface AssessSafetyEventMeetingTriggerInput {
+  assessedBy?: string | null;
+}
+
+export interface SafetyEventMeetingTriggerReviewFlags {
+  sopReviewRequired: boolean;
+  trainingRequired: boolean;
+  maintenanceReviewRequired: boolean;
+  accountableManagerReviewRequired: boolean;
+  regulatorReportableReviewRequired: boolean;
+}
+
+export interface SafetyEventMeetingTrigger {
+  id: string;
+  safetyEventId: string;
+  meetingRequired: boolean;
+  recommendedMeetingType: SafetyEventMeetingType | null;
+  triggerReasons: string[];
+  reviewFlags: SafetyEventMeetingTriggerReviewFlags;
+  assessedBy: string | null;
+  assessedAt: string;
+  createdAt: string;
+}

--- a/src/safety-events/safety-event.validators.ts
+++ b/src/safety-events/safety-event.validators.ts
@@ -1,5 +1,6 @@
 import { SafetyEventValidationError } from "./safety-event.errors";
 import type {
+  AssessSafetyEventMeetingTriggerInput,
   CreateSafetyEventInput,
   SafetyEventSeverity,
   SafetyEventStatus,
@@ -164,5 +165,33 @@ export function validateCreateSafetyEventInput(
       input.regulatorReportableReviewRequired,
       "regulatorReportableReviewRequired",
     ),
+  };
+}
+
+export function validateSafetyEventId(value: unknown): string {
+  const normalized = requiredTrimmed(value, "eventId");
+
+  if (!UUID_RE.test(normalized)) {
+    throw new SafetyEventValidationError("eventId must be a valid UUID");
+  }
+
+  return normalized;
+}
+
+export function validateAssessMeetingTriggerInput(
+  input: AssessSafetyEventMeetingTriggerInput | undefined,
+) {
+  if (input === undefined || input === null) {
+    return {
+      assessedBy: null,
+    };
+  }
+
+  if (typeof input !== "object") {
+    throw new SafetyEventValidationError("Request body must be an object");
+  }
+
+  return {
+    assessedBy: optionalTrimmed(input.assessedBy, "assessedBy"),
   };
 }

--- a/src/tests/safety-events.test.ts
+++ b/src/tests/safety-events.test.ts
@@ -5,6 +5,7 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from safety_event_meeting_triggers");
   await pool.query("delete from safety_events");
   await pool.query("delete from post_operation_audit_signoffs");
   await pool.query("delete from post_operation_evidence_snapshots");
@@ -33,6 +34,7 @@ const countRows = async (ids: {
     `
     select
       (select count(*)::int from safety_events) as safety_event_count,
+      (select count(*)::int from safety_event_meeting_triggers) as safety_event_trigger_count,
       (select count(*)::int from missions where ($1::uuid is null or id = $1)) as mission_count,
       (select count(*)::int from platforms where ($2::uuid is null or id = $2)) as platform_count,
       (select count(*)::int from pilots where ($3::uuid is null or id = $3)) as pilot_count,
@@ -49,6 +51,7 @@ const countRows = async (ids: {
 
   return result.rows[0] as {
     safety_event_count: number;
+    safety_event_trigger_count: number;
     mission_count: number;
     platform_count: number;
     pilot_count: number;
@@ -200,6 +203,138 @@ describe("safety events", () => {
     expect(listResponse.body.events[0]).toEqual(response.body.event);
   });
 
+  it("stores meeting trigger decisions for serious safety events", async () => {
+    const response = await request(app).post("/safety-events").send({
+      eventType: "near_miss",
+      severity: "high",
+      eventOccurredAt: "2026-04-13T09:00:00.000Z",
+      reportedBy: "safety-manager",
+      summary: "Loss of separation during recovery",
+    });
+
+    expect(response.status).toBe(201);
+
+    const triggerResponse = await request(app)
+      .post(`/safety-events/${response.body.event.id}/meeting-trigger`)
+      .send({
+        assessedBy: " accountable manager ",
+      });
+
+    expect(triggerResponse.status).toBe(201);
+    expect(triggerResponse.body.trigger).toMatchObject({
+      safetyEventId: response.body.event.id,
+      meetingRequired: true,
+      recommendedMeetingType: "event_triggered_safety_review",
+      triggerReasons: ["severity:high"],
+      reviewFlags: {
+        sopReviewRequired: false,
+        trainingRequired: false,
+        maintenanceReviewRequired: false,
+        accountableManagerReviewRequired: false,
+        regulatorReportableReviewRequired: false,
+      },
+      assessedBy: "accountable manager",
+    });
+    expect(triggerResponse.body.trigger.id).toEqual(expect.any(String));
+    expect(triggerResponse.body.trigger.assessedAt).toEqual(expect.any(String));
+
+    const listResponse = await request(app).get(
+      `/safety-events/${response.body.event.id}/meeting-triggers`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.triggers).toHaveLength(1);
+    expect(listResponse.body.triggers[0]).toEqual(
+      triggerResponse.body.trigger,
+    );
+  });
+
+  it("stores SOP breach, training, and maintenance trigger decisions", async () => {
+    const cases = [
+      {
+        eventType: "sop_breach",
+        severity: "low",
+        summary: "Dispatch checklist missed",
+        recommendedMeetingType: "sop_breach_review",
+        triggerReason: "event_type:sop_breach",
+        reviewFlag: "sopReviewRequired",
+      },
+      {
+        eventType: "training_need",
+        severity: "medium",
+        summary: "Manual mode recovery refresher required",
+        recommendedMeetingType: "training_review",
+        triggerReason: "event_type:training_need",
+        reviewFlag: "trainingRequired",
+      },
+      {
+        eventType: "maintenance_concern",
+        severity: "medium",
+        summary: "Motor bearing noise after landing",
+        recommendedMeetingType: "maintenance_safety_review",
+        triggerReason: "event_type:maintenance_concern",
+        reviewFlag: "maintenanceReviewRequired",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const response = await request(app).post("/safety-events").send({
+        eventType: testCase.eventType,
+        severity: testCase.severity,
+        eventOccurredAt: "2026-04-13T10:00:00.000Z",
+        summary: testCase.summary,
+      });
+
+      expect(response.status).toBe(201);
+
+      const triggerResponse = await request(app)
+        .post(`/safety-events/${response.body.event.id}/meeting-trigger`)
+        .send({});
+
+      expect(triggerResponse.status).toBe(201);
+      expect(triggerResponse.body.trigger).toMatchObject({
+        safetyEventId: response.body.event.id,
+        meetingRequired: true,
+        recommendedMeetingType: testCase.recommendedMeetingType,
+        triggerReasons: [testCase.triggerReason],
+      });
+      expect(triggerResponse.body.trigger.reviewFlags[testCase.reviewFlag]).toBe(
+        true,
+      );
+    }
+  });
+
+  it("stores non-triggering low-risk event decisions without requiring meetings", async () => {
+    const response = await request(app).post("/safety-events").send({
+      eventType: "mission_planning_issue",
+      severity: "low",
+      eventOccurredAt: "2026-04-13T11:00:00.000Z",
+      summary: "Minor planning note corrected before review",
+    });
+
+    expect(response.status).toBe(201);
+
+    const triggerResponse = await request(app)
+      .post(`/safety-events/${response.body.event.id}/meeting-trigger`)
+      .send({});
+
+    expect(triggerResponse.status).toBe(201);
+    expect(triggerResponse.body.trigger).toMatchObject({
+      safetyEventId: response.body.event.id,
+      meetingRequired: false,
+      recommendedMeetingType: null,
+      triggerReasons: [],
+      reviewFlags: {
+        sopReviewRequired: false,
+        trainingRequired: false,
+        maintenanceReviewRequired: false,
+        accountableManagerReviewRequired: false,
+        regulatorReportableReviewRequired: false,
+      },
+      assessedBy: null,
+    });
+  });
+
   it("captures linked post-operation safety findings without mutating linked records", async () => {
     const platform = await createPlatform();
     const pilot = await createPilot();
@@ -253,6 +388,62 @@ describe("safety events", () => {
     })).toEqual({
       ...before,
       safety_event_count: before.safety_event_count + 1,
+    });
+  });
+
+  it("assesses linked safety events without mutating linked records", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    const meeting = await createAirSafetyMeeting();
+    const safetyEvent = await request(app).post("/safety-events").send({
+      eventType: "maintenance_concern",
+      severity: "critical",
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      airSafetyMeetingId: meeting.id,
+      eventOccurredAt: "2026-04-13T12:00:00.000Z",
+      summary: "Propeller damage found during post-flight inspection",
+    });
+
+    expect(safetyEvent.status).toBe(201);
+
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      meetingId: meeting.id,
+    });
+
+    const triggerResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/meeting-trigger`)
+      .send({});
+
+    expect(triggerResponse.status).toBe(201);
+    expect(triggerResponse.body.trigger).toMatchObject({
+      safetyEventId: safetyEvent.body.event.id,
+      meetingRequired: true,
+      recommendedMeetingType: "accountable_manager_review",
+      triggerReasons: [
+        "severity:critical",
+        "event_type:maintenance_concern",
+      ],
+      reviewFlags: {
+        maintenanceReviewRequired: true,
+      },
+    });
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      meetingId: meeting.id,
+    })).toEqual({
+      ...before,
+      safety_event_trigger_count: before.safety_event_trigger_count + 1,
     });
   });
 
@@ -331,6 +522,27 @@ describe("safety events", () => {
     expect(response.status).toBe(404);
     expect(response.body.error).toMatchObject({
       type: "safety_event_reference_not_found",
+    });
+    expect(await countRows({})).toEqual(before);
+  });
+
+  it("rejects meeting trigger assessment for invalid or missing safety events", async () => {
+    const invalidId = await request(app)
+      .post("/safety-events/not-a-uuid/meeting-trigger")
+      .send({});
+    const missingId = randomUUID();
+    const before = await countRows({});
+    const missingEvent = await request(app)
+      .post(`/safety-events/${missingId}/meeting-trigger`)
+      .send({});
+
+    expect(invalidId.status).toBe(400);
+    expect(invalidId.body.error).toMatchObject({
+      type: "safety_event_validation_failed",
+    });
+    expect(missingEvent.status).toBe(404);
+    expect(missingEvent.body.error).toMatchObject({
+      type: "safety_event_not_found",
     });
     expect(await countRows({})).toEqual(before);
   });


### PR DESCRIPTION
What changed:

Added migration-backed safety_event_meeting_triggers audit records in 022_create_safety_event_meeting_triggers.sql (line 1).
Added endpoints in safety-event.routes.ts (line 11):
POST /safety-events/:eventId/meeting-trigger
GET /safety-events/:eventId/meeting-triggers
Added trigger rules in safety-event.service.ts (line 54) for:
high / critical severity
SOP breaches
training needs
maintenance concerns
existing review flags
Added tests for serious events, SOP/training/maintenance triggers, non-triggering low-risk events, missing event rejection, and no side effects in safety-events.test.ts (line 206).
Advanced the save point to agenda linkage in fsms-save-point.json (line 92).
Verification:

vitest.cmd run src/tests/safety-events.test.ts passed: 10 tests.
vitest.cmd run passed: 230 tests across 21 files.
node scripts/validate-save-point.mjs fsms-save-point.json passed.
git diff --check passed.
node scripts/check-next-build-step-pr.mjs origin/main passed.
npm.cmd run build still exits with TypeScript help text because the repo does not currently have a root tsconfig.json.