### PR TITLE
Add safety action proposal records

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add migration-backed safety action proposal records so agenda-linked safety events can generate SOP, training, and maintenance follow-up actions.",
+ "nextBuildStep": "Add migration-backed safety action approval workflow so proposed SOP, training, and maintenance actions can be accepted, rejected, or completed.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/migrations/024_create_safety_action_proposals.sql
+++ b/src/migrations/024_create_safety_action_proposals.sql
@@ -1,0 +1,39 @@
+create table if not exists safety_action_proposals (
+  id uuid primary key,
+  safety_event_agenda_link_id uuid not null
+    references safety_event_agenda_links(id) on delete cascade,
+  safety_event_id uuid not null
+    references safety_events(id) on delete cascade,
+  safety_event_meeting_trigger_id uuid not null
+    references safety_event_meeting_triggers(id) on delete cascade,
+  air_safety_meeting_id uuid not null
+    references air_safety_meetings(id) on delete cascade,
+  proposal_type text not null check (
+    proposal_type in (
+      'sop_change',
+      'training_action',
+      'maintenance_action',
+      'accountable_manager_review',
+      'general_safety_action'
+    )
+  ),
+  status text not null check (
+    status in ('proposed', 'accepted', 'rejected', 'completed')
+  ),
+  summary text not null,
+  rationale text,
+  proposed_owner text,
+  proposed_due_at timestamptz,
+  created_by text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_safety_action_proposals_agenda_link
+  on safety_action_proposals (safety_event_agenda_link_id, created_at desc);
+
+create index if not exists idx_safety_action_proposals_event
+  on safety_action_proposals (safety_event_id, created_at desc);
+
+create index if not exists idx_safety_action_proposals_status
+  on safety_action_proposals (status, proposal_type, proposed_due_at asc);

--- a/src/safety-events/safety-event.controller.ts
+++ b/src/safety-events/safety-event.controller.ts
@@ -92,4 +92,39 @@ export class SafetyEventController {
       next(error);
     }
   };
+
+  createSafetyActionProposal = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const proposal =
+        await this.safetyEventService.createSafetyActionProposal(
+          req.params.eventId,
+          req.params.agendaLinkId,
+          req.body,
+        );
+      res.status(201).json({ proposal });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listSafetyActionProposals = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const proposals =
+        await this.safetyEventService.listSafetyActionProposals(
+          req.params.eventId,
+          req.params.agendaLinkId,
+        );
+      res.status(200).json({ proposals });
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/safety-events/safety-event.errors.ts
+++ b/src/safety-events/safety-event.errors.ts
@@ -38,3 +38,12 @@ export class SafetyEventAgendaLinkConflictError extends Error {
     super("Safety event meeting trigger is already linked to this meeting");
   }
 }
+
+export class SafetyEventAgendaLinkNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "SAFETY_EVENT_AGENDA_LINK_NOT_FOUND";
+
+  constructor(agendaLinkId: string) {
+    super(`Safety event agenda link not found: ${agendaLinkId}`);
+  }
+}

--- a/src/safety-events/safety-event.repository.ts
+++ b/src/safety-events/safety-event.repository.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from "crypto";
 import type { PoolClient, QueryResultRow } from "pg";
 import type {
+  SafetyActionProposal,
+  SafetyActionProposalStatus,
+  SafetyActionProposalType,
   SafetyEvent,
   SafetyEventAgendaLink,
   SafetyEventMeetingTrigger,
@@ -101,6 +104,37 @@ interface CreateSafetyEventAgendaLinkRow {
   linkedBy: string | null;
 }
 
+interface SafetyActionProposalRow extends QueryResultRow {
+  id: string;
+  safety_event_agenda_link_id: string;
+  safety_event_id: string;
+  safety_event_meeting_trigger_id: string;
+  air_safety_meeting_id: string;
+  proposal_type: SafetyActionProposalType;
+  status: SafetyActionProposalStatus;
+  summary: string;
+  rationale: string | null;
+  proposed_owner: string | null;
+  proposed_due_at: Date | null;
+  created_by: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface CreateSafetyActionProposalRow {
+  safetyEventAgendaLinkId: string;
+  safetyEventId: string;
+  safetyEventMeetingTriggerId: string;
+  airSafetyMeetingId: string;
+  proposalType: SafetyActionProposalType;
+  status: SafetyActionProposalStatus;
+  summary: string;
+  rationale: string | null;
+  proposedOwner: string | null;
+  proposedDueAt: Date | null;
+  createdBy: string | null;
+}
+
 const toSafetyEvent = (row: SafetyEventRow): SafetyEvent => ({
   id: row.id,
   eventType: row.event_type,
@@ -153,6 +187,25 @@ const toSafetyEventAgendaLink = (
   linkedBy: row.linked_by,
   linkedAt: row.linked_at.toISOString(),
   createdAt: row.created_at.toISOString(),
+});
+
+const toSafetyActionProposal = (
+  row: SafetyActionProposalRow,
+): SafetyActionProposal => ({
+  id: row.id,
+  safetyEventAgendaLinkId: row.safety_event_agenda_link_id,
+  safetyEventId: row.safety_event_id,
+  safetyEventMeetingTriggerId: row.safety_event_meeting_trigger_id,
+  airSafetyMeetingId: row.air_safety_meeting_id,
+  proposalType: row.proposal_type,
+  status: row.status,
+  summary: row.summary,
+  rationale: row.rationale,
+  proposedOwner: row.proposed_owner,
+  proposedDueAt: row.proposed_due_at?.toISOString() ?? null,
+  createdBy: row.created_by,
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
 });
 
 export class SafetyEventRepository {
@@ -357,6 +410,81 @@ export class SafetyEventRepository {
     );
 
     return result.rows.map(toSafetyEventAgendaLink);
+  }
+
+  async getSafetyEventAgendaLinkById(
+    tx: PoolClient,
+    agendaLinkId: string,
+  ): Promise<SafetyEventAgendaLink | null> {
+    const result = await tx.query<SafetyEventAgendaLinkRow>(
+      `
+      select *
+      from safety_event_agenda_links
+      where id = $1
+      `,
+      [agendaLinkId],
+    );
+
+    return result.rows[0] ? toSafetyEventAgendaLink(result.rows[0]) : null;
+  }
+
+  async insertSafetyActionProposal(
+    tx: PoolClient,
+    input: CreateSafetyActionProposalRow,
+  ): Promise<SafetyActionProposal> {
+    const result = await tx.query<SafetyActionProposalRow>(
+      `
+      insert into safety_action_proposals (
+        id,
+        safety_event_agenda_link_id,
+        safety_event_id,
+        safety_event_meeting_trigger_id,
+        air_safety_meeting_id,
+        proposal_type,
+        status,
+        summary,
+        rationale,
+        proposed_owner,
+        proposed_due_at,
+        created_by
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.safetyEventAgendaLinkId,
+        input.safetyEventId,
+        input.safetyEventMeetingTriggerId,
+        input.airSafetyMeetingId,
+        input.proposalType,
+        input.status,
+        input.summary,
+        input.rationale,
+        input.proposedOwner,
+        input.proposedDueAt,
+        input.createdBy,
+      ],
+    );
+
+    return toSafetyActionProposal(result.rows[0]);
+  }
+
+  async listSafetyActionProposalsByAgendaLink(
+    tx: PoolClient,
+    agendaLinkId: string,
+  ): Promise<SafetyActionProposal[]> {
+    const result = await tx.query<SafetyActionProposalRow>(
+      `
+      select *
+      from safety_action_proposals
+      where safety_event_agenda_link_id = $1
+      order by created_at desc, id desc
+      `,
+      [agendaLinkId],
+    );
+
+    return result.rows.map(toSafetyActionProposal);
   }
 
   async referenceExists(

--- a/src/safety-events/safety-event.routes.ts
+++ b/src/safety-events/safety-event.routes.ts
@@ -15,6 +15,14 @@ export function createSafetyEventRouter(
     controller.createAgendaLink,
   );
   router.get("/:eventId/agenda-links", controller.listAgendaLinks);
+  router.post(
+    "/:eventId/agenda-links/:agendaLinkId/action-proposals",
+    controller.createSafetyActionProposal,
+  );
+  router.get(
+    "/:eventId/agenda-links/:agendaLinkId/action-proposals",
+    controller.listSafetyActionProposals,
+  );
 
   return router;
 }

--- a/src/safety-events/safety-event.service.ts
+++ b/src/safety-events/safety-event.service.ts
@@ -1,6 +1,7 @@
 import type { Pool } from "pg";
 import {
   SafetyEventAgendaLinkConflictError,
+  SafetyEventAgendaLinkNotFoundError,
   SafetyEventMeetingTriggerNotFoundError,
   SafetyEventNotFoundError,
   SafetyEventReferenceNotFoundError,
@@ -8,8 +9,10 @@ import {
 import { SafetyEventRepository } from "./safety-event.repository";
 import type {
   AssessSafetyEventMeetingTriggerInput,
+  CreateSafetyActionProposalInput,
   CreateSafetyEventAgendaLinkInput,
   CreateSafetyEventInput,
+  SafetyActionProposal,
   SafetyEvent,
   SafetyEventAgendaLink,
   SafetyEventMeetingTrigger,
@@ -18,8 +21,10 @@ import type {
 } from "./safety-event.types";
 import {
   validateAssessMeetingTriggerInput,
+  validateCreateSafetyActionProposalInput,
   validateCreateAgendaLinkInput,
   validateCreateSafetyEventInput,
+  validateSafetyEventAgendaLinkId,
   validateSafetyEventId,
   validateSafetyEventMeetingTriggerId,
 } from "./safety-event.validators";
@@ -198,6 +203,62 @@ export class SafetyEventService {
     }
   }
 
+  async createSafetyActionProposal(
+    eventIdInput: unknown,
+    agendaLinkIdInput: unknown,
+    input: CreateSafetyActionProposalInput | undefined,
+  ): Promise<SafetyActionProposal> {
+    const eventId = validateSafetyEventId(eventIdInput);
+    const agendaLinkId = validateSafetyEventAgendaLinkId(agendaLinkIdInput);
+    const validated = validateCreateSafetyActionProposalInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      const agendaLink = await this.getValidatedAgendaLink(
+        client,
+        eventId,
+        agendaLinkId,
+      );
+
+      return await this.safetyEventRepository.insertSafetyActionProposal(
+        client,
+        {
+          safetyEventAgendaLinkId: agendaLink.id,
+          safetyEventId: agendaLink.safetyEventId,
+          safetyEventMeetingTriggerId: agendaLink.safetyEventMeetingTriggerId,
+          airSafetyMeetingId: agendaLink.airSafetyMeetingId,
+          proposalType: validated.proposalType,
+          status: validated.status,
+          summary: validated.summary,
+          rationale: validated.rationale,
+          proposedOwner: validated.proposedOwner,
+          proposedDueAt: validated.proposedDueAt,
+          createdBy: validated.createdBy,
+        },
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  async listSafetyActionProposals(
+    eventIdInput: unknown,
+    agendaLinkIdInput: unknown,
+  ): Promise<SafetyActionProposal[]> {
+    const eventId = validateSafetyEventId(eventIdInput);
+    const agendaLinkId = validateSafetyEventAgendaLinkId(agendaLinkIdInput);
+    const client = await this.pool.connect();
+
+    try {
+      await this.getValidatedAgendaLink(client, eventId, agendaLinkId);
+
+      return await this.safetyEventRepository
+        .listSafetyActionProposalsByAgendaLink(client, agendaLinkId);
+    } finally {
+      client.release();
+    }
+  }
+
   private buildMeetingTriggerAssessment(event: SafetyEvent): {
     meetingRequired: boolean;
     recommendedMeetingType: SafetyEventMeetingType | null;
@@ -359,5 +420,32 @@ export class SafetyEventService {
       "code" in error &&
       (error as { code?: unknown }).code === "23505"
     );
+  }
+
+  private async getValidatedAgendaLink(
+    client: Awaited<ReturnType<Pool["connect"]>>,
+    eventId: string,
+    agendaLinkId: string,
+  ): Promise<SafetyEventAgendaLink> {
+    const event = await this.safetyEventRepository.getSafetyEventById(
+      client,
+      eventId,
+    );
+
+    if (!event) {
+      throw new SafetyEventNotFoundError(eventId);
+    }
+
+    const agendaLink =
+      await this.safetyEventRepository.getSafetyEventAgendaLinkById(
+        client,
+        agendaLinkId,
+      );
+
+    if (!agendaLink || agendaLink.safetyEventId !== eventId) {
+      throw new SafetyEventAgendaLinkNotFoundError(agendaLinkId);
+    }
+
+    return agendaLink;
   }
 }

--- a/src/safety-events/safety-event.types.ts
+++ b/src/safety-events/safety-event.types.ts
@@ -111,3 +111,43 @@ export interface SafetyEventAgendaLink {
   linkedAt: string;
   createdAt: string;
 }
+
+export type SafetyActionProposalType =
+  | "sop_change"
+  | "training_action"
+  | "maintenance_action"
+  | "accountable_manager_review"
+  | "general_safety_action";
+
+export type SafetyActionProposalStatus =
+  | "proposed"
+  | "accepted"
+  | "rejected"
+  | "completed";
+
+export interface CreateSafetyActionProposalInput {
+  proposalType?: SafetyActionProposalType;
+  status?: SafetyActionProposalStatus;
+  summary?: string;
+  rationale?: string | null;
+  proposedOwner?: string | null;
+  proposedDueAt?: string | null;
+  createdBy?: string | null;
+}
+
+export interface SafetyActionProposal {
+  id: string;
+  safetyEventAgendaLinkId: string;
+  safetyEventId: string;
+  safetyEventMeetingTriggerId: string;
+  airSafetyMeetingId: string;
+  proposalType: SafetyActionProposalType;
+  status: SafetyActionProposalStatus;
+  summary: string;
+  rationale: string | null;
+  proposedOwner: string | null;
+  proposedDueAt: string | null;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/safety-events/safety-event.validators.ts
+++ b/src/safety-events/safety-event.validators.ts
@@ -1,8 +1,11 @@
 import { SafetyEventValidationError } from "./safety-event.errors";
 import type {
   AssessSafetyEventMeetingTriggerInput,
+  CreateSafetyActionProposalInput,
   CreateSafetyEventAgendaLinkInput,
   CreateSafetyEventInput,
+  SafetyActionProposalStatus,
+  SafetyActionProposalType,
   SafetyEventSeverity,
   SafetyEventStatus,
   SafetyEventType,
@@ -32,6 +35,21 @@ const STATUSES = new Set<SafetyEventStatus>([
   "open",
   "under_review",
   "closed",
+]);
+
+const ACTION_PROPOSAL_TYPES = new Set<SafetyActionProposalType>([
+  "sop_change",
+  "training_action",
+  "maintenance_action",
+  "accountable_manager_review",
+  "general_safety_action",
+]);
+
+const ACTION_PROPOSAL_STATUSES = new Set<SafetyActionProposalStatus>([
+  "proposed",
+  "accepted",
+  "rejected",
+  "completed",
 ]);
 
 const UUID_RE =
@@ -82,6 +100,22 @@ function requiredDate(value: unknown, fieldName: string): Date {
   }
 
   return new Date(value);
+}
+
+function optionalDate(value: unknown, fieldName: string): Date | null {
+  const normalized = optionalTrimmed(value, fieldName);
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (Number.isNaN(Date.parse(normalized))) {
+    throw new SafetyEventValidationError(
+      `${fieldName} must be a valid ISO timestamp`,
+    );
+  }
+
+  return new Date(normalized);
 }
 
 function optionalBoolean(value: unknown, fieldName: string): boolean {
@@ -194,6 +228,18 @@ export function validateSafetyEventMeetingTriggerId(value: unknown): string {
   return normalized;
 }
 
+export function validateSafetyEventAgendaLinkId(value: unknown): string {
+  const normalized = requiredTrimmed(value, "safetyEventAgendaLinkId");
+
+  if (!UUID_RE.test(normalized)) {
+    throw new SafetyEventValidationError(
+      "safetyEventAgendaLinkId must be a valid UUID",
+    );
+  }
+
+  return normalized;
+}
+
 export function validateAssessMeetingTriggerInput(
   input: AssessSafetyEventMeetingTriggerInput | undefined,
 ) {
@@ -226,5 +272,35 @@ export function validateCreateAgendaLinkInput(
     ) ?? requiredTrimmed(input.airSafetyMeetingId, "airSafetyMeetingId"),
     agendaItem: requiredTrimmed(input.agendaItem, "agendaItem"),
     linkedBy: optionalTrimmed(input.linkedBy, "linkedBy"),
+  };
+}
+
+export function validateCreateSafetyActionProposalInput(
+  input: CreateSafetyActionProposalInput | undefined,
+) {
+  if (!input || typeof input !== "object") {
+    throw new SafetyEventValidationError("Request body must be an object");
+  }
+
+  const proposalType = input.proposalType;
+  if (!proposalType || !ACTION_PROPOSAL_TYPES.has(proposalType)) {
+    throw new SafetyEventValidationError(
+      "proposalType is required and supported",
+    );
+  }
+
+  const status = input.status ?? "proposed";
+  if (!ACTION_PROPOSAL_STATUSES.has(status)) {
+    throw new SafetyEventValidationError("status is not supported");
+  }
+
+  return {
+    proposalType,
+    status,
+    summary: requiredTrimmed(input.summary, "summary"),
+    rationale: optionalTrimmed(input.rationale, "rationale"),
+    proposedOwner: optionalTrimmed(input.proposedOwner, "proposedOwner"),
+    proposedDueAt: optionalDate(input.proposedDueAt, "proposedDueAt"),
+    createdBy: optionalTrimmed(input.createdBy, "createdBy"),
   };
 }

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -4,6 +4,7 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from safety_action_proposals");
   await pool.query("delete from safety_event_agenda_links");
   await pool.query("delete from safety_event_meeting_triggers");
   await pool.query("delete from safety_events");

--- a/src/tests/safety-events.test.ts
+++ b/src/tests/safety-events.test.ts
@@ -5,6 +5,7 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from safety_action_proposals");
   await pool.query("delete from safety_event_agenda_links");
   await pool.query("delete from safety_event_meeting_triggers");
   await pool.query("delete from safety_events");
@@ -37,6 +38,7 @@ const countRows = async (ids: {
       (select count(*)::int from safety_events) as safety_event_count,
       (select count(*)::int from safety_event_meeting_triggers) as safety_event_trigger_count,
       (select count(*)::int from safety_event_agenda_links) as safety_event_agenda_link_count,
+      (select count(*)::int from safety_action_proposals) as safety_action_proposal_count,
       (select count(*)::int from missions where ($1::uuid is null or id = $1)) as mission_count,
       (select count(*)::int from platforms where ($2::uuid is null or id = $2)) as platform_count,
       (select count(*)::int from pilots where ($3::uuid is null or id = $3)) as pilot_count,
@@ -55,6 +57,7 @@ const countRows = async (ids: {
     safety_event_count: number;
     safety_event_trigger_count: number;
     safety_event_agenda_link_count: number;
+    safety_action_proposal_count: number;
     mission_count: number;
     platform_count: number;
     pilot_count: number;
@@ -171,6 +174,32 @@ const createTriggeredSafetyEvent = async (params?: {
   return {
     event: eventResponse.body.event as { id: string },
     trigger: triggerResponse.body.trigger as { id: string },
+  };
+};
+
+const createAgendaLinkedSafetyEvent = async (params?: {
+  eventType?: string;
+  severity?: string;
+  summary?: string;
+  agendaItem?: string;
+}) => {
+  const meeting = await createAirSafetyMeeting();
+  const { event, trigger } = await createTriggeredSafetyEvent(params);
+  const linkResponse = await request(app)
+    .post(`/safety-events/${event.id}/meeting-triggers/${trigger.id}/agenda-links`)
+    .send({
+      airSafetyMeetingId: meeting.id,
+      agendaItem: params?.agendaItem ?? "Review safety event follow-up",
+      linkedBy: "safety-coordinator",
+    });
+
+  expect(linkResponse.status).toBe(201);
+
+  return {
+    meeting,
+    event,
+    trigger,
+    agendaLink: linkResponse.body.link as { id: string },
   };
 };
 
@@ -486,6 +515,156 @@ describe("safety events", () => {
     });
   });
 
+  it("creates SOP, training, and maintenance action proposals from agenda links", async () => {
+    const cases = [
+      {
+        eventType: "sop_breach",
+        proposalType: "sop_change",
+        summary: "Update launch checklist confirmation wording",
+      },
+      {
+        eventType: "training_need",
+        proposalType: "training_action",
+        summary: "Schedule manual recovery refresher",
+      },
+      {
+        eventType: "maintenance_concern",
+        proposalType: "maintenance_action",
+        summary: "Inspect propulsion system before next dispatch",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const { event, trigger, meeting, agendaLink } =
+        await createAgendaLinkedSafetyEvent({
+          eventType: testCase.eventType,
+          severity: "medium",
+          summary: testCase.summary,
+        });
+
+      const response = await request(app)
+        .post(`/safety-events/${event.id}/agenda-links/${agendaLink.id}/action-proposals`)
+        .send({
+          proposalType: testCase.proposalType,
+          summary: ` ${testCase.summary} `,
+          rationale: "Required by safety meeting review.",
+          proposedOwner: " Safety Manager ",
+          proposedDueAt: "2026-05-01T10:00:00.000Z",
+          createdBy: " accountable-manager ",
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.proposal).toMatchObject({
+        safetyEventAgendaLinkId: agendaLink.id,
+        safetyEventId: event.id,
+        safetyEventMeetingTriggerId: trigger.id,
+        airSafetyMeetingId: meeting.id,
+        proposalType: testCase.proposalType,
+        status: "proposed",
+        summary: testCase.summary,
+        rationale: "Required by safety meeting review.",
+        proposedOwner: "Safety Manager",
+        proposedDueAt: "2026-05-01T10:00:00.000Z",
+        createdBy: "accountable-manager",
+      });
+      expect(response.body.proposal.id).toEqual(expect.any(String));
+      expect(response.body.proposal.createdAt).toEqual(expect.any(String));
+    }
+  });
+
+  it("lists multiple action proposals from one agenda-linked safety event", async () => {
+    const { event, agendaLink } = await createAgendaLinkedSafetyEvent({
+      eventType: "sop_breach",
+      severity: "high",
+      summary: "Repeated dispatch briefing SOP breach",
+    });
+
+    const first = await request(app)
+      .post(`/safety-events/${event.id}/agenda-links/${agendaLink.id}/action-proposals`)
+      .send({
+        proposalType: "sop_change",
+        summary: "Clarify dispatch briefing SOP",
+      });
+    const second = await request(app)
+      .post(`/safety-events/${event.id}/agenda-links/${agendaLink.id}/action-proposals`)
+      .send({
+        proposalType: "training_action",
+        summary: "Brief flight team on dispatch changes",
+      });
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+
+    const listResponse = await request(app).get(
+      `/safety-events/${event.id}/agenda-links/${agendaLink.id}/action-proposals`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.proposals).toHaveLength(2);
+    expect(listResponse.body.proposals.map((proposal: { id: string }) => proposal.id))
+      .toEqual(expect.arrayContaining([
+        first.body.proposal.id,
+        second.body.proposal.id,
+      ]));
+  });
+
+  it("rejects invalid safety action proposal input", async () => {
+    const { event, agendaLink } = await createAgendaLinkedSafetyEvent();
+
+    const badType = await request(app)
+      .post(`/safety-events/${event.id}/agenda-links/${agendaLink.id}/action-proposals`)
+      .send({
+        proposalType: "unsupported",
+        summary: "Bad type",
+      });
+    const badStatus = await request(app)
+      .post(`/safety-events/${event.id}/agenda-links/${agendaLink.id}/action-proposals`)
+      .send({
+        proposalType: "general_safety_action",
+        status: "started",
+        summary: "Bad status",
+      });
+    const badDate = await request(app)
+      .post(`/safety-events/${event.id}/agenda-links/${agendaLink.id}/action-proposals`)
+      .send({
+        proposalType: "general_safety_action",
+        summary: "Bad date",
+        proposedDueAt: "not-a-date",
+      });
+
+    expect(badType.status).toBe(400);
+    expect(badType.body.error).toMatchObject({
+      type: "safety_event_validation_failed",
+    });
+    expect(badStatus.status).toBe(400);
+    expect(badStatus.body.error).toMatchObject({
+      type: "safety_event_validation_failed",
+    });
+    expect(badDate.status).toBe(400);
+    expect(badDate.body.error).toMatchObject({
+      type: "safety_event_validation_failed",
+    });
+  });
+
+  it("rejects safety action proposals for missing agenda links", async () => {
+    const { event } = await createAgendaLinkedSafetyEvent();
+    const missingAgendaLinkId = randomUUID();
+    const before = await countRows({});
+
+    const response = await request(app)
+      .post(`/safety-events/${event.id}/agenda-links/${missingAgendaLinkId}/action-proposals`)
+      .send({
+        proposalType: "general_safety_action",
+        summary: "Missing agenda link",
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toMatchObject({
+      type: "safety_event_agenda_link_not_found",
+    });
+    expect(await countRows({})).toEqual(before);
+  });
+
   it("captures linked post-operation safety findings without mutating linked records", async () => {
     const platform = await createPlatform();
     const pilot = await createPilot();
@@ -648,6 +827,68 @@ describe("safety events", () => {
       ...before,
       safety_event_agenda_link_count:
         before.safety_event_agenda_link_count + 1,
+    });
+  });
+
+  it("creates action proposals without mutating source safety records", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    const meeting = await createAirSafetyMeeting();
+    const safetyEvent = await request(app).post("/safety-events").send({
+      eventType: "maintenance_concern",
+      severity: "critical",
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      eventOccurredAt: "2026-04-15T12:00:00.000Z",
+      summary: "Motor vibration exceeded limit",
+    });
+
+    expect(safetyEvent.status).toBe(201);
+
+    const triggerResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/meeting-trigger`)
+      .send({});
+
+    expect(triggerResponse.status).toBe(201);
+
+    const agendaLinkResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/meeting-triggers/${triggerResponse.body.trigger.id}/agenda-links`)
+      .send({
+        airSafetyMeetingId: meeting.id,
+        agendaItem: "Review vibration exceedance",
+      });
+
+    expect(agendaLinkResponse.status).toBe(201);
+
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      meetingId: meeting.id,
+    });
+
+    const proposalResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/agenda-links/${agendaLinkResponse.body.link.id}/action-proposals`)
+      .send({
+        proposalType: "maintenance_action",
+        summary: "Inspect motor mounts before next flight",
+      });
+
+    expect(proposalResponse.status).toBe(201);
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      meetingId: meeting.id,
+    })).toEqual({
+      ...before,
+      safety_action_proposal_count:
+        before.safety_action_proposal_count + 1,
     });
   });
 


### PR DESCRIPTION
What changed:

Added migration-backed safety_action_proposals in 024_create_safety_action_proposals.sql (line 1).
Added action proposal endpoints in safety-event.routes.ts (line 19):
POST /safety-events/:eventId/agenda-links/:agendaLinkId/action-proposals
GET /safety-events/:eventId/agenda-links/:agendaLinkId/action-proposals
Added proposal creation/listing logic in safety-event.service.ts (line 206).
Preserved the full audit chain on proposal records: agenda link, safety event, trigger, and air safety meeting.
Added tests for SOP, training, maintenance proposals, multiple proposals from one agenda link, invalid input, missing agenda link, and no side effects in safety-events.test.ts (line 518).
Advanced the save point to safety action approval workflow in fsms-save-point.json (line 92).
Verification:

vitest.cmd run src/tests/safety-events.test.ts passed: 20 tests.
vitest.cmd run src/tests/air-safety-meetings.test.ts passed: 7 tests.
vitest.cmd run passed: 240 tests across 21 files.
node scripts/validate-save-point.mjs fsms-save-point.json passed.
git diff --check passed.
node scripts/check-next-build-step-pr.mjs origin/main passed.
npm.cmd run build still exits with TypeScript help text because the repo does not currently have a root tsconfig.json.