### PR TITLE
Add safety meeting pack export

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add safety meeting pack export endpoint so meeting agenda, triggered events, action proposals, decisions, and closure evidence can be reviewed together.",
+ "nextBuildStep": "Add safety meeting pack rendered report endpoint so meeting exports can be reviewed as regulator-ready meeting packs.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/air-safety-meetings/air-safety-meeting.controller.ts
+++ b/src/air-safety-meetings/air-safety-meeting.controller.ts
@@ -49,4 +49,20 @@ export class AirSafetyMeetingController {
       next(error);
     }
   };
+
+  exportAirSafetyMeetingPack = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const meetingExport =
+        await this.airSafetyMeetingService.exportAirSafetyMeetingPack(
+          req.params.meetingId,
+        );
+      res.status(200).json({ export: meetingExport });
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/air-safety-meetings/air-safety-meeting.errors.ts
+++ b/src/air-safety-meetings/air-safety-meeting.errors.ts
@@ -2,3 +2,12 @@ export class AirSafetyMeetingValidationError extends Error {
   readonly statusCode = 400;
   readonly code = "AIR_SAFETY_MEETING_VALIDATION_FAILED";
 }
+
+export class AirSafetyMeetingNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "AIR_SAFETY_MEETING_NOT_FOUND";
+
+  constructor(meetingId: string) {
+    super(`Air safety meeting not found: ${meetingId}`);
+  }
+}

--- a/src/air-safety-meetings/air-safety-meeting.repository.ts
+++ b/src/air-safety-meetings/air-safety-meeting.repository.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import type { PoolClient, QueryResultRow } from "pg";
 import type {
   AirSafetyMeeting,
+  AirSafetyMeetingPackExportAgendaItem,
   AirSafetyMeetingStatus,
   AirSafetyMeetingType,
 } from "./air-safety-meeting.types";
@@ -35,6 +36,10 @@ interface CreateAirSafetyMeetingRow {
   agenda: string[];
   minutes: string | null;
   createdBy: string | null;
+}
+
+interface AirSafetyMeetingPackExportAgendaItemRow extends QueryResultRow {
+  agenda_item: AirSafetyMeetingPackExportAgendaItem;
 }
 
 const toDateOnly = (value: Date | string | null): string | null => {
@@ -137,6 +142,151 @@ export class AirSafetyMeetingRepository {
     );
 
     return result.rows.map(toAirSafetyMeeting);
+  }
+
+  async getAirSafetyMeetingById(
+    tx: PoolClient,
+    meetingId: string,
+  ): Promise<AirSafetyMeeting | null> {
+    const result = await tx.query<AirSafetyMeetingRow>(
+      `
+      select *
+      from air_safety_meetings
+      where id = $1
+      `,
+      [meetingId],
+    );
+
+    return result.rows[0] ? toAirSafetyMeeting(result.rows[0]) : null;
+  }
+
+  async listAirSafetyMeetingPackAgendaItems(
+    tx: PoolClient,
+    meetingId: string,
+  ): Promise<AirSafetyMeetingPackExportAgendaItem[]> {
+    const result = await tx.query<AirSafetyMeetingPackExportAgendaItemRow>(
+      `
+      select jsonb_build_object(
+        'link', jsonb_build_object(
+          'id', links.id,
+          'safetyEventId', links.safety_event_id,
+          'safetyEventMeetingTriggerId', links.safety_event_meeting_trigger_id,
+          'airSafetyMeetingId', links.air_safety_meeting_id,
+          'agendaItem', links.agenda_item,
+          'linkedBy', links.linked_by,
+          'linkedAt', links.linked_at,
+          'createdAt', links.created_at
+        ),
+        'safetyEvent', jsonb_build_object(
+          'id', events.id,
+          'eventType', events.event_type,
+          'severity', events.severity,
+          'status', events.status,
+          'missionId', events.mission_id,
+          'platformId', events.platform_id,
+          'pilotId', events.pilot_id,
+          'postOperationEvidenceSnapshotId', events.post_operation_evidence_snapshot_id,
+          'reportedBy', events.reported_by,
+          'eventOccurredAt', events.event_occurred_at,
+          'reportedAt', events.reported_at,
+          'summary', events.summary,
+          'description', events.description,
+          'immediateActionTaken', events.immediate_action_taken,
+          'sopReference', events.sop_reference,
+          'meetingRequired', events.meeting_required,
+          'sopReviewRequired', events.sop_review_required,
+          'trainingRequired', events.training_required,
+          'maintenanceReviewRequired', events.maintenance_review_required,
+          'accountableManagerReviewRequired', events.accountable_manager_review_required,
+          'regulatorReportableReviewRequired', events.regulator_reportable_review_required,
+          'createdAt', events.created_at,
+          'updatedAt', events.updated_at
+        ),
+        'meetingTrigger', jsonb_build_object(
+          'id', triggers.id,
+          'safetyEventId', triggers.safety_event_id,
+          'meetingRequired', triggers.meeting_required,
+          'recommendedMeetingType', triggers.recommended_meeting_type,
+          'triggerReasons', triggers.trigger_reasons,
+          'reviewFlags', triggers.review_flags,
+          'assessedBy', triggers.assessed_by,
+          'assessedAt', triggers.assessed_at,
+          'createdAt', triggers.created_at
+        ),
+        'actionProposals', coalesce(
+          (
+            select jsonb_agg(
+              jsonb_build_object(
+                'id', proposals.id,
+                'proposalType', proposals.proposal_type,
+                'status', proposals.status,
+                'summary', proposals.summary,
+                'rationale', proposals.rationale,
+                'proposedOwner', proposals.proposed_owner,
+                'proposedDueAt', proposals.proposed_due_at,
+                'createdBy', proposals.created_by,
+                'createdAt', proposals.created_at,
+                'updatedAt', proposals.updated_at,
+                'decisions', coalesce(
+                  (
+                    select jsonb_agg(
+                      jsonb_build_object(
+                        'id', decisions.id,
+                        'decision', decisions.decision,
+                        'decidedBy', decisions.decided_by,
+                        'decisionNotes', decisions.decision_notes,
+                        'decidedAt', decisions.decided_at,
+                        'createdAt', decisions.created_at
+                      )
+                      order by decisions.decided_at asc, decisions.created_at asc, decisions.id asc
+                    )
+                    from safety_action_decisions decisions
+                    where decisions.safety_action_proposal_id = proposals.id
+                  ),
+                  '[]'::jsonb
+                ),
+                'implementationEvidence', coalesce(
+                  (
+                    select jsonb_agg(
+                      jsonb_build_object(
+                        'id', evidence.id,
+                        'evidenceCategory', evidence.evidence_category,
+                        'implementationSummary', evidence.implementation_summary,
+                        'evidenceReference', evidence.evidence_reference,
+                        'completedBy', evidence.completed_by,
+                        'completedAt', evidence.completed_at,
+                        'reviewedBy', evidence.reviewed_by,
+                        'reviewNotes', evidence.review_notes,
+                        'createdAt', evidence.created_at
+                      )
+                      order by evidence.completed_at desc, evidence.created_at desc, evidence.id desc
+                    )
+                    from safety_action_implementation_evidence evidence
+                    where evidence.safety_action_proposal_id = proposals.id
+                  ),
+                  '[]'::jsonb
+                )
+              )
+              order by proposals.created_at desc, proposals.id desc
+            )
+            from safety_action_proposals proposals
+            where proposals.safety_event_agenda_link_id = links.id
+          ),
+          '[]'::jsonb
+        )
+      ) as agenda_item
+      from safety_event_agenda_links links
+      inner join safety_events events
+        on events.id = links.safety_event_id
+      inner join safety_event_meeting_triggers triggers
+        on triggers.id = links.safety_event_meeting_trigger_id
+      where links.air_safety_meeting_id = $1
+      order by links.linked_at desc, links.created_at desc, links.id desc
+      `,
+      [meetingId],
+    );
+
+    return result.rows.map((row) => row.agenda_item);
   }
 
   async getLatestCompletedQuarterlyMeeting(

--- a/src/air-safety-meetings/air-safety-meeting.routes.ts
+++ b/src/air-safety-meetings/air-safety-meeting.routes.ts
@@ -9,6 +9,7 @@ export function createAirSafetyMeetingRouter(
   router.post("/", controller.createAirSafetyMeeting);
   router.get("/", controller.listAirSafetyMeetings);
   router.get("/quarterly-compliance", controller.getQuarterlyCompliance);
+  router.get("/:meetingId/export", controller.exportAirSafetyMeetingPack);
 
   return router;
 }

--- a/src/air-safety-meetings/air-safety-meeting.service.ts
+++ b/src/air-safety-meetings/air-safety-meeting.service.ts
@@ -1,12 +1,15 @@
 import type { Pool } from "pg";
+import { AirSafetyMeetingNotFoundError } from "./air-safety-meeting.errors";
 import { AirSafetyMeetingRepository } from "./air-safety-meeting.repository";
 import type {
   AirSafetyMeeting,
+  AirSafetyMeetingPackExport,
   CreateAirSafetyMeetingInput,
   QuarterlyAirSafetyMeetingCompliance,
   QuarterlyComplianceStatus,
 } from "./air-safety-meeting.types";
 import {
+  validateAirSafetyMeetingId,
   validateCreateAirSafetyMeetingInput,
   validateQuarterlyComplianceQuery,
 } from "./air-safety-meeting.validators";
@@ -61,6 +64,36 @@ export class AirSafetyMeetingService {
         );
 
       return this.buildQuarterlyCompliance(asOf, lastCompletedMeeting);
+    } finally {
+      client.release();
+    }
+  }
+
+  async exportAirSafetyMeetingPack(
+    meetingIdInput: unknown,
+  ): Promise<AirSafetyMeetingPackExport> {
+    const meetingId = validateAirSafetyMeetingId(meetingIdInput);
+    const client = await this.pool.connect();
+
+    try {
+      const meeting = await this.airSafetyMeetingRepository
+        .getAirSafetyMeetingById(client, meetingId);
+
+      if (!meeting) {
+        throw new AirSafetyMeetingNotFoundError(meetingId);
+      }
+
+      const agendaItems = await this.airSafetyMeetingRepository
+        .listAirSafetyMeetingPackAgendaItems(client, meetingId);
+
+      return {
+        exportType: "air_safety_meeting_pack",
+        formatVersion: 1,
+        generatedAt: new Date().toISOString(),
+        meetingId,
+        meeting,
+        agendaItems,
+      };
     } finally {
       client.release();
     }

--- a/src/air-safety-meetings/air-safety-meeting.types.ts
+++ b/src/air-safety-meetings/air-safety-meeting.types.ts
@@ -57,3 +57,104 @@ export interface QuarterlyAirSafetyMeetingCompliance {
   nextDueAt: string | null;
   message: string;
 }
+
+export interface AirSafetyMeetingPackExportAgendaLink {
+  id: string;
+  safetyEventId: string;
+  safetyEventMeetingTriggerId: string;
+  airSafetyMeetingId: string;
+  agendaItem: string;
+  linkedBy: string | null;
+  linkedAt: string;
+  createdAt: string;
+}
+
+export interface AirSafetyMeetingPackExportSafetyEvent {
+  id: string;
+  eventType: string;
+  severity: string;
+  status: string;
+  missionId: string | null;
+  platformId: string | null;
+  pilotId: string | null;
+  postOperationEvidenceSnapshotId: string | null;
+  reportedBy: string | null;
+  eventOccurredAt: string;
+  reportedAt: string;
+  summary: string;
+  description: string | null;
+  immediateActionTaken: string | null;
+  sopReference: string | null;
+  meetingRequired: boolean;
+  sopReviewRequired: boolean;
+  trainingRequired: boolean;
+  maintenanceReviewRequired: boolean;
+  accountableManagerReviewRequired: boolean;
+  regulatorReportableReviewRequired: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AirSafetyMeetingPackExportMeetingTrigger {
+  id: string;
+  safetyEventId: string;
+  meetingRequired: boolean;
+  recommendedMeetingType: string | null;
+  triggerReasons: string[];
+  reviewFlags: Record<string, boolean>;
+  assessedBy: string | null;
+  assessedAt: string;
+  createdAt: string;
+}
+
+export interface AirSafetyMeetingPackExportActionDecision {
+  id: string;
+  decision: string;
+  decidedBy: string | null;
+  decisionNotes: string | null;
+  decidedAt: string;
+  createdAt: string;
+}
+
+export interface AirSafetyMeetingPackExportImplementationEvidence {
+  id: string;
+  evidenceCategory: string;
+  implementationSummary: string;
+  evidenceReference: string | null;
+  completedBy: string | null;
+  completedAt: string;
+  reviewedBy: string | null;
+  reviewNotes: string | null;
+  createdAt: string;
+}
+
+export interface AirSafetyMeetingPackExportActionProposal {
+  id: string;
+  proposalType: string;
+  status: string;
+  summary: string;
+  rationale: string | null;
+  proposedOwner: string | null;
+  proposedDueAt: string | null;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt: string;
+  decisions: AirSafetyMeetingPackExportActionDecision[];
+  implementationEvidence: AirSafetyMeetingPackExportImplementationEvidence[];
+}
+
+export interface AirSafetyMeetingPackExportAgendaItem {
+  link: AirSafetyMeetingPackExportAgendaLink;
+  safetyEvent: AirSafetyMeetingPackExportSafetyEvent;
+  meetingTrigger: AirSafetyMeetingPackExportMeetingTrigger;
+  actionProposals: AirSafetyMeetingPackExportActionProposal[];
+}
+
+export interface AirSafetyMeetingPackExport {
+  exportType: "air_safety_meeting_pack";
+  formatVersion: 1;
+  generatedAt: string;
+  meetingId: string;
+  meeting: AirSafetyMeeting;
+  agendaItems: AirSafetyMeetingPackExportAgendaItem[];
+}

--- a/src/air-safety-meetings/air-safety-meeting.validators.ts
+++ b/src/air-safety-meetings/air-safety-meeting.validators.ts
@@ -20,6 +20,9 @@ const MEETING_STATUSES = new Set<AirSafetyMeetingStatus>([
   "cancelled",
 ]);
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 function optionalTrimmed(value: unknown, fieldName: string): string | null {
   if (value === undefined || value === null) {
     return null;
@@ -164,4 +167,20 @@ export function validateQuarterlyComplianceQuery(input: {
   asOf?: unknown;
 }): Date {
   return optionalDate(input.asOf, "asOf") ?? new Date();
+}
+
+export function validateAirSafetyMeetingId(value: unknown): string {
+  const normalized = optionalTrimmed(value, "meetingId");
+
+  if (!normalized) {
+    throw new AirSafetyMeetingValidationError("meetingId is required");
+  }
+
+  if (!UUID_RE.test(normalized)) {
+    throw new AirSafetyMeetingValidationError(
+      "meetingId must be a valid UUID",
+    );
+  }
+
+  return normalized;
 }

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import request from "supertest";
 import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
+import { randomUUID } from "crypto";
 
 const clearTables = async () => {
   await pool.query("delete from safety_action_implementation_evidence");
@@ -28,6 +29,161 @@ const createCompletedQuarterlyMeeting = async (heldAt: string) => {
 
   expect(response.status).toBe(201);
   return response.body.meeting;
+};
+
+const countRows = async () => {
+  const result = await pool.query(
+    `
+    select
+      (select count(*)::int from air_safety_meetings) as meeting_count,
+      (select count(*)::int from safety_events) as safety_event_count,
+      (select count(*)::int from safety_event_meeting_triggers) as trigger_count,
+      (select count(*)::int from safety_event_agenda_links) as agenda_link_count,
+      (select count(*)::int from safety_action_proposals) as proposal_count,
+      (select count(*)::int from safety_action_decisions) as decision_count,
+      (select count(*)::int from safety_action_implementation_evidence) as implementation_evidence_count
+    `,
+  );
+
+  return result.rows[0] as {
+    meeting_count: number;
+    safety_event_count: number;
+    trigger_count: number;
+    agenda_link_count: number;
+    proposal_count: number;
+    decision_count: number;
+    implementation_evidence_count: number;
+  };
+};
+
+const createEventTriggeredMeeting = async () => {
+  const response = await request(app).post("/air-safety-meetings").send({
+    meetingType: "event_triggered_safety_review",
+    dueAt: "2026-04-20T10:00:00.000Z",
+    chairperson: "Safety Manager",
+    attendees: ["Accountable Manager", "Chief Pilot"],
+    agenda: ["Review safety events", "Review action closure"],
+    createdBy: "safety-admin",
+  });
+
+  expect(response.status).toBe(201);
+  return response.body.meeting as { id: string };
+};
+
+const createAgendaLinkedEvent = async (
+  meetingId: string,
+  params?: {
+    eventType?: string;
+    severity?: string;
+    summary?: string;
+    agendaItem?: string;
+  },
+) => {
+  const eventResponse = await request(app).post("/safety-events").send({
+    eventType: params?.eventType ?? "sop_breach",
+    severity: params?.severity ?? "high",
+    eventOccurredAt: "2026-04-19T09:00:00.000Z",
+    reportedBy: "safety-manager",
+    summary: params?.summary ?? "Safety event for meeting pack",
+    sopReference: "OPS-SOP-LAUNCH-001",
+  });
+
+  expect(eventResponse.status).toBe(201);
+
+  const triggerResponse = await request(app)
+    .post(`/safety-events/${eventResponse.body.event.id}/meeting-trigger`)
+    .send({
+      assessedBy: "safety-manager",
+    });
+
+  expect(triggerResponse.status).toBe(201);
+
+  const agendaLinkResponse = await request(app)
+    .post(`/safety-events/${eventResponse.body.event.id}/meeting-triggers/${triggerResponse.body.trigger.id}/agenda-links`)
+    .send({
+      airSafetyMeetingId: meetingId,
+      agendaItem: params?.agendaItem ?? "Review safety action",
+      linkedBy: "safety-coordinator",
+    });
+
+  expect(agendaLinkResponse.status).toBe(201);
+
+  return {
+    event: eventResponse.body.event,
+    trigger: triggerResponse.body.trigger,
+    agendaLink: agendaLinkResponse.body.link,
+  };
+};
+
+const createCompletedActionWithEvidence = async (
+  meetingId: string,
+  params?: {
+    eventType?: string;
+    proposalType?: string;
+    evidenceCategory?: string;
+    implementationSummary?: string;
+  },
+) => {
+  const source = await createAgendaLinkedEvent(meetingId, {
+    eventType: params?.eventType ?? "sop_breach",
+    agendaItem: "Review completed action evidence",
+  });
+
+  const proposalResponse = await request(app)
+    .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals`)
+    .send({
+      proposalType: params?.proposalType ?? "sop_change",
+      summary: "Update safety procedure",
+      rationale: "Meeting review identified required follow-up.",
+      proposedOwner: "Safety Manager",
+      proposedDueAt: "2026-05-01T10:00:00.000Z",
+      createdBy: "safety-manager",
+    });
+
+  expect(proposalResponse.status).toBe(201);
+
+  const acceptResponse = await request(app)
+    .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${proposalResponse.body.proposal.id}/decisions`)
+    .send({
+      decision: "accepted",
+      decidedBy: "accountable-manager",
+      decisionNotes: "Accepted for implementation.",
+    });
+
+  expect(acceptResponse.status).toBe(201);
+
+  const completeResponse = await request(app)
+    .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${proposalResponse.body.proposal.id}/decisions`)
+    .send({
+      decision: "completed",
+      decidedBy: "safety-manager",
+      decisionNotes: "Action completed.",
+    });
+
+  expect(completeResponse.status).toBe(201);
+
+  const evidenceResponse = await request(app)
+    .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals/${proposalResponse.body.proposal.id}/implementation-evidence`)
+    .send({
+      evidenceCategory: params?.evidenceCategory ?? "sop_implementation",
+      implementationSummary:
+        params?.implementationSummary ?? "Procedure update completed",
+      evidenceReference: "DOC-SAFETY-001",
+      completedBy: "safety-manager",
+      completedAt: "2026-05-02T09:00:00.000Z",
+      reviewedBy: "accountable-manager",
+      reviewNotes: "Closure evidence reviewed.",
+    });
+
+  expect(evidenceResponse.status).toBe(201);
+
+  return {
+    ...source,
+    proposal: completeResponse.body.proposal,
+    acceptDecision: acceptResponse.body.decision,
+    completeDecision: completeResponse.body.decision,
+    implementationEvidence: evidenceResponse.body.evidence,
+  };
 };
 
 describe("air safety meetings", () => {
@@ -166,6 +322,224 @@ describe("air safety meetings", () => {
       lastCompletedMeeting: null,
       nextDueAt: null,
     });
+  });
+
+  it("exports an empty safety meeting pack without mutating source records", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const before = await countRows();
+
+    const response = await request(app).get(
+      `/air-safety-meetings/${meeting.id}/export`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.export).toMatchObject({
+      exportType: "air_safety_meeting_pack",
+      formatVersion: 1,
+      meetingId: meeting.id,
+      meeting: {
+        id: meeting.id,
+        meetingType: "event_triggered_safety_review",
+        status: "scheduled",
+        chairperson: "Safety Manager",
+      },
+      agendaItems: [],
+    });
+    expect(response.body.export.generatedAt).toEqual(expect.any(String));
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("exports agenda-linked safety events, triggers, proposals, decisions, and closure evidence", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const source = await createCompletedActionWithEvidence(meeting.id);
+    const before = await countRows();
+
+    const response = await request(app).get(
+      `/air-safety-meetings/${meeting.id}/export`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.export.agendaItems).toHaveLength(1);
+    expect(response.body.export.agendaItems[0]).toMatchObject({
+      link: {
+        id: source.agendaLink.id,
+        safetyEventId: source.event.id,
+        safetyEventMeetingTriggerId: source.trigger.id,
+        airSafetyMeetingId: meeting.id,
+        agendaItem: "Review completed action evidence",
+        linkedBy: "safety-coordinator",
+      },
+      safetyEvent: {
+        id: source.event.id,
+        eventType: "sop_breach",
+        severity: "high",
+        status: "open",
+        summary: "Safety event for meeting pack",
+        sopReference: "OPS-SOP-LAUNCH-001",
+      },
+      meetingTrigger: {
+        id: source.trigger.id,
+        safetyEventId: source.event.id,
+        meetingRequired: true,
+        recommendedMeetingType: "sop_breach_review",
+        triggerReasons: expect.arrayContaining([
+          "severity:high",
+          "event_type:sop_breach",
+        ]),
+        reviewFlags: {
+          sopReviewRequired: true,
+        },
+        assessedBy: "safety-manager",
+      },
+      actionProposals: [
+        {
+          id: source.proposal.id,
+          proposalType: "sop_change",
+          status: "completed",
+          summary: "Update safety procedure",
+          rationale: "Meeting review identified required follow-up.",
+          proposedOwner: "Safety Manager",
+          createdBy: "safety-manager",
+          decisions: [
+            expect.objectContaining({
+              id: source.acceptDecision.id,
+              decision: "accepted",
+              decidedBy: "accountable-manager",
+              decisionNotes: "Accepted for implementation.",
+            }),
+            expect.objectContaining({
+              id: source.completeDecision.id,
+              decision: "completed",
+              decidedBy: "safety-manager",
+              decisionNotes: "Action completed.",
+            }),
+          ],
+          implementationEvidence: [
+            expect.objectContaining({
+              id: source.implementationEvidence.id,
+              evidenceCategory: "sop_implementation",
+              implementationSummary: "Procedure update completed",
+              evidenceReference: "DOC-SAFETY-001",
+              completedBy: "safety-manager",
+              reviewedBy: "accountable-manager",
+              reviewNotes: "Closure evidence reviewed.",
+            }),
+          ],
+        },
+      ],
+    });
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("exports multiple agenda-linked safety events for one meeting", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const sop = await createAgendaLinkedEvent(meeting.id, {
+      eventType: "sop_breach",
+      summary: "SOP breach review",
+      agendaItem: "Review SOP breach",
+    });
+    const training = await createAgendaLinkedEvent(meeting.id, {
+      eventType: "training_need",
+      severity: "medium",
+      summary: "Training action review",
+      agendaItem: "Review training need",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get(
+      `/air-safety-meetings/${meeting.id}/export`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.export.agendaItems).toHaveLength(2);
+    expect(
+      response.body.export.agendaItems.map(
+        (item: { safetyEvent: { id: string } }) => item.safetyEvent.id,
+      ),
+    ).toEqual(expect.arrayContaining([sop.event.id, training.event.id]));
+    expect(
+      response.body.export.agendaItems.map(
+        (item: { link: { agendaItem: string } }) => item.link.agendaItem,
+      ),
+    ).toEqual(
+      expect.arrayContaining(["Review SOP breach", "Review training need"]),
+    );
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("represents missing proposals, decisions, and closure evidence as empty arrays", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const source = await createAgendaLinkedEvent(meeting.id);
+    const proposalResponse = await request(app)
+      .post(`/safety-events/${source.event.id}/agenda-links/${source.agendaLink.id}/action-proposals`)
+      .send({
+        proposalType: "general_safety_action",
+        summary: "Track meeting action without decision yet",
+      });
+
+    expect(proposalResponse.status).toBe(201);
+    const before = await countRows();
+
+    const response = await request(app).get(
+      `/air-safety-meetings/${meeting.id}/export`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.export.agendaItems[0].actionProposals).toEqual([
+      expect.objectContaining({
+        id: proposalResponse.body.proposal.id,
+        status: "proposed",
+        decisions: [],
+        implementationEvidence: [],
+      }),
+    ]);
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("does not leak meeting pack records from other meetings", async () => {
+    const firstMeeting = await createEventTriggeredMeeting();
+    const secondMeeting = await createEventTriggeredMeeting();
+    const secondSource = await createCompletedActionWithEvidence(
+      secondMeeting.id,
+      {
+        eventType: "maintenance_concern",
+        proposalType: "maintenance_action",
+        evidenceCategory: "maintenance_completion",
+      },
+    );
+    const firstBefore = await countRows();
+
+    const response = await request(app).get(
+      `/air-safety-meetings/${firstMeeting.id}/export`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.export.meetingId).toBe(firstMeeting.id);
+    expect(response.body.export.agendaItems).toEqual([]);
+    expect(JSON.stringify(response.body.export)).not.toContain(
+      secondSource.event.id,
+    );
+    expect(await countRows()).toEqual(firstBefore);
+  });
+
+  it("rejects invalid or missing meeting pack export IDs", async () => {
+    const before = await countRows();
+    const invalidResponse = await request(app).get(
+      "/air-safety-meetings/not-a-uuid/export",
+    );
+    const missingResponse = await request(app).get(
+      `/air-safety-meetings/${randomUUID()}/export`,
+    );
+
+    expect(invalidResponse.status).toBe(400);
+    expect(invalidResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_validation_failed",
+    });
+    expect(missingResponse.status).toBe(404);
+    expect(missingResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_not_found",
+    });
+    expect(await countRows()).toEqual(before);
   });
 
   it("rejects invalid air safety meeting records", async () => {


### PR DESCRIPTION
## Summary

Implements GitHub issue #79 by adding a read-only safety meeting pack export endpoint.

## What changed

- Added `GET /air-safety-meetings/:meetingId/export`.
- Added typed meeting pack export models covering:
  - air safety meeting record
  - agenda links
  - linked safety events
  - meeting trigger context
  - action proposals
  - action decisions
  - implementation closure evidence
- Added repository export query that assembles the full meeting pack from existing tables.
- Added validation and 404 handling for meeting pack export IDs.
- Added integration coverage for:
  - empty/no-agenda meeting packs
  - populated meeting packs
  - multiple agenda-linked safety events
  - proposals with missing decisions/evidence represented as empty arrays
  - meeting isolation
  - invalid/missing meeting IDs
  - no source-record mutation
- Updated the save point to the next build step.

## Verification

- `npm.cmd ci` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 13 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 260 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `node scripts\\check-next-build-step-pr.mjs origin/main` passed.
- `git diff --cached --check` passed.
- `npm.cmd run build` still cannot run because the repo does not currently have a root `tsconfig.json`; `tsc` prints compiler help text.

Closes #79.
