### PR TITLE
Add root TypeScript compile config

### DIFF
--- a/src/airspace-compliance/airspace-compliance.validators.ts
+++ b/src/airspace-compliance/airspace-compliance.validators.ts
@@ -33,7 +33,7 @@ function requiredEnum<T extends string>(
 }
 
 function requiredNonNegativeInteger(value: unknown, fieldName: string): number {
-  if (!Number.isInteger(value) || value < 0) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
     throw new AirspaceComplianceValidationError(
       `${fieldName} must be a non-negative integer`,
     );

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -1,4 +1,4 @@
-import type { Pool } from "pg";
+import type { Pool, PoolClient } from "pg";
 import type { MissionReadinessCheck } from "../missions/mission-readiness.types";
 import { MissionService } from "../missions/mission.service";
 import {
@@ -461,7 +461,7 @@ export class AuditEvidenceService {
   }
 
   private async buildPostOperationCompletionSnapshot(
-    client: Awaited<ReturnType<Pool["connect"]>>,
+    client: PoolClient,
     mission: { missionId: string; missionPlanId: string | null; status: string },
   ): Promise<PostOperationCompletionSnapshot> {
     const events =

--- a/src/platforms/platform.validators.ts
+++ b/src/platforms/platform.validators.ts
@@ -63,7 +63,7 @@ function optionalPositiveInteger(value: unknown, fieldName: string): number | nu
     return null;
   }
 
-  if (!Number.isInteger(value) || value <= 0) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
     throw new PlatformValidationError(`${fieldName} must be a positive integer`);
   }
 

--- a/src/safety-events/safety-event.service.ts
+++ b/src/safety-events/safety-event.service.ts
@@ -1,4 +1,4 @@
-import type { Pool } from "pg";
+import type { Pool, PoolClient } from "pg";
 import {
   SafetyEventAgendaLinkConflictError,
   SafetyEventAgendaLinkNotFoundError,
@@ -512,7 +512,7 @@ export class SafetyEventService {
   }
 
   private async validateReferences(
-    client: Awaited<ReturnType<Pool["connect"]>>,
+    client: PoolClient,
     input: ReturnType<typeof validateCreateSafetyEventInput>,
   ): Promise<void> {
     await this.validateReference(client, "missions", input.missionId, "mission");
@@ -538,7 +538,7 @@ export class SafetyEventService {
   }
 
   private async validateReference(
-    client: Awaited<ReturnType<Pool["connect"]>>,
+    client: PoolClient,
     tableName:
       | "missions"
       | "platforms"
@@ -575,7 +575,7 @@ export class SafetyEventService {
   }
 
   private async getValidatedAgendaLink(
-    client: Awaited<ReturnType<Pool["connect"]>>,
+    client: PoolClient,
     eventId: string,
     agendaLinkId: string,
   ): Promise<SafetyEventAgendaLink> {
@@ -602,7 +602,7 @@ export class SafetyEventService {
   }
 
   private async getValidatedProposal(
-    client: Awaited<ReturnType<Pool["connect"]>>,
+    client: PoolClient,
     eventId: string,
     agendaLinkId: string,
     proposalId: string,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "lib": ["ES2022"],
+    "strict": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Implements GitHub issue #81 by adding a root TypeScript project configuration so `npm run build` performs a real compile check instead of printing `tsc` help text.

## What changed

- Added root `tsconfig.json`.
- Configured `npm run build` as a no-emit production TypeScript compile check.
- Excluded test files from the production build gate for this first config step.
- Fixed minimal production type issues exposed by the new compile gate:
  - narrowed numeric validator inputs before numeric comparisons
  - replaced overloaded `Awaited<ReturnType<Pool["connect"]>>` helper parameter types with explicit `PoolClient`

## Verification

- `npm.cmd ci` passed.
- `npm.cmd run build` passed and now runs `tsc` as a real compile check.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/airspace-compliance.test.ts src/tests/platform-maintenance.test.ts src/tests/audit-evidence.test.ts src/tests/safety-events.test.ts` passed: 81 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 260 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `node scripts\\check-next-build-step-pr.mjs origin/main` passed.
- `git diff --cached --check` passed.

Closes #81.
