### PR TITLE
Add safety action approval workflow

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add migration-backed safety action approval workflow so proposed SOP, training, and maintenance actions can be accepted, rejected, or completed.",
+ "nextBuildStep": "Add migration-backed safety action implementation evidence so completed SOP, training, and maintenance actions can store reviewable closure records.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/migrations/025_create_safety_action_decisions.sql
+++ b/src/migrations/025_create_safety_action_decisions.sql
@@ -1,0 +1,26 @@
+create table if not exists safety_action_decisions (
+  id uuid primary key,
+  safety_action_proposal_id uuid not null
+    references safety_action_proposals(id) on delete cascade,
+  safety_event_agenda_link_id uuid not null
+    references safety_event_agenda_links(id) on delete cascade,
+  safety_event_id uuid not null
+    references safety_events(id) on delete cascade,
+  safety_event_meeting_trigger_id uuid not null
+    references safety_event_meeting_triggers(id) on delete cascade,
+  air_safety_meeting_id uuid not null
+    references air_safety_meetings(id) on delete cascade,
+  decision text not null check (
+    decision in ('accepted', 'rejected', 'completed')
+  ),
+  decided_by text,
+  decision_notes text,
+  decided_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_safety_action_decisions_proposal
+  on safety_action_decisions (safety_action_proposal_id, decided_at desc);
+
+create index if not exists idx_safety_action_decisions_event
+  on safety_action_decisions (safety_event_id, decided_at desc);

--- a/src/safety-events/safety-event.controller.ts
+++ b/src/safety-events/safety-event.controller.ts
@@ -127,4 +127,40 @@ export class SafetyEventController {
       next(error);
     }
   };
+
+  createSafetyActionDecision = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const result = await this.safetyEventService.createSafetyActionDecision(
+        req.params.eventId,
+        req.params.agendaLinkId,
+        req.params.proposalId,
+        req.body,
+      );
+      res.status(201).json(result);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listSafetyActionDecisions = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const decisions =
+        await this.safetyEventService.listSafetyActionDecisions(
+          req.params.eventId,
+          req.params.agendaLinkId,
+          req.params.proposalId,
+        );
+      res.status(200).json({ decisions });
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/safety-events/safety-event.errors.ts
+++ b/src/safety-events/safety-event.errors.ts
@@ -47,3 +47,21 @@ export class SafetyEventAgendaLinkNotFoundError extends Error {
     super(`Safety event agenda link not found: ${agendaLinkId}`);
   }
 }
+
+export class SafetyActionProposalNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "SAFETY_ACTION_PROPOSAL_NOT_FOUND";
+
+  constructor(proposalId: string) {
+    super(`Safety action proposal not found: ${proposalId}`);
+  }
+}
+
+export class SafetyActionDecisionTransitionError extends Error {
+  readonly statusCode = 409;
+  readonly code = "SAFETY_ACTION_DECISION_TRANSITION_INVALID";
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/safety-events/safety-event.repository.ts
+++ b/src/safety-events/safety-event.repository.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "crypto";
 import type { PoolClient, QueryResultRow } from "pg";
 import type {
+  SafetyActionDecision,
+  SafetyActionDecisionType,
   SafetyActionProposal,
   SafetyActionProposalStatus,
   SafetyActionProposalType,
@@ -135,6 +137,31 @@ interface CreateSafetyActionProposalRow {
   createdBy: string | null;
 }
 
+interface SafetyActionDecisionRow extends QueryResultRow {
+  id: string;
+  safety_action_proposal_id: string;
+  safety_event_agenda_link_id: string;
+  safety_event_id: string;
+  safety_event_meeting_trigger_id: string;
+  air_safety_meeting_id: string;
+  decision: SafetyActionDecisionType;
+  decided_by: string | null;
+  decision_notes: string | null;
+  decided_at: Date;
+  created_at: Date;
+}
+
+interface CreateSafetyActionDecisionRow {
+  safetyActionProposalId: string;
+  safetyEventAgendaLinkId: string;
+  safetyEventId: string;
+  safetyEventMeetingTriggerId: string;
+  airSafetyMeetingId: string;
+  decision: SafetyActionDecisionType;
+  decidedBy: string | null;
+  decisionNotes: string | null;
+}
+
 const toSafetyEvent = (row: SafetyEventRow): SafetyEvent => ({
   id: row.id,
   eventType: row.event_type,
@@ -206,6 +233,22 @@ const toSafetyActionProposal = (
   createdBy: row.created_by,
   createdAt: row.created_at.toISOString(),
   updatedAt: row.updated_at.toISOString(),
+});
+
+const toSafetyActionDecision = (
+  row: SafetyActionDecisionRow,
+): SafetyActionDecision => ({
+  id: row.id,
+  safetyActionProposalId: row.safety_action_proposal_id,
+  safetyEventAgendaLinkId: row.safety_event_agenda_link_id,
+  safetyEventId: row.safety_event_id,
+  safetyEventMeetingTriggerId: row.safety_event_meeting_trigger_id,
+  airSafetyMeetingId: row.air_safety_meeting_id,
+  decision: row.decision,
+  decidedBy: row.decided_by,
+  decisionNotes: row.decision_notes,
+  decidedAt: row.decided_at.toISOString(),
+  createdAt: row.created_at.toISOString(),
 });
 
 export class SafetyEventRepository {
@@ -485,6 +528,94 @@ export class SafetyEventRepository {
     );
 
     return result.rows.map(toSafetyActionProposal);
+  }
+
+  async getSafetyActionProposalById(
+    tx: PoolClient,
+    proposalId: string,
+  ): Promise<SafetyActionProposal | null> {
+    const result = await tx.query<SafetyActionProposalRow>(
+      `
+      select *
+      from safety_action_proposals
+      where id = $1
+      `,
+      [proposalId],
+    );
+
+    return result.rows[0] ? toSafetyActionProposal(result.rows[0]) : null;
+  }
+
+  async updateSafetyActionProposalStatus(
+    tx: PoolClient,
+    proposalId: string,
+    status: SafetyActionProposalStatus,
+  ): Promise<SafetyActionProposal> {
+    const result = await tx.query<SafetyActionProposalRow>(
+      `
+      update safety_action_proposals
+      set status = $2,
+          updated_at = now()
+      where id = $1
+      returning *
+      `,
+      [proposalId, status],
+    );
+
+    return toSafetyActionProposal(result.rows[0]);
+  }
+
+  async insertSafetyActionDecision(
+    tx: PoolClient,
+    input: CreateSafetyActionDecisionRow,
+  ): Promise<SafetyActionDecision> {
+    const result = await tx.query<SafetyActionDecisionRow>(
+      `
+      insert into safety_action_decisions (
+        id,
+        safety_action_proposal_id,
+        safety_event_agenda_link_id,
+        safety_event_id,
+        safety_event_meeting_trigger_id,
+        air_safety_meeting_id,
+        decision,
+        decided_by,
+        decision_notes
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.safetyActionProposalId,
+        input.safetyEventAgendaLinkId,
+        input.safetyEventId,
+        input.safetyEventMeetingTriggerId,
+        input.airSafetyMeetingId,
+        input.decision,
+        input.decidedBy,
+        input.decisionNotes,
+      ],
+    );
+
+    return toSafetyActionDecision(result.rows[0]);
+  }
+
+  async listSafetyActionDecisionsByProposal(
+    tx: PoolClient,
+    proposalId: string,
+  ): Promise<SafetyActionDecision[]> {
+    const result = await tx.query<SafetyActionDecisionRow>(
+      `
+      select *
+      from safety_action_decisions
+      where safety_action_proposal_id = $1
+      order by decided_at desc, created_at desc, id desc
+      `,
+      [proposalId],
+    );
+
+    return result.rows.map(toSafetyActionDecision);
   }
 
   async referenceExists(

--- a/src/safety-events/safety-event.routes.ts
+++ b/src/safety-events/safety-event.routes.ts
@@ -23,6 +23,14 @@ export function createSafetyEventRouter(
     "/:eventId/agenda-links/:agendaLinkId/action-proposals",
     controller.listSafetyActionProposals,
   );
+  router.post(
+    "/:eventId/agenda-links/:agendaLinkId/action-proposals/:proposalId/decisions",
+    controller.createSafetyActionDecision,
+  );
+  router.get(
+    "/:eventId/agenda-links/:agendaLinkId/action-proposals/:proposalId/decisions",
+    controller.listSafetyActionDecisions,
+  );
 
   return router;
 }

--- a/src/safety-events/safety-event.service.ts
+++ b/src/safety-events/safety-event.service.ts
@@ -2,6 +2,8 @@ import type { Pool } from "pg";
 import {
   SafetyEventAgendaLinkConflictError,
   SafetyEventAgendaLinkNotFoundError,
+  SafetyActionDecisionTransitionError,
+  SafetyActionProposalNotFoundError,
   SafetyEventMeetingTriggerNotFoundError,
   SafetyEventNotFoundError,
   SafetyEventReferenceNotFoundError,
@@ -9,9 +11,12 @@ import {
 import { SafetyEventRepository } from "./safety-event.repository";
 import type {
   AssessSafetyEventMeetingTriggerInput,
+  CreateSafetyActionDecisionInput,
   CreateSafetyActionProposalInput,
+  SafetyActionDecision,
   CreateSafetyEventAgendaLinkInput,
   CreateSafetyEventInput,
+  SafetyActionDecisionType,
   SafetyActionProposal,
   SafetyEvent,
   SafetyEventAgendaLink,
@@ -21,9 +26,11 @@ import type {
 } from "./safety-event.types";
 import {
   validateAssessMeetingTriggerInput,
+  validateCreateSafetyActionDecisionInput,
   validateCreateSafetyActionProposalInput,
   validateCreateAgendaLinkInput,
   validateCreateSafetyEventInput,
+  validateSafetyActionProposalId,
   validateSafetyEventAgendaLinkId,
   validateSafetyEventId,
   validateSafetyEventMeetingTriggerId,
@@ -259,6 +266,82 @@ export class SafetyEventService {
     }
   }
 
+  async createSafetyActionDecision(
+    eventIdInput: unknown,
+    agendaLinkIdInput: unknown,
+    proposalIdInput: unknown,
+    input: CreateSafetyActionDecisionInput | undefined,
+  ): Promise<{
+    decision: SafetyActionDecision;
+    proposal: SafetyActionProposal;
+  }> {
+    const eventId = validateSafetyEventId(eventIdInput);
+    const agendaLinkId = validateSafetyEventAgendaLinkId(agendaLinkIdInput);
+    const proposalId = validateSafetyActionProposalId(proposalIdInput);
+    const validated = validateCreateSafetyActionDecisionInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      await client.query("begin");
+      const proposal = await this.getValidatedProposal(
+        client,
+        eventId,
+        agendaLinkId,
+        proposalId,
+      );
+      this.validateDecisionTransition(proposal, validated.decision);
+
+      const decision =
+        await this.safetyEventRepository.insertSafetyActionDecision(client, {
+          safetyActionProposalId: proposal.id,
+          safetyEventAgendaLinkId: proposal.safetyEventAgendaLinkId,
+          safetyEventId: proposal.safetyEventId,
+          safetyEventMeetingTriggerId: proposal.safetyEventMeetingTriggerId,
+          airSafetyMeetingId: proposal.airSafetyMeetingId,
+          decision: validated.decision,
+          decidedBy: validated.decidedBy,
+          decisionNotes: validated.decisionNotes,
+        });
+      const updatedProposal =
+        await this.safetyEventRepository.updateSafetyActionProposalStatus(
+          client,
+          proposal.id,
+          validated.decision,
+        );
+      await client.query("commit");
+
+      return {
+        decision,
+        proposal: updatedProposal,
+      };
+    } catch (error) {
+      await client.query("rollback");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async listSafetyActionDecisions(
+    eventIdInput: unknown,
+    agendaLinkIdInput: unknown,
+    proposalIdInput: unknown,
+  ): Promise<SafetyActionDecision[]> {
+    const eventId = validateSafetyEventId(eventIdInput);
+    const agendaLinkId = validateSafetyEventAgendaLinkId(agendaLinkIdInput);
+    const proposalId = validateSafetyActionProposalId(proposalIdInput);
+    const client = await this.pool.connect();
+
+    try {
+      await this.getValidatedProposal(client, eventId, agendaLinkId, proposalId);
+
+      return await this.safetyEventRepository
+        .listSafetyActionDecisionsByProposal(client, proposalId);
+    } finally {
+      client.release();
+    }
+  }
+
   private buildMeetingTriggerAssessment(event: SafetyEvent): {
     meetingRequired: boolean;
     recommendedMeetingType: SafetyEventMeetingType | null;
@@ -447,5 +530,50 @@ export class SafetyEventService {
     }
 
     return agendaLink;
+  }
+
+  private async getValidatedProposal(
+    client: Awaited<ReturnType<Pool["connect"]>>,
+    eventId: string,
+    agendaLinkId: string,
+    proposalId: string,
+  ): Promise<SafetyActionProposal> {
+    await this.getValidatedAgendaLink(client, eventId, agendaLinkId);
+
+    const proposal =
+      await this.safetyEventRepository.getSafetyActionProposalById(
+        client,
+        proposalId,
+      );
+
+    if (
+      !proposal ||
+      proposal.safetyEventId !== eventId ||
+      proposal.safetyEventAgendaLinkId !== agendaLinkId
+    ) {
+      throw new SafetyActionProposalNotFoundError(proposalId);
+    }
+
+    return proposal;
+  }
+
+  private validateDecisionTransition(
+    proposal: SafetyActionProposal,
+    decision: SafetyActionDecisionType,
+  ): void {
+    if (
+      (decision === "accepted" || decision === "rejected") &&
+      proposal.status === "proposed"
+    ) {
+      return;
+    }
+
+    if (decision === "completed" && proposal.status === "accepted") {
+      return;
+    }
+
+    throw new SafetyActionDecisionTransitionError(
+      `Cannot mark safety action proposal ${proposal.id} as ${decision} from ${proposal.status}`,
+    );
   }
 }

--- a/src/safety-events/safety-event.types.ts
+++ b/src/safety-events/safety-event.types.ts
@@ -151,3 +151,25 @@ export interface SafetyActionProposal {
   createdAt: string;
   updatedAt: string;
 }
+
+export type SafetyActionDecisionType = "accepted" | "rejected" | "completed";
+
+export interface CreateSafetyActionDecisionInput {
+  decision?: SafetyActionDecisionType;
+  decidedBy?: string | null;
+  decisionNotes?: string | null;
+}
+
+export interface SafetyActionDecision {
+  id: string;
+  safetyActionProposalId: string;
+  safetyEventAgendaLinkId: string;
+  safetyEventId: string;
+  safetyEventMeetingTriggerId: string;
+  airSafetyMeetingId: string;
+  decision: SafetyActionDecisionType;
+  decidedBy: string | null;
+  decisionNotes: string | null;
+  decidedAt: string;
+  createdAt: string;
+}

--- a/src/safety-events/safety-event.validators.ts
+++ b/src/safety-events/safety-event.validators.ts
@@ -1,9 +1,11 @@
 import { SafetyEventValidationError } from "./safety-event.errors";
 import type {
   AssessSafetyEventMeetingTriggerInput,
+  CreateSafetyActionDecisionInput,
   CreateSafetyActionProposalInput,
   CreateSafetyEventAgendaLinkInput,
   CreateSafetyEventInput,
+  SafetyActionDecisionType,
   SafetyActionProposalStatus,
   SafetyActionProposalType,
   SafetyEventSeverity,
@@ -47,6 +49,12 @@ const ACTION_PROPOSAL_TYPES = new Set<SafetyActionProposalType>([
 
 const ACTION_PROPOSAL_STATUSES = new Set<SafetyActionProposalStatus>([
   "proposed",
+  "accepted",
+  "rejected",
+  "completed",
+]);
+
+const ACTION_DECISIONS = new Set<SafetyActionDecisionType>([
   "accepted",
   "rejected",
   "completed",
@@ -240,6 +248,18 @@ export function validateSafetyEventAgendaLinkId(value: unknown): string {
   return normalized;
 }
 
+export function validateSafetyActionProposalId(value: unknown): string {
+  const normalized = requiredTrimmed(value, "safetyActionProposalId");
+
+  if (!UUID_RE.test(normalized)) {
+    throw new SafetyEventValidationError(
+      "safetyActionProposalId must be a valid UUID",
+    );
+  }
+
+  return normalized;
+}
+
 export function validateAssessMeetingTriggerInput(
   input: AssessSafetyEventMeetingTriggerInput | undefined,
 ) {
@@ -302,5 +322,24 @@ export function validateCreateSafetyActionProposalInput(
     proposedOwner: optionalTrimmed(input.proposedOwner, "proposedOwner"),
     proposedDueAt: optionalDate(input.proposedDueAt, "proposedDueAt"),
     createdBy: optionalTrimmed(input.createdBy, "createdBy"),
+  };
+}
+
+export function validateCreateSafetyActionDecisionInput(
+  input: CreateSafetyActionDecisionInput | undefined,
+) {
+  if (!input || typeof input !== "object") {
+    throw new SafetyEventValidationError("Request body must be an object");
+  }
+
+  const decision = input.decision;
+  if (!decision || !ACTION_DECISIONS.has(decision)) {
+    throw new SafetyEventValidationError("decision is required and supported");
+  }
+
+  return {
+    decision,
+    decidedBy: optionalTrimmed(input.decidedBy, "decidedBy"),
+    decisionNotes: optionalTrimmed(input.decisionNotes, "decisionNotes"),
   };
 }

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -4,6 +4,7 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from safety_action_decisions");
   await pool.query("delete from safety_action_proposals");
   await pool.query("delete from safety_event_agenda_links");
   await pool.query("delete from safety_event_meeting_triggers");

--- a/src/tests/safety-events.test.ts
+++ b/src/tests/safety-events.test.ts
@@ -5,6 +5,7 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from safety_action_decisions");
   await pool.query("delete from safety_action_proposals");
   await pool.query("delete from safety_event_agenda_links");
   await pool.query("delete from safety_event_meeting_triggers");
@@ -39,6 +40,7 @@ const countRows = async (ids: {
       (select count(*)::int from safety_event_meeting_triggers) as safety_event_trigger_count,
       (select count(*)::int from safety_event_agenda_links) as safety_event_agenda_link_count,
       (select count(*)::int from safety_action_proposals) as safety_action_proposal_count,
+      (select count(*)::int from safety_action_decisions) as safety_action_decision_count,
       (select count(*)::int from missions where ($1::uuid is null or id = $1)) as mission_count,
       (select count(*)::int from platforms where ($2::uuid is null or id = $2)) as platform_count,
       (select count(*)::int from pilots where ($3::uuid is null or id = $3)) as pilot_count,
@@ -58,6 +60,7 @@ const countRows = async (ids: {
     safety_event_trigger_count: number;
     safety_event_agenda_link_count: number;
     safety_action_proposal_count: number;
+    safety_action_decision_count: number;
     mission_count: number;
     platform_count: number;
     pilot_count: number;
@@ -200,6 +203,27 @@ const createAgendaLinkedSafetyEvent = async (params?: {
     event,
     trigger,
     agendaLink: linkResponse.body.link as { id: string },
+  };
+};
+
+const createSafetyActionProposal = async (params?: {
+  proposalType?: string;
+  summary?: string;
+}) => {
+  const source = await createAgendaLinkedSafetyEvent();
+  const proposalResponse = await request(app)
+    .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals`)
+    .send({
+      proposalType: params?.proposalType ?? "general_safety_action",
+      summary: params?.summary ?? "Review safety follow-up",
+      createdBy: "safety-manager",
+    });
+
+  expect(proposalResponse.status).toBe(201);
+
+  return {
+    ...source,
+    proposal: proposalResponse.body.proposal as { id: string; status: string },
   };
 };
 
@@ -665,6 +689,139 @@ describe("safety events", () => {
     expect(await countRows({})).toEqual(before);
   });
 
+  it("accepts and rejects safety action proposals with decision records", async () => {
+    const acceptedSource = await createSafetyActionProposal({
+      proposalType: "sop_change",
+      summary: "Update launch SOP",
+    });
+    const rejectedSource = await createSafetyActionProposal({
+      proposalType: "training_action",
+      summary: "Training action not required",
+    });
+
+    const acceptResponse = await request(app)
+      .post(`/safety-events/${acceptedSource.event.id}/agenda-links/${acceptedSource.agendaLink.id}/action-proposals/${acceptedSource.proposal.id}/decisions`)
+      .send({
+        decision: "accepted",
+        decidedBy: " accountable-manager ",
+        decisionNotes: " Accepted for implementation. ",
+      });
+    const rejectResponse = await request(app)
+      .post(`/safety-events/${rejectedSource.event.id}/agenda-links/${rejectedSource.agendaLink.id}/action-proposals/${rejectedSource.proposal.id}/decisions`)
+      .send({
+        decision: "rejected",
+        decidedBy: "safety-manager",
+        decisionNotes: "Covered by existing controls.",
+      });
+
+    expect(acceptResponse.status).toBe(201);
+    expect(acceptResponse.body.decision).toMatchObject({
+      safetyActionProposalId: acceptedSource.proposal.id,
+      safetyEventAgendaLinkId: acceptedSource.agendaLink.id,
+      safetyEventId: acceptedSource.event.id,
+      safetyEventMeetingTriggerId: acceptedSource.trigger.id,
+      airSafetyMeetingId: acceptedSource.meeting.id,
+      decision: "accepted",
+      decidedBy: "accountable-manager",
+      decisionNotes: "Accepted for implementation.",
+    });
+    expect(acceptResponse.body.proposal).toMatchObject({
+      id: acceptedSource.proposal.id,
+      status: "accepted",
+    });
+
+    expect(rejectResponse.status).toBe(201);
+    expect(rejectResponse.body.decision).toMatchObject({
+      safetyActionProposalId: rejectedSource.proposal.id,
+      decision: "rejected",
+      decidedBy: "safety-manager",
+      decisionNotes: "Covered by existing controls.",
+    });
+    expect(rejectResponse.body.proposal).toMatchObject({
+      id: rejectedSource.proposal.id,
+      status: "rejected",
+    });
+  });
+
+  it("completes accepted safety action proposals and lists decisions", async () => {
+    const source = await createSafetyActionProposal({
+      proposalType: "maintenance_action",
+      summary: "Inspect motor mounts",
+    });
+
+    const acceptResponse = await request(app)
+      .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/decisions`)
+      .send({
+        decision: "accepted",
+        decidedBy: "maintenance-lead",
+      });
+    const completeResponse = await request(app)
+      .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/decisions`)
+      .send({
+        decision: "completed",
+        decidedBy: "maintenance-lead",
+        decisionNotes: "Inspection completed and recorded.",
+      });
+
+    expect(acceptResponse.status).toBe(201);
+    expect(completeResponse.status).toBe(201);
+    expect(completeResponse.body.proposal).toMatchObject({
+      id: source.proposal.id,
+      status: "completed",
+    });
+
+    const listResponse = await request(app).get(
+      `/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/decisions`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.decisions).toHaveLength(2);
+    expect(listResponse.body.decisions.map((decision: { decision: string }) => decision.decision))
+      .toEqual(expect.arrayContaining(["accepted", "completed"]));
+  });
+
+  it("rejects invalid safety action decision input and invalid transitions", async () => {
+    const source = await createSafetyActionProposal();
+
+    const badDecision = await request(app)
+      .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/decisions`)
+      .send({
+        decision: "paused",
+      });
+    const prematureComplete = await request(app)
+      .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/decisions`)
+      .send({
+        decision: "completed",
+      });
+
+    expect(badDecision.status).toBe(400);
+    expect(badDecision.body.error).toMatchObject({
+      type: "safety_event_validation_failed",
+    });
+    expect(prematureComplete.status).toBe(409);
+    expect(prematureComplete.body.error).toMatchObject({
+      type: "safety_action_decision_transition_invalid",
+    });
+  });
+
+  it("rejects safety action decisions for missing proposals", async () => {
+    const source = await createSafetyActionProposal();
+    const missingProposalId = randomUUID();
+    const before = await countRows({});
+
+    const response = await request(app)
+      .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${missingProposalId}/decisions`)
+      .send({
+        decision: "accepted",
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toMatchObject({
+      type: "safety_action_proposal_not_found",
+    });
+    expect(await countRows({})).toEqual(before);
+  });
+
   it("captures linked post-operation safety findings without mutating linked records", async () => {
     const platform = await createPlatform();
     const pilot = await createPilot();
@@ -889,6 +1046,73 @@ describe("safety events", () => {
       ...before,
       safety_action_proposal_count:
         before.safety_action_proposal_count + 1,
+    });
+  });
+
+  it("creates action decisions without mutating unrelated source safety records", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    const meeting = await createAirSafetyMeeting();
+    const safetyEvent = await request(app).post("/safety-events").send({
+      eventType: "training_need",
+      severity: "medium",
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      eventOccurredAt: "2026-04-16T12:00:00.000Z",
+      summary: "Crew training follow-up required",
+    });
+
+    expect(safetyEvent.status).toBe(201);
+
+    const triggerResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/meeting-trigger`)
+      .send({});
+    const agendaLinkResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/meeting-triggers/${triggerResponse.body.trigger.id}/agenda-links`)
+      .send({
+        airSafetyMeetingId: meeting.id,
+        agendaItem: "Review training follow-up",
+      });
+    const proposalResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/agenda-links/${agendaLinkResponse.body.link.id}/action-proposals`)
+      .send({
+        proposalType: "training_action",
+        summary: "Schedule refresher training",
+      });
+
+    expect(triggerResponse.status).toBe(201);
+    expect(agendaLinkResponse.status).toBe(201);
+    expect(proposalResponse.status).toBe(201);
+
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      meetingId: meeting.id,
+    });
+
+    const decisionResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/agenda-links/${agendaLinkResponse.body.link.id}/action-proposals/${proposalResponse.body.proposal.id}/decisions`)
+      .send({
+        decision: "accepted",
+        decidedBy: "training-manager",
+      });
+
+    expect(decisionResponse.status).toBe(201);
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      meetingId: meeting.id,
+    })).toEqual({
+      ...before,
+      safety_action_decision_count:
+        before.safety_action_decision_count + 1,
     });
   });
 


### PR DESCRIPTION
What changed:

Added migration-backed safety_action_decisions in 025_create_safety_action_decisions.sql (line 1).
Added decision endpoints in safety-event.routes.ts (line 27):
POST /safety-events/:eventId/agenda-links/:agendaLinkId/action-proposals/:proposalId/decisions
GET /safety-events/:eventId/agenda-links/:agendaLinkId/action-proposals/:proposalId/decisions
Added decision workflow logic in safety-event.service.ts (line 269).
Enforced transitions in safety-event.service.ts (line 560):
proposed -> accepted
proposed -> rejected
accepted -> completed
Proposal status is updated transactionally with the decision record.
Added tests for accept, reject, complete, invalid decisions, missing proposal, invalid transitions, status update, and no unrelated side effects in safety-events.test.ts (line 692).
Advanced the save point to implementation evidence in fsms-save-point.json (line 92).
Verification:

vitest.cmd run src/tests/safety-events.test.ts passed: 25 tests.
vitest.cmd run src/tests/air-safety-meetings.test.ts passed: 7 tests.
vitest.cmd run passed: 245 tests across 21 files.
node scripts/validate-save-point.mjs fsms-save-point.json passed.
git diff --check passed.
node scripts/check-next-build-step-pr.mjs origin/main passed.
npm.cmd run build still exits with TypeScript help text because the repo does not currently have a root tsconfig.json.

Closes #73