### PR TITLE
Add safety action implementation evidence

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add migration-backed safety action implementation evidence so completed SOP, training, and maintenance actions can store reviewable closure records.",
+ "nextBuildStep": "Add migration-backed safety action evidence export context so closure records can appear in safety meeting and audit reports.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/migrations/026_create_safety_action_implementation_evidence.sql
+++ b/src/migrations/026_create_safety_action_implementation_evidence.sql
@@ -1,0 +1,33 @@
+create table if not exists safety_action_implementation_evidence (
+  id uuid primary key,
+  safety_action_proposal_id uuid not null references safety_action_proposals(id) on delete cascade,
+  safety_event_agenda_link_id uuid not null references safety_event_agenda_links(id) on delete cascade,
+  safety_event_id uuid not null references safety_events(id) on delete cascade,
+  safety_event_meeting_trigger_id uuid not null references safety_event_meeting_triggers(id) on delete cascade,
+  air_safety_meeting_id uuid not null references air_safety_meetings(id) on delete cascade,
+  evidence_category text not null check (
+    evidence_category in (
+      'sop_implementation',
+      'training_completion',
+      'maintenance_completion',
+      'accountable_manager_review',
+      'general_safety_action_closure'
+    )
+  ),
+  implementation_summary text not null,
+  evidence_reference text,
+  completed_by text,
+  completed_at timestamptz not null,
+  reviewed_by text,
+  review_notes text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists safety_action_implementation_evidence_proposal_idx
+  on safety_action_implementation_evidence (safety_action_proposal_id, completed_at desc, created_at desc);
+
+create index if not exists safety_action_implementation_evidence_event_idx
+  on safety_action_implementation_evidence (safety_event_id, completed_at desc, created_at desc);
+
+create index if not exists safety_action_implementation_evidence_category_idx
+  on safety_action_implementation_evidence (evidence_category, completed_at desc);

--- a/src/safety-events/safety-event.controller.ts
+++ b/src/safety-events/safety-event.controller.ts
@@ -163,4 +163,41 @@ export class SafetyEventController {
       next(error);
     }
   };
+
+  createSafetyActionImplementationEvidence = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const evidence =
+        await this.safetyEventService.createSafetyActionImplementationEvidence(
+          req.params.eventId,
+          req.params.agendaLinkId,
+          req.params.proposalId,
+          req.body,
+        );
+      res.status(201).json({ evidence });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listSafetyActionImplementationEvidence = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const evidence =
+        await this.safetyEventService.listSafetyActionImplementationEvidence(
+          req.params.eventId,
+          req.params.agendaLinkId,
+          req.params.proposalId,
+        );
+      res.status(200).json({ evidence });
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/safety-events/safety-event.errors.ts
+++ b/src/safety-events/safety-event.errors.ts
@@ -65,3 +65,14 @@ export class SafetyActionDecisionTransitionError extends Error {
     super(message);
   }
 }
+
+export class SafetyActionImplementationEvidenceStateError extends Error {
+  readonly statusCode = 409;
+  readonly code = "SAFETY_ACTION_IMPLEMENTATION_EVIDENCE_STATE_INVALID";
+
+  constructor(proposalId: string) {
+    super(
+      `Implementation evidence can only be created for completed safety action proposals: ${proposalId}`,
+    );
+  }
+}

--- a/src/safety-events/safety-event.repository.ts
+++ b/src/safety-events/safety-event.repository.ts
@@ -3,6 +3,8 @@ import type { PoolClient, QueryResultRow } from "pg";
 import type {
   SafetyActionDecision,
   SafetyActionDecisionType,
+  SafetyActionImplementationEvidence,
+  SafetyActionImplementationEvidenceCategory,
   SafetyActionProposal,
   SafetyActionProposalStatus,
   SafetyActionProposalType,
@@ -162,6 +164,38 @@ interface CreateSafetyActionDecisionRow {
   decisionNotes: string | null;
 }
 
+interface SafetyActionImplementationEvidenceRow extends QueryResultRow {
+  id: string;
+  safety_action_proposal_id: string;
+  safety_event_agenda_link_id: string;
+  safety_event_id: string;
+  safety_event_meeting_trigger_id: string;
+  air_safety_meeting_id: string;
+  evidence_category: SafetyActionImplementationEvidenceCategory;
+  implementation_summary: string;
+  evidence_reference: string | null;
+  completed_by: string | null;
+  completed_at: Date;
+  reviewed_by: string | null;
+  review_notes: string | null;
+  created_at: Date;
+}
+
+interface CreateSafetyActionImplementationEvidenceRow {
+  safetyActionProposalId: string;
+  safetyEventAgendaLinkId: string;
+  safetyEventId: string;
+  safetyEventMeetingTriggerId: string;
+  airSafetyMeetingId: string;
+  evidenceCategory: SafetyActionImplementationEvidenceCategory;
+  implementationSummary: string;
+  evidenceReference: string | null;
+  completedBy: string | null;
+  completedAt: Date;
+  reviewedBy: string | null;
+  reviewNotes: string | null;
+}
+
 const toSafetyEvent = (row: SafetyEventRow): SafetyEvent => ({
   id: row.id,
   eventType: row.event_type,
@@ -248,6 +282,25 @@ const toSafetyActionDecision = (
   decidedBy: row.decided_by,
   decisionNotes: row.decision_notes,
   decidedAt: row.decided_at.toISOString(),
+  createdAt: row.created_at.toISOString(),
+});
+
+const toSafetyActionImplementationEvidence = (
+  row: SafetyActionImplementationEvidenceRow,
+): SafetyActionImplementationEvidence => ({
+  id: row.id,
+  safetyActionProposalId: row.safety_action_proposal_id,
+  safetyEventAgendaLinkId: row.safety_event_agenda_link_id,
+  safetyEventId: row.safety_event_id,
+  safetyEventMeetingTriggerId: row.safety_event_meeting_trigger_id,
+  airSafetyMeetingId: row.air_safety_meeting_id,
+  evidenceCategory: row.evidence_category,
+  implementationSummary: row.implementation_summary,
+  evidenceReference: row.evidence_reference,
+  completedBy: row.completed_by,
+  completedAt: row.completed_at.toISOString(),
+  reviewedBy: row.reviewed_by,
+  reviewNotes: row.review_notes,
   createdAt: row.created_at.toISOString(),
 });
 
@@ -616,6 +669,67 @@ export class SafetyEventRepository {
     );
 
     return result.rows.map(toSafetyActionDecision);
+  }
+
+  async insertSafetyActionImplementationEvidence(
+    tx: PoolClient,
+    input: CreateSafetyActionImplementationEvidenceRow,
+  ): Promise<SafetyActionImplementationEvidence> {
+    const result = await tx.query<SafetyActionImplementationEvidenceRow>(
+      `
+      insert into safety_action_implementation_evidence (
+        id,
+        safety_action_proposal_id,
+        safety_event_agenda_link_id,
+        safety_event_id,
+        safety_event_meeting_trigger_id,
+        air_safety_meeting_id,
+        evidence_category,
+        implementation_summary,
+        evidence_reference,
+        completed_by,
+        completed_at,
+        reviewed_by,
+        review_notes
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.safetyActionProposalId,
+        input.safetyEventAgendaLinkId,
+        input.safetyEventId,
+        input.safetyEventMeetingTriggerId,
+        input.airSafetyMeetingId,
+        input.evidenceCategory,
+        input.implementationSummary,
+        input.evidenceReference,
+        input.completedBy,
+        input.completedAt,
+        input.reviewedBy,
+        input.reviewNotes,
+      ],
+    );
+
+    return toSafetyActionImplementationEvidence(result.rows[0]);
+  }
+
+  async listSafetyActionImplementationEvidenceByProposal(
+    tx: PoolClient,
+    proposalId: string,
+  ): Promise<SafetyActionImplementationEvidence[]> {
+    const result = await tx.query<SafetyActionImplementationEvidenceRow>(
+      `
+      select *
+      from safety_action_implementation_evidence
+      where safety_action_proposal_id = $1
+      order by completed_at desc, created_at desc, id desc
+      `,
+      [proposalId],
+    );
+
+    return result.rows.map(toSafetyActionImplementationEvidence);
   }
 
   async referenceExists(

--- a/src/safety-events/safety-event.routes.ts
+++ b/src/safety-events/safety-event.routes.ts
@@ -31,6 +31,14 @@ export function createSafetyEventRouter(
     "/:eventId/agenda-links/:agendaLinkId/action-proposals/:proposalId/decisions",
     controller.listSafetyActionDecisions,
   );
+  router.post(
+    "/:eventId/agenda-links/:agendaLinkId/action-proposals/:proposalId/implementation-evidence",
+    controller.createSafetyActionImplementationEvidence,
+  );
+  router.get(
+    "/:eventId/agenda-links/:agendaLinkId/action-proposals/:proposalId/implementation-evidence",
+    controller.listSafetyActionImplementationEvidence,
+  );
 
   return router;
 }

--- a/src/safety-events/safety-event.service.ts
+++ b/src/safety-events/safety-event.service.ts
@@ -3,6 +3,7 @@ import {
   SafetyEventAgendaLinkConflictError,
   SafetyEventAgendaLinkNotFoundError,
   SafetyActionDecisionTransitionError,
+  SafetyActionImplementationEvidenceStateError,
   SafetyActionProposalNotFoundError,
   SafetyEventMeetingTriggerNotFoundError,
   SafetyEventNotFoundError,
@@ -12,8 +13,10 @@ import { SafetyEventRepository } from "./safety-event.repository";
 import type {
   AssessSafetyEventMeetingTriggerInput,
   CreateSafetyActionDecisionInput,
+  CreateSafetyActionImplementationEvidenceInput,
   CreateSafetyActionProposalInput,
   SafetyActionDecision,
+  SafetyActionImplementationEvidence,
   CreateSafetyEventAgendaLinkInput,
   CreateSafetyEventInput,
   SafetyActionDecisionType,
@@ -27,6 +30,7 @@ import type {
 import {
   validateAssessMeetingTriggerInput,
   validateCreateSafetyActionDecisionInput,
+  validateCreateSafetyActionImplementationEvidenceInput,
   validateCreateSafetyActionProposalInput,
   validateCreateAgendaLinkInput,
   validateCreateSafetyEventInput,
@@ -337,6 +341,71 @@ export class SafetyEventService {
 
       return await this.safetyEventRepository
         .listSafetyActionDecisionsByProposal(client, proposalId);
+    } finally {
+      client.release();
+    }
+  }
+
+  async createSafetyActionImplementationEvidence(
+    eventIdInput: unknown,
+    agendaLinkIdInput: unknown,
+    proposalIdInput: unknown,
+    input: CreateSafetyActionImplementationEvidenceInput | undefined,
+  ): Promise<SafetyActionImplementationEvidence> {
+    const eventId = validateSafetyEventId(eventIdInput);
+    const agendaLinkId = validateSafetyEventAgendaLinkId(agendaLinkIdInput);
+    const proposalId = validateSafetyActionProposalId(proposalIdInput);
+    const validated =
+      validateCreateSafetyActionImplementationEvidenceInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      const proposal = await this.getValidatedProposal(
+        client,
+        eventId,
+        agendaLinkId,
+        proposalId,
+      );
+
+      if (proposal.status !== "completed") {
+        throw new SafetyActionImplementationEvidenceStateError(proposal.id);
+      }
+
+      return await this.safetyEventRepository
+        .insertSafetyActionImplementationEvidence(client, {
+          safetyActionProposalId: proposal.id,
+          safetyEventAgendaLinkId: proposal.safetyEventAgendaLinkId,
+          safetyEventId: proposal.safetyEventId,
+          safetyEventMeetingTriggerId: proposal.safetyEventMeetingTriggerId,
+          airSafetyMeetingId: proposal.airSafetyMeetingId,
+          evidenceCategory: validated.evidenceCategory,
+          implementationSummary: validated.implementationSummary,
+          evidenceReference: validated.evidenceReference,
+          completedBy: validated.completedBy,
+          completedAt: validated.completedAt,
+          reviewedBy: validated.reviewedBy,
+          reviewNotes: validated.reviewNotes,
+        });
+    } finally {
+      client.release();
+    }
+  }
+
+  async listSafetyActionImplementationEvidence(
+    eventIdInput: unknown,
+    agendaLinkIdInput: unknown,
+    proposalIdInput: unknown,
+  ): Promise<SafetyActionImplementationEvidence[]> {
+    const eventId = validateSafetyEventId(eventIdInput);
+    const agendaLinkId = validateSafetyEventAgendaLinkId(agendaLinkIdInput);
+    const proposalId = validateSafetyActionProposalId(proposalIdInput);
+    const client = await this.pool.connect();
+
+    try {
+      await this.getValidatedProposal(client, eventId, agendaLinkId, proposalId);
+
+      return await this.safetyEventRepository
+        .listSafetyActionImplementationEvidenceByProposal(client, proposalId);
     } finally {
       client.release();
     }

--- a/src/safety-events/safety-event.types.ts
+++ b/src/safety-events/safety-event.types.ts
@@ -173,3 +173,37 @@ export interface SafetyActionDecision {
   decidedAt: string;
   createdAt: string;
 }
+
+export type SafetyActionImplementationEvidenceCategory =
+  | "sop_implementation"
+  | "training_completion"
+  | "maintenance_completion"
+  | "accountable_manager_review"
+  | "general_safety_action_closure";
+
+export interface CreateSafetyActionImplementationEvidenceInput {
+  evidenceCategory?: SafetyActionImplementationEvidenceCategory;
+  implementationSummary?: string;
+  evidenceReference?: string | null;
+  completedBy?: string | null;
+  completedAt?: string;
+  reviewedBy?: string | null;
+  reviewNotes?: string | null;
+}
+
+export interface SafetyActionImplementationEvidence {
+  id: string;
+  safetyActionProposalId: string;
+  safetyEventAgendaLinkId: string;
+  safetyEventId: string;
+  safetyEventMeetingTriggerId: string;
+  airSafetyMeetingId: string;
+  evidenceCategory: SafetyActionImplementationEvidenceCategory;
+  implementationSummary: string;
+  evidenceReference: string | null;
+  completedBy: string | null;
+  completedAt: string;
+  reviewedBy: string | null;
+  reviewNotes: string | null;
+  createdAt: string;
+}

--- a/src/safety-events/safety-event.validators.ts
+++ b/src/safety-events/safety-event.validators.ts
@@ -2,10 +2,12 @@ import { SafetyEventValidationError } from "./safety-event.errors";
 import type {
   AssessSafetyEventMeetingTriggerInput,
   CreateSafetyActionDecisionInput,
+  CreateSafetyActionImplementationEvidenceInput,
   CreateSafetyActionProposalInput,
   CreateSafetyEventAgendaLinkInput,
   CreateSafetyEventInput,
   SafetyActionDecisionType,
+  SafetyActionImplementationEvidenceCategory,
   SafetyActionProposalStatus,
   SafetyActionProposalType,
   SafetyEventSeverity,
@@ -59,6 +61,15 @@ const ACTION_DECISIONS = new Set<SafetyActionDecisionType>([
   "rejected",
   "completed",
 ]);
+
+const ACTION_IMPLEMENTATION_EVIDENCE_CATEGORIES =
+  new Set<SafetyActionImplementationEvidenceCategory>([
+    "sop_implementation",
+    "training_completion",
+    "maintenance_completion",
+    "accountable_manager_review",
+    "general_safety_action_closure",
+  ]);
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -341,5 +352,39 @@ export function validateCreateSafetyActionDecisionInput(
     decision,
     decidedBy: optionalTrimmed(input.decidedBy, "decidedBy"),
     decisionNotes: optionalTrimmed(input.decisionNotes, "decisionNotes"),
+  };
+}
+
+export function validateCreateSafetyActionImplementationEvidenceInput(
+  input: CreateSafetyActionImplementationEvidenceInput | undefined,
+) {
+  if (!input || typeof input !== "object") {
+    throw new SafetyEventValidationError("Request body must be an object");
+  }
+
+  const evidenceCategory = input.evidenceCategory;
+  if (
+    !evidenceCategory ||
+    !ACTION_IMPLEMENTATION_EVIDENCE_CATEGORIES.has(evidenceCategory)
+  ) {
+    throw new SafetyEventValidationError(
+      "evidenceCategory is required and supported",
+    );
+  }
+
+  return {
+    evidenceCategory,
+    implementationSummary: requiredTrimmed(
+      input.implementationSummary,
+      "implementationSummary",
+    ),
+    evidenceReference: optionalTrimmed(
+      input.evidenceReference,
+      "evidenceReference",
+    ),
+    completedBy: optionalTrimmed(input.completedBy, "completedBy"),
+    completedAt: requiredDate(input.completedAt, "completedAt"),
+    reviewedBy: optionalTrimmed(input.reviewedBy, "reviewedBy"),
+    reviewNotes: optionalTrimmed(input.reviewNotes, "reviewNotes"),
   };
 }

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -4,6 +4,7 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from safety_action_implementation_evidence");
   await pool.query("delete from safety_action_decisions");
   await pool.query("delete from safety_action_proposals");
   await pool.query("delete from safety_event_agenda_links");

--- a/src/tests/safety-events.test.ts
+++ b/src/tests/safety-events.test.ts
@@ -5,6 +5,7 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 
 const clearTables = async () => {
+  await pool.query("delete from safety_action_implementation_evidence");
   await pool.query("delete from safety_action_decisions");
   await pool.query("delete from safety_action_proposals");
   await pool.query("delete from safety_event_agenda_links");
@@ -41,6 +42,7 @@ const countRows = async (ids: {
       (select count(*)::int from safety_event_agenda_links) as safety_event_agenda_link_count,
       (select count(*)::int from safety_action_proposals) as safety_action_proposal_count,
       (select count(*)::int from safety_action_decisions) as safety_action_decision_count,
+      (select count(*)::int from safety_action_implementation_evidence) as safety_action_implementation_evidence_count,
       (select count(*)::int from missions where ($1::uuid is null or id = $1)) as mission_count,
       (select count(*)::int from platforms where ($2::uuid is null or id = $2)) as platform_count,
       (select count(*)::int from pilots where ($3::uuid is null or id = $3)) as pilot_count,
@@ -61,6 +63,7 @@ const countRows = async (ids: {
     safety_event_agenda_link_count: number;
     safety_action_proposal_count: number;
     safety_action_decision_count: number;
+    safety_action_implementation_evidence_count: number;
     mission_count: number;
     platform_count: number;
     pilot_count: number;
@@ -224,6 +227,35 @@ const createSafetyActionProposal = async (params?: {
   return {
     ...source,
     proposal: proposalResponse.body.proposal as { id: string; status: string },
+  };
+};
+
+const createCompletedSafetyActionProposal = async (params?: {
+  proposalType?: string;
+  summary?: string;
+}) => {
+  const source = await createSafetyActionProposal(params);
+
+  const acceptResponse = await request(app)
+    .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/decisions`)
+    .send({
+      decision: "accepted",
+      decidedBy: "safety-manager",
+    });
+  const completeResponse = await request(app)
+    .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/decisions`)
+    .send({
+      decision: "completed",
+      decidedBy: "safety-manager",
+      decisionNotes: "Action implemented.",
+    });
+
+  expect(acceptResponse.status).toBe(201);
+  expect(completeResponse.status).toBe(201);
+
+  return {
+    ...source,
+    proposal: completeResponse.body.proposal as { id: string; status: string },
   };
 };
 
@@ -822,6 +854,188 @@ describe("safety events", () => {
     expect(await countRows({})).toEqual(before);
   });
 
+  it("stores SOP, training, and maintenance implementation evidence for completed safety actions", async () => {
+    const cases = [
+      {
+        proposalType: "sop_change",
+        evidenceCategory: "sop_implementation",
+        summary: "Launch checklist SOP updated",
+      },
+      {
+        proposalType: "training_action",
+        evidenceCategory: "training_completion",
+        summary: "Manual recovery refresher completed",
+      },
+      {
+        proposalType: "maintenance_action",
+        evidenceCategory: "maintenance_completion",
+        summary: "Motor mount inspection completed",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const source = await createCompletedSafetyActionProposal({
+        proposalType: testCase.proposalType,
+        summary: testCase.summary,
+      });
+
+      const response = await request(app)
+        .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/implementation-evidence`)
+        .send({
+          evidenceCategory: testCase.evidenceCategory,
+          implementationSummary: ` ${testCase.summary} `,
+          evidenceReference: " DOC-REF-001 ",
+          completedBy: " safety-manager ",
+          completedAt: "2026-05-20T09:00:00.000Z",
+          reviewedBy: " accountable-manager ",
+          reviewNotes: " Closure evidence reviewed. ",
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.evidence).toMatchObject({
+        safetyActionProposalId: source.proposal.id,
+        safetyEventAgendaLinkId: source.agendaLink.id,
+        safetyEventId: source.event.id,
+        safetyEventMeetingTriggerId: source.trigger.id,
+        airSafetyMeetingId: source.meeting.id,
+        evidenceCategory: testCase.evidenceCategory,
+        implementationSummary: testCase.summary,
+        evidenceReference: "DOC-REF-001",
+        completedBy: "safety-manager",
+        completedAt: "2026-05-20T09:00:00.000Z",
+        reviewedBy: "accountable-manager",
+        reviewNotes: "Closure evidence reviewed.",
+      });
+      expect(response.body.evidence.id).toEqual(expect.any(String));
+      expect(response.body.evidence.createdAt).toEqual(expect.any(String));
+    }
+  });
+
+  it("lists implementation evidence for the requested completed safety action", async () => {
+    const source = await createCompletedSafetyActionProposal({
+      proposalType: "general_safety_action",
+      summary: "Complete safety review follow-up",
+    });
+
+    const first = await request(app)
+      .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/implementation-evidence`)
+      .send({
+        evidenceCategory: "general_safety_action_closure",
+        implementationSummary: "Initial closure evidence captured",
+        completedAt: "2026-05-20T09:00:00.000Z",
+      });
+    const second = await request(app)
+      .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/implementation-evidence`)
+      .send({
+        evidenceCategory: "accountable_manager_review",
+        implementationSummary: "Accountable manager review completed",
+        completedAt: "2026-05-21T09:00:00.000Z",
+      });
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+
+    const listResponse = await request(app).get(
+      `/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/implementation-evidence`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.evidence).toHaveLength(2);
+    expect(
+      listResponse.body.evidence.map((evidence: { id: string }) => evidence.id),
+    ).toEqual(
+      expect.arrayContaining([
+        first.body.evidence.id,
+        second.body.evidence.id,
+      ]),
+    );
+  });
+
+  it("rejects implementation evidence unless the safety action proposal is completed", async () => {
+    const proposedSource = await createSafetyActionProposal();
+    const acceptedSource = await createSafetyActionProposal();
+    const rejectedSource = await createSafetyActionProposal();
+
+    const acceptedDecision = await request(app)
+      .post(`/safety-events/${acceptedSource.event.id}/agenda-links/${acceptedSource.agendaLink.id}/action-proposals/${acceptedSource.proposal.id}/decisions`)
+      .send({
+        decision: "accepted",
+      });
+    const rejectedDecision = await request(app)
+      .post(`/safety-events/${rejectedSource.event.id}/agenda-links/${rejectedSource.agendaLink.id}/action-proposals/${rejectedSource.proposal.id}/decisions`)
+      .send({
+        decision: "rejected",
+      });
+
+    expect(acceptedDecision.status).toBe(201);
+    expect(rejectedDecision.status).toBe(201);
+
+    for (const source of [proposedSource, acceptedSource, rejectedSource]) {
+      const response = await request(app)
+        .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/implementation-evidence`)
+        .send({
+          evidenceCategory: "general_safety_action_closure",
+          implementationSummary: "Closure evidence attempted too early",
+          completedAt: "2026-05-20T09:00:00.000Z",
+        });
+
+      expect(response.status).toBe(409);
+      expect(response.body.error).toMatchObject({
+        type: "safety_action_implementation_evidence_state_invalid",
+      });
+    }
+  });
+
+  it("rejects invalid implementation evidence input and missing proposals", async () => {
+    const source = await createCompletedSafetyActionProposal();
+    const missingProposalId = randomUUID();
+
+    const badCategory = await request(app)
+      .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/implementation-evidence`)
+      .send({
+        evidenceCategory: "unsupported",
+        implementationSummary: "Bad category",
+        completedAt: "2026-05-20T09:00:00.000Z",
+      });
+    const badDate = await request(app)
+      .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/implementation-evidence`)
+      .send({
+        evidenceCategory: "general_safety_action_closure",
+        implementationSummary: "Bad date",
+        completedAt: "not-a-date",
+      });
+    const missingSummary = await request(app)
+      .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${source.proposal.id}/implementation-evidence`)
+      .send({
+        evidenceCategory: "general_safety_action_closure",
+        completedAt: "2026-05-20T09:00:00.000Z",
+      });
+    const missingProposal = await request(app)
+      .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${missingProposalId}/implementation-evidence`)
+      .send({
+        evidenceCategory: "general_safety_action_closure",
+        implementationSummary: "Missing proposal",
+        completedAt: "2026-05-20T09:00:00.000Z",
+      });
+
+    expect(badCategory.status).toBe(400);
+    expect(badDate.status).toBe(400);
+    expect(missingSummary.status).toBe(400);
+    expect(badCategory.body.error).toMatchObject({
+      type: "safety_event_validation_failed",
+    });
+    expect(badDate.body.error).toMatchObject({
+      type: "safety_event_validation_failed",
+    });
+    expect(missingSummary.body.error).toMatchObject({
+      type: "safety_event_validation_failed",
+    });
+    expect(missingProposal.status).toBe(404);
+    expect(missingProposal.body.error).toMatchObject({
+      type: "safety_action_proposal_not_found",
+    });
+  });
+
   it("captures linked post-operation safety findings without mutating linked records", async () => {
     const platform = await createPlatform();
     const pilot = await createPilot();
@@ -1113,6 +1327,86 @@ describe("safety events", () => {
       ...before,
       safety_action_decision_count:
         before.safety_action_decision_count + 1,
+    });
+  });
+
+  it("creates implementation evidence without mutating source safety records", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    const missionId = await insertMission({
+      platformId: platform.id,
+      pilotId: pilot.id,
+    });
+    const meeting = await createAirSafetyMeeting();
+    const safetyEvent = await request(app).post("/safety-events").send({
+      eventType: "sop_breach",
+      severity: "high",
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      eventOccurredAt: "2026-04-17T12:00:00.000Z",
+      summary: "Launch SOP breach requires closure evidence",
+    });
+
+    expect(safetyEvent.status).toBe(201);
+
+    const triggerResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/meeting-trigger`)
+      .send({});
+    const agendaLinkResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/meeting-triggers/${triggerResponse.body.trigger.id}/agenda-links`)
+      .send({
+        airSafetyMeetingId: meeting.id,
+        agendaItem: "Review launch SOP breach",
+      });
+    const proposalResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/agenda-links/${agendaLinkResponse.body.link.id}/action-proposals`)
+      .send({
+        proposalType: "sop_change",
+        summary: "Update launch SOP",
+      });
+    const acceptResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/agenda-links/${agendaLinkResponse.body.link.id}/action-proposals/${proposalResponse.body.proposal.id}/decisions`)
+      .send({
+        decision: "accepted",
+      });
+    const completeResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/agenda-links/${agendaLinkResponse.body.link.id}/action-proposals/${proposalResponse.body.proposal.id}/decisions`)
+      .send({
+        decision: "completed",
+      });
+
+    expect(triggerResponse.status).toBe(201);
+    expect(agendaLinkResponse.status).toBe(201);
+    expect(proposalResponse.status).toBe(201);
+    expect(acceptResponse.status).toBe(201);
+    expect(completeResponse.status).toBe(201);
+
+    const before = await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      meetingId: meeting.id,
+    });
+
+    const evidenceResponse = await request(app)
+      .post(`/safety-events/${safetyEvent.body.event.id}/agenda-links/${agendaLinkResponse.body.link.id}/action-proposals/${proposalResponse.body.proposal.id}/implementation-evidence`)
+      .send({
+        evidenceCategory: "sop_implementation",
+        implementationSummary: "Launch SOP update completed",
+        completedAt: "2026-05-20T09:00:00.000Z",
+      });
+
+    expect(evidenceResponse.status).toBe(201);
+    expect(await countRows({
+      missionId,
+      platformId: platform.id,
+      pilotId: pilot.id,
+      meetingId: meeting.id,
+    })).toEqual({
+      ...before,
+      safety_action_implementation_evidence_count:
+        before.safety_action_implementation_evidence_count + 1,
     });
   });
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #75 by adding migration-backed safety action implementation evidence so completed SOP, training, and maintenance actions can store reviewable closure records.

## What changed

- Added `safety_action_implementation_evidence` with proposal/event/trigger/meeting audit-chain links.
- Added nested endpoints:
  - `POST /safety-events/:eventId/agenda-links/:agendaLinkId/action-proposals/:proposalId/implementation-evidence`
  - `GET /safety-events/:eventId/agenda-links/:agendaLinkId/action-proposals/:proposalId/implementation-evidence`
- Added validation for supported evidence categories, completion timestamps, and required implementation summaries.
- Added a 409 guard so implementation evidence can only be created once the safety action proposal is `completed`.
- Added integration coverage for SOP, training, maintenance, listing, invalid input, missing proposals, state guard behavior, and no mutation of linked source records.
- Updated the save point to the next build step.

## Verification

- `npm.cmd ci` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/safety-events.test.ts` passed: 30 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 7 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 250 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `node scripts\\check-next-build-step-pr.mjs origin/main` passed.
- `git diff --cached --check` passed.
- `npm.cmd run build` still cannot run because the repo does not currently have a root `tsconfig.json`; `tsc` prints compiler help text.

Closes #75.
