### PR TITLE
Add safety event agenda linkage

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add migration-backed safety event agenda linkage so triggered safety events can be connected to air safety meeting agenda records.",
+ "nextBuildStep": "Add migration-backed safety action proposal records so agenda-linked safety events can generate SOP, training, and maintenance follow-up actions.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/migrations/023_create_safety_event_agenda_links.sql
+++ b/src/migrations/023_create_safety_event_agenda_links.sql
@@ -1,0 +1,21 @@
+create table if not exists safety_event_agenda_links (
+  id uuid primary key,
+  safety_event_id uuid not null
+    references safety_events(id) on delete cascade,
+  safety_event_meeting_trigger_id uuid not null
+    references safety_event_meeting_triggers(id) on delete cascade,
+  air_safety_meeting_id uuid not null
+    references air_safety_meetings(id) on delete cascade,
+  agenda_item text not null,
+  linked_by text,
+  linked_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  constraint safety_event_agenda_links_unique
+    unique (safety_event_meeting_trigger_id, air_safety_meeting_id)
+);
+
+create index if not exists idx_safety_event_agenda_links_event
+  on safety_event_agenda_links (safety_event_id, linked_at desc);
+
+create index if not exists idx_safety_event_agenda_links_meeting
+  on safety_event_agenda_links (air_safety_meeting_id, linked_at desc);

--- a/src/safety-events/safety-event.controller.ts
+++ b/src/safety-events/safety-event.controller.ts
@@ -60,4 +60,36 @@ export class SafetyEventController {
       next(error);
     }
   };
+
+  createAgendaLink = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const link = await this.safetyEventService.createAgendaLink(
+        req.params.eventId,
+        req.params.triggerId,
+        req.body,
+      );
+      res.status(201).json({ link });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listAgendaLinks = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const links = await this.safetyEventService.listAgendaLinks(
+        req.params.eventId,
+      );
+      res.status(200).json({ links });
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/safety-events/safety-event.errors.ts
+++ b/src/safety-events/safety-event.errors.ts
@@ -20,3 +20,21 @@ export class SafetyEventNotFoundError extends Error {
     super(`Safety event not found: ${eventId}`);
   }
 }
+
+export class SafetyEventMeetingTriggerNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "SAFETY_EVENT_MEETING_TRIGGER_NOT_FOUND";
+
+  constructor(triggerId: string) {
+    super(`Safety event meeting trigger not found: ${triggerId}`);
+  }
+}
+
+export class SafetyEventAgendaLinkConflictError extends Error {
+  readonly statusCode = 409;
+  readonly code = "SAFETY_EVENT_AGENDA_LINK_CONFLICT";
+
+  constructor() {
+    super("Safety event meeting trigger is already linked to this meeting");
+  }
+}

--- a/src/safety-events/safety-event.repository.ts
+++ b/src/safety-events/safety-event.repository.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import type { PoolClient, QueryResultRow } from "pg";
 import type {
   SafetyEvent,
+  SafetyEventAgendaLink,
   SafetyEventMeetingTrigger,
   SafetyEventMeetingTriggerReviewFlags,
   SafetyEventMeetingType,
@@ -81,6 +82,25 @@ interface CreateSafetyEventMeetingTriggerRow {
   assessedBy: string | null;
 }
 
+interface SafetyEventAgendaLinkRow extends QueryResultRow {
+  id: string;
+  safety_event_id: string;
+  safety_event_meeting_trigger_id: string;
+  air_safety_meeting_id: string;
+  agenda_item: string;
+  linked_by: string | null;
+  linked_at: Date;
+  created_at: Date;
+}
+
+interface CreateSafetyEventAgendaLinkRow {
+  safetyEventId: string;
+  safetyEventMeetingTriggerId: string;
+  airSafetyMeetingId: string;
+  agendaItem: string;
+  linkedBy: string | null;
+}
+
 const toSafetyEvent = (row: SafetyEventRow): SafetyEvent => ({
   id: row.id,
   eventType: row.event_type,
@@ -119,6 +139,19 @@ const toSafetyEventMeetingTrigger = (
   reviewFlags: row.review_flags,
   assessedBy: row.assessed_by,
   assessedAt: row.assessed_at.toISOString(),
+  createdAt: row.created_at.toISOString(),
+});
+
+const toSafetyEventAgendaLink = (
+  row: SafetyEventAgendaLinkRow,
+): SafetyEventAgendaLink => ({
+  id: row.id,
+  safetyEventId: row.safety_event_id,
+  safetyEventMeetingTriggerId: row.safety_event_meeting_trigger_id,
+  airSafetyMeetingId: row.air_safety_meeting_id,
+  agendaItem: row.agenda_item,
+  linkedBy: row.linked_by,
+  linkedAt: row.linked_at.toISOString(),
   createdAt: row.created_at.toISOString(),
 });
 
@@ -261,6 +294,69 @@ export class SafetyEventRepository {
     );
 
     return result.rows.map(toSafetyEventMeetingTrigger);
+  }
+
+  async getSafetyEventMeetingTriggerById(
+    tx: PoolClient,
+    triggerId: string,
+  ): Promise<SafetyEventMeetingTrigger | null> {
+    const result = await tx.query<SafetyEventMeetingTriggerRow>(
+      `
+      select *
+      from safety_event_meeting_triggers
+      where id = $1
+      `,
+      [triggerId],
+    );
+
+    return result.rows[0] ? toSafetyEventMeetingTrigger(result.rows[0]) : null;
+  }
+
+  async insertSafetyEventAgendaLink(
+    tx: PoolClient,
+    input: CreateSafetyEventAgendaLinkRow,
+  ): Promise<SafetyEventAgendaLink> {
+    const result = await tx.query<SafetyEventAgendaLinkRow>(
+      `
+      insert into safety_event_agenda_links (
+        id,
+        safety_event_id,
+        safety_event_meeting_trigger_id,
+        air_safety_meeting_id,
+        agenda_item,
+        linked_by
+      )
+      values ($1, $2, $3, $4, $5, $6)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.safetyEventId,
+        input.safetyEventMeetingTriggerId,
+        input.airSafetyMeetingId,
+        input.agendaItem,
+        input.linkedBy,
+      ],
+    );
+
+    return toSafetyEventAgendaLink(result.rows[0]);
+  }
+
+  async listSafetyEventAgendaLinks(
+    tx: PoolClient,
+    eventId: string,
+  ): Promise<SafetyEventAgendaLink[]> {
+    const result = await tx.query<SafetyEventAgendaLinkRow>(
+      `
+      select *
+      from safety_event_agenda_links
+      where safety_event_id = $1
+      order by linked_at desc, created_at desc, id desc
+      `,
+      [eventId],
+    );
+
+    return result.rows.map(toSafetyEventAgendaLink);
   }
 
   async referenceExists(

--- a/src/safety-events/safety-event.routes.ts
+++ b/src/safety-events/safety-event.routes.ts
@@ -10,6 +10,11 @@ export function createSafetyEventRouter(
   router.get("/", controller.listSafetyEvents);
   router.post("/:eventId/meeting-trigger", controller.assessMeetingTrigger);
   router.get("/:eventId/meeting-triggers", controller.listMeetingTriggers);
+  router.post(
+    "/:eventId/meeting-triggers/:triggerId/agenda-links",
+    controller.createAgendaLink,
+  );
+  router.get("/:eventId/agenda-links", controller.listAgendaLinks);
 
   return router;
 }

--- a/src/safety-events/safety-event.service.ts
+++ b/src/safety-events/safety-event.service.ts
@@ -1,21 +1,27 @@
 import type { Pool } from "pg";
 import {
+  SafetyEventAgendaLinkConflictError,
+  SafetyEventMeetingTriggerNotFoundError,
   SafetyEventNotFoundError,
   SafetyEventReferenceNotFoundError,
 } from "./safety-event.errors";
 import { SafetyEventRepository } from "./safety-event.repository";
 import type {
   AssessSafetyEventMeetingTriggerInput,
+  CreateSafetyEventAgendaLinkInput,
   CreateSafetyEventInput,
   SafetyEvent,
+  SafetyEventAgendaLink,
   SafetyEventMeetingTrigger,
   SafetyEventMeetingTriggerReviewFlags,
   SafetyEventMeetingType,
 } from "./safety-event.types";
 import {
   validateAssessMeetingTriggerInput,
+  validateCreateAgendaLinkInput,
   validateCreateSafetyEventInput,
   validateSafetyEventId,
+  validateSafetyEventMeetingTriggerId,
 } from "./safety-event.validators";
 
 export class SafetyEventService {
@@ -101,6 +107,89 @@ export class SafetyEventService {
       }
 
       return await this.safetyEventRepository.listSafetyEventMeetingTriggers(
+        client,
+        eventId,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  async createAgendaLink(
+    eventIdInput: unknown,
+    triggerIdInput: unknown,
+    input: CreateSafetyEventAgendaLinkInput | undefined,
+  ): Promise<SafetyEventAgendaLink> {
+    const eventId = validateSafetyEventId(eventIdInput);
+    const triggerId = validateSafetyEventMeetingTriggerId(triggerIdInput);
+    const validated = validateCreateAgendaLinkInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      const event = await this.safetyEventRepository.getSafetyEventById(
+        client,
+        eventId,
+      );
+
+      if (!event) {
+        throw new SafetyEventNotFoundError(eventId);
+      }
+
+      const trigger =
+        await this.safetyEventRepository.getSafetyEventMeetingTriggerById(
+          client,
+          triggerId,
+        );
+
+      if (!trigger || trigger.safetyEventId !== eventId) {
+        throw new SafetyEventMeetingTriggerNotFoundError(triggerId);
+      }
+
+      await this.validateReference(
+        client,
+        "air_safety_meetings",
+        validated.airSafetyMeetingId,
+        "air safety meeting",
+      );
+
+      try {
+        return await this.safetyEventRepository.insertSafetyEventAgendaLink(
+          client,
+          {
+            safetyEventId: event.id,
+            safetyEventMeetingTriggerId: trigger.id,
+            airSafetyMeetingId: validated.airSafetyMeetingId,
+            agendaItem: validated.agendaItem,
+            linkedBy: validated.linkedBy,
+          },
+        );
+      } catch (error) {
+        if (this.isUniqueViolation(error)) {
+          throw new SafetyEventAgendaLinkConflictError();
+        }
+
+        throw error;
+      }
+    } finally {
+      client.release();
+    }
+  }
+
+  async listAgendaLinks(eventIdInput: unknown): Promise<SafetyEventAgendaLink[]> {
+    const eventId = validateSafetyEventId(eventIdInput);
+    const client = await this.pool.connect();
+
+    try {
+      const event = await this.safetyEventRepository.getSafetyEventById(
+        client,
+        eventId,
+      );
+
+      if (!event) {
+        throw new SafetyEventNotFoundError(eventId);
+      }
+
+      return await this.safetyEventRepository.listSafetyEventAgendaLinks(
         client,
         eventId,
       );
@@ -261,5 +350,14 @@ export class SafetyEventService {
         `Safety event references missing ${label}: ${id}`,
       );
     }
+  }
+
+  private isUniqueViolation(error: unknown): boolean {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: unknown }).code === "23505"
+    );
   }
 }

--- a/src/safety-events/safety-event.types.ts
+++ b/src/safety-events/safety-event.types.ts
@@ -94,3 +94,20 @@ export interface SafetyEventMeetingTrigger {
   assessedAt: string;
   createdAt: string;
 }
+
+export interface CreateSafetyEventAgendaLinkInput {
+  airSafetyMeetingId?: string;
+  agendaItem?: string;
+  linkedBy?: string | null;
+}
+
+export interface SafetyEventAgendaLink {
+  id: string;
+  safetyEventId: string;
+  safetyEventMeetingTriggerId: string;
+  airSafetyMeetingId: string;
+  agendaItem: string;
+  linkedBy: string | null;
+  linkedAt: string;
+  createdAt: string;
+}

--- a/src/safety-events/safety-event.validators.ts
+++ b/src/safety-events/safety-event.validators.ts
@@ -1,6 +1,7 @@
 import { SafetyEventValidationError } from "./safety-event.errors";
 import type {
   AssessSafetyEventMeetingTriggerInput,
+  CreateSafetyEventAgendaLinkInput,
   CreateSafetyEventInput,
   SafetyEventSeverity,
   SafetyEventStatus,
@@ -178,6 +179,21 @@ export function validateSafetyEventId(value: unknown): string {
   return normalized;
 }
 
+export function validateSafetyEventMeetingTriggerId(value: unknown): string {
+  const normalized = requiredTrimmed(
+    value,
+    "safetyEventMeetingTriggerId",
+  );
+
+  if (!UUID_RE.test(normalized)) {
+    throw new SafetyEventValidationError(
+      "safetyEventMeetingTriggerId must be a valid UUID",
+    );
+  }
+
+  return normalized;
+}
+
 export function validateAssessMeetingTriggerInput(
   input: AssessSafetyEventMeetingTriggerInput | undefined,
 ) {
@@ -193,5 +209,22 @@ export function validateAssessMeetingTriggerInput(
 
   return {
     assessedBy: optionalTrimmed(input.assessedBy, "assessedBy"),
+  };
+}
+
+export function validateCreateAgendaLinkInput(
+  input: CreateSafetyEventAgendaLinkInput | undefined,
+) {
+  if (!input || typeof input !== "object") {
+    throw new SafetyEventValidationError("Request body must be an object");
+  }
+
+  return {
+    airSafetyMeetingId: optionalUuid(
+      input.airSafetyMeetingId,
+      "airSafetyMeetingId",
+    ) ?? requiredTrimmed(input.airSafetyMeetingId, "airSafetyMeetingId"),
+    agendaItem: requiredTrimmed(input.agendaItem, "agendaItem"),
+    linkedBy: optionalTrimmed(input.linkedBy, "linkedBy"),
   };
 }

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -4,6 +4,9 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from safety_event_agenda_links");
+  await pool.query("delete from safety_event_meeting_triggers");
+  await pool.query("delete from safety_events");
   await pool.query("delete from air_safety_meetings");
 };
 

--- a/src/tests/safety-events.test.ts
+++ b/src/tests/safety-events.test.ts
@@ -5,6 +5,7 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from safety_event_agenda_links");
   await pool.query("delete from safety_event_meeting_triggers");
   await pool.query("delete from safety_events");
   await pool.query("delete from post_operation_audit_signoffs");
@@ -35,6 +36,7 @@ const countRows = async (ids: {
     select
       (select count(*)::int from safety_events) as safety_event_count,
       (select count(*)::int from safety_event_meeting_triggers) as safety_event_trigger_count,
+      (select count(*)::int from safety_event_agenda_links) as safety_event_agenda_link_count,
       (select count(*)::int from missions where ($1::uuid is null or id = $1)) as mission_count,
       (select count(*)::int from platforms where ($2::uuid is null or id = $2)) as platform_count,
       (select count(*)::int from pilots where ($3::uuid is null or id = $3)) as pilot_count,
@@ -52,6 +54,7 @@ const countRows = async (ids: {
   return result.rows[0] as {
     safety_event_count: number;
     safety_event_trigger_count: number;
+    safety_event_agenda_link_count: number;
     mission_count: number;
     platform_count: number;
     pilot_count: number;
@@ -141,6 +144,34 @@ const createAirSafetyMeeting = async () => {
 
   expect(response.status).toBe(201);
   return response.body.meeting as { id: string };
+};
+
+const createTriggeredSafetyEvent = async (params?: {
+  eventType?: string;
+  severity?: string;
+  summary?: string;
+}) => {
+  const eventResponse = await request(app).post("/safety-events").send({
+    eventType: params?.eventType ?? "near_miss",
+    severity: params?.severity ?? "high",
+    eventOccurredAt: "2026-04-14T09:00:00.000Z",
+    summary: params?.summary ?? "Near miss requires safety review",
+  });
+
+  expect(eventResponse.status).toBe(201);
+
+  const triggerResponse = await request(app)
+    .post(`/safety-events/${eventResponse.body.event.id}/meeting-trigger`)
+    .send({
+      assessedBy: "safety-manager",
+    });
+
+  expect(triggerResponse.status).toBe(201);
+
+  return {
+    event: eventResponse.body.event as { id: string },
+    trigger: triggerResponse.body.trigger as { id: string },
+  };
 };
 
 describe("safety events", () => {
@@ -335,6 +366,126 @@ describe("safety events", () => {
     });
   });
 
+  it("links a triggered safety event to an air safety meeting agenda record", async () => {
+    const meeting = await createAirSafetyMeeting();
+    const { event, trigger } = await createTriggeredSafetyEvent();
+
+    const response = await request(app)
+      .post(`/safety-events/${event.id}/meeting-triggers/${trigger.id}/agenda-links`)
+      .send({
+        airSafetyMeetingId: meeting.id,
+        agendaItem: " Review near miss recovery actions ",
+        linkedBy: " safety coordinator ",
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.link).toMatchObject({
+      safetyEventId: event.id,
+      safetyEventMeetingTriggerId: trigger.id,
+      airSafetyMeetingId: meeting.id,
+      agendaItem: "Review near miss recovery actions",
+      linkedBy: "safety coordinator",
+    });
+    expect(response.body.link.id).toEqual(expect.any(String));
+    expect(response.body.link.linkedAt).toEqual(expect.any(String));
+
+    const listResponse = await request(app).get(
+      `/safety-events/${event.id}/agenda-links`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.links).toHaveLength(1);
+    expect(listResponse.body.links[0]).toEqual(response.body.link);
+  });
+
+  it("links multiple safety event triggers to the same air safety meeting", async () => {
+    const meeting = await createAirSafetyMeeting();
+    const first = await createTriggeredSafetyEvent({
+      eventType: "sop_breach",
+      severity: "low",
+      summary: "Checklist step missed",
+    });
+    const second = await createTriggeredSafetyEvent({
+      eventType: "training_need",
+      severity: "medium",
+      summary: "Manual recovery refresher needed",
+    });
+
+    const firstLink = await request(app)
+      .post(`/safety-events/${first.event.id}/meeting-triggers/${first.trigger.id}/agenda-links`)
+      .send({
+        airSafetyMeetingId: meeting.id,
+        agendaItem: "Review SOP breach",
+      });
+    const secondLink = await request(app)
+      .post(`/safety-events/${second.event.id}/meeting-triggers/${second.trigger.id}/agenda-links`)
+      .send({
+        airSafetyMeetingId: meeting.id,
+        agendaItem: "Review training action",
+      });
+
+    expect(firstLink.status).toBe(201);
+    expect(secondLink.status).toBe(201);
+    expect(firstLink.body.link.airSafetyMeetingId).toBe(meeting.id);
+    expect(secondLink.body.link.airSafetyMeetingId).toBe(meeting.id);
+    expect(firstLink.body.link.safetyEventId).not.toBe(
+      secondLink.body.link.safetyEventId,
+    );
+  });
+
+  it("rejects agenda linkage for missing trigger or missing meeting", async () => {
+    const meeting = await createAirSafetyMeeting();
+    const { event, trigger } = await createTriggeredSafetyEvent();
+    const missingTrigger = randomUUID();
+    const missingMeeting = randomUUID();
+
+    const missingTriggerResponse = await request(app)
+      .post(`/safety-events/${event.id}/meeting-triggers/${missingTrigger}/agenda-links`)
+      .send({
+        airSafetyMeetingId: meeting.id,
+        agendaItem: "Review missing trigger",
+      });
+    const missingMeetingResponse = await request(app)
+      .post(`/safety-events/${event.id}/meeting-triggers/${trigger.id}/agenda-links`)
+      .send({
+        airSafetyMeetingId: missingMeeting,
+        agendaItem: "Review missing meeting",
+      });
+
+    expect(missingTriggerResponse.status).toBe(404);
+    expect(missingTriggerResponse.body.error).toMatchObject({
+      type: "safety_event_meeting_trigger_not_found",
+    });
+    expect(missingMeetingResponse.status).toBe(404);
+    expect(missingMeetingResponse.body.error).toMatchObject({
+      type: "safety_event_reference_not_found",
+    });
+  });
+
+  it("rejects duplicate agenda linkage for the same trigger and meeting", async () => {
+    const meeting = await createAirSafetyMeeting();
+    const { event, trigger } = await createTriggeredSafetyEvent();
+
+    const firstResponse = await request(app)
+      .post(`/safety-events/${event.id}/meeting-triggers/${trigger.id}/agenda-links`)
+      .send({
+        airSafetyMeetingId: meeting.id,
+        agendaItem: "Initial review",
+      });
+    const duplicateResponse = await request(app)
+      .post(`/safety-events/${event.id}/meeting-triggers/${trigger.id}/agenda-links`)
+      .send({
+        airSafetyMeetingId: meeting.id,
+        agendaItem: "Duplicate review",
+      });
+
+    expect(firstResponse.status).toBe(201);
+    expect(duplicateResponse.status).toBe(409);
+    expect(duplicateResponse.body.error).toMatchObject({
+      type: "safety_event_agenda_link_conflict",
+    });
+  });
+
   it("captures linked post-operation safety findings without mutating linked records", async () => {
     const platform = await createPlatform();
     const pilot = await createPilot();
@@ -444,6 +595,59 @@ describe("safety events", () => {
     })).toEqual({
       ...before,
       safety_event_trigger_count: before.safety_event_trigger_count + 1,
+    });
+  });
+
+  it("links agenda records without mutating safety event, trigger, meeting, or linked records", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    const meeting = await createAirSafetyMeeting();
+    const safetyEvent = await request(app).post("/safety-events").send({
+      eventType: "sop_breach",
+      severity: "high",
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      eventOccurredAt: "2026-04-14T12:00:00.000Z",
+      summary: "Dispatch briefing step missed",
+    });
+
+    expect(safetyEvent.status).toBe(201);
+
+    const triggerResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/meeting-trigger`)
+      .send({});
+
+    expect(triggerResponse.status).toBe(201);
+
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      meetingId: meeting.id,
+    });
+
+    const linkResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/meeting-triggers/${triggerResponse.body.trigger.id}/agenda-links`)
+      .send({
+        airSafetyMeetingId: meeting.id,
+        agendaItem: "Review dispatch briefing SOP breach",
+      });
+
+    expect(linkResponse.status).toBe(201);
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      meetingId: meeting.id,
+    })).toEqual({
+      ...before,
+      safety_event_agenda_link_count:
+        before.safety_event_agenda_link_count + 1,
     });
   });
 


### PR DESCRIPTION
What changed:

Added migration-backed safety_event_agenda_links in 023_create_safety_event_agenda_links.sql (line 1).
Added agenda linkage endpoints in safety-event.routes.ts (line 14):
POST /safety-events/:eventId/meeting-triggers/:triggerId/agenda-links
GET /safety-events/:eventId/agenda-links
Added linkage validation in safety-event.service.ts (line 118):
safety event must exist
trigger must exist and belong to that safety event
air safety meeting must exist
duplicate trigger-to-meeting link returns 409
Added tests for successful linkage, multiple events on one meeting, missing trigger, missing meeting, duplicate link rejection, and no side effects in safety-events.test.ts (line 369).
Advanced the save point to safety action proposals in fsms-save-point.json (line 92).
Verification:

vitest.cmd run src/tests/safety-events.test.ts passed: 15 tests.
vitest.cmd run src/tests/air-safety-meetings.test.ts passed: 7 tests.
vitest.cmd run passed: 235 tests across 21 files.
node scripts/validate-save-point.mjs fsms-save-point.json passed.
git diff --check passed.
node scripts/check-next-build-step-pr.mjs origin/main passed.
npm.cmd run build still exits with TypeScript help text because the repo does not currently have a root tsconfig.json.