### PR TITLE
Add safety meeting pack rendered report

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add safety meeting pack rendered report endpoint so meeting exports can be reviewed as regulator-ready meeting packs.",
+ "nextBuildStep": "Add safety meeting pack PDF generation endpoint so rendered meeting packs can be downloaded for formal review.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/air-safety-meetings/air-safety-meeting.controller.ts
+++ b/src/air-safety-meetings/air-safety-meeting.controller.ts
@@ -65,4 +65,20 @@ export class AirSafetyMeetingController {
       next(error);
     }
   };
+
+  renderAirSafetyMeetingPack = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const report =
+        await this.airSafetyMeetingService.renderAirSafetyMeetingPack(
+          req.params.meetingId,
+        );
+      res.status(200).json({ report });
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/air-safety-meetings/air-safety-meeting.routes.ts
+++ b/src/air-safety-meetings/air-safety-meeting.routes.ts
@@ -9,6 +9,7 @@ export function createAirSafetyMeetingRouter(
   router.post("/", controller.createAirSafetyMeeting);
   router.get("/", controller.listAirSafetyMeetings);
   router.get("/quarterly-compliance", controller.getQuarterlyCompliance);
+  router.get("/:meetingId/export/render", controller.renderAirSafetyMeetingPack);
   router.get("/:meetingId/export", controller.exportAirSafetyMeetingPack);
 
   return router;

--- a/src/air-safety-meetings/air-safety-meeting.service.ts
+++ b/src/air-safety-meetings/air-safety-meeting.service.ts
@@ -3,7 +3,11 @@ import { AirSafetyMeetingNotFoundError } from "./air-safety-meeting.errors";
 import { AirSafetyMeetingRepository } from "./air-safety-meeting.repository";
 import type {
   AirSafetyMeeting,
+  AirSafetyMeetingPackExportActionProposal,
+  AirSafetyMeetingPackExportAgendaItem,
   AirSafetyMeetingPackExport,
+  AirSafetyMeetingPackRenderedReport,
+  AirSafetyMeetingReportSection,
   CreateAirSafetyMeetingInput,
   QuarterlyAirSafetyMeetingCompliance,
   QuarterlyComplianceStatus,
@@ -99,6 +103,25 @@ export class AirSafetyMeetingService {
     }
   }
 
+  async renderAirSafetyMeetingPack(
+    meetingIdInput: unknown,
+  ): Promise<AirSafetyMeetingPackRenderedReport> {
+    const meetingExport = await this.exportAirSafetyMeetingPack(meetingIdInput);
+    const sections = this.buildMeetingPackReportSections(meetingExport);
+
+    return {
+      renderType: "air_safety_meeting_pack_report",
+      formatVersion: 1,
+      generatedAt: new Date().toISOString(),
+      sourceExport: meetingExport,
+      report: {
+        title: `Air safety meeting pack for meeting ${meetingExport.meetingId}`,
+        sections,
+        plainText: this.renderSectionsAsPlainText(sections),
+      },
+    };
+  }
+
   private buildQuarterlyCompliance(
     asOf: Date,
     lastCompletedMeeting: AirSafetyMeeting | null,
@@ -173,5 +196,230 @@ export class AirSafetyMeetingService {
     const result = new Date(value.getTime());
     result.setUTCMonth(result.getUTCMonth() + months);
     return result;
+  }
+
+  private buildMeetingPackReportSections(
+    meetingExport: AirSafetyMeetingPackExport,
+  ): AirSafetyMeetingReportSection[] {
+    const meeting = meetingExport.meeting;
+    const sections: AirSafetyMeetingReportSection[] = [
+      {
+        heading: "Meeting summary",
+        fields: [
+          { label: "Meeting ID", value: meeting.id },
+          { label: "Meeting type", value: meeting.meetingType },
+          { label: "Status", value: meeting.status },
+          { label: "Due at", value: meeting.dueAt },
+          { label: "Held at", value: meeting.heldAt },
+          { label: "Chairperson", value: meeting.chairperson },
+          {
+            label: "Attendees",
+            value:
+              meeting.attendees.length > 0
+                ? meeting.attendees.join(", ")
+                : "No attendees recorded",
+          },
+          { label: "Created by", value: meeting.createdBy },
+          { label: "Created at", value: meeting.createdAt },
+          { label: "Closed at", value: meeting.closedAt },
+          { label: "Export generated at", value: meetingExport.generatedAt },
+        ],
+      },
+      {
+        heading: "Meeting metadata",
+        fields: [
+          {
+            label: "Scheduled period start",
+            value: meeting.scheduledPeriodStart,
+          },
+          {
+            label: "Scheduled period end",
+            value: meeting.scheduledPeriodEnd,
+          },
+          {
+            label: "Standing agenda",
+            value:
+              meeting.agenda.length > 0
+                ? meeting.agenda.join("; ")
+                : "No standing agenda recorded",
+          },
+          { label: "Minutes", value: meeting.minutes },
+        ],
+      },
+    ];
+
+    if (meetingExport.agendaItems.length === 0) {
+      sections.push({
+        heading: "Agenda-linked safety events",
+        fields: [
+          {
+            label: "Agenda items",
+            value: "No agenda-linked safety events recorded",
+          },
+          {
+            label: "Action proposals",
+            value: "No safety action proposals recorded",
+          },
+          {
+            label: "Implementation closure evidence",
+            value: "No implementation closure evidence recorded",
+          },
+        ],
+      });
+      return sections;
+    }
+
+    meetingExport.agendaItems.forEach((item, index) => {
+      sections.push(this.buildAgendaItemSection(item, index));
+
+      if (item.actionProposals.length === 0) {
+        sections.push({
+          heading: `Agenda item ${index + 1} actions`,
+          fields: [
+            {
+              label: "Action proposals",
+              value: "No safety action proposals recorded",
+            },
+            {
+              label: "Decision history",
+              value: "No action decisions recorded",
+            },
+            {
+              label: "Implementation closure evidence",
+              value: "No implementation closure evidence recorded",
+            },
+          ],
+        });
+        return;
+      }
+
+      item.actionProposals.forEach((proposal, proposalIndex) => {
+        sections.push(
+          this.buildActionProposalSection(index, proposalIndex, proposal),
+        );
+      });
+    });
+
+    return sections;
+  }
+
+  private buildAgendaItemSection(
+    item: AirSafetyMeetingPackExportAgendaItem,
+    index: number,
+  ): AirSafetyMeetingReportSection {
+    return {
+      heading: `Agenda item ${index + 1}`,
+      fields: [
+        { label: "Agenda link ID", value: item.link.id },
+        { label: "Agenda item", value: item.link.agendaItem },
+        { label: "Linked by", value: item.link.linkedBy },
+        { label: "Linked at", value: item.link.linkedAt },
+        { label: "Safety event ID", value: item.safetyEvent.id },
+        { label: "Safety event type", value: item.safetyEvent.eventType },
+        { label: "Severity", value: item.safetyEvent.severity },
+        { label: "Event status", value: item.safetyEvent.status },
+        { label: "Event summary", value: item.safetyEvent.summary },
+        { label: "SOP reference", value: item.safetyEvent.sopReference },
+        { label: "Meeting required", value: item.meetingTrigger.meetingRequired },
+        {
+          label: "Recommended meeting type",
+          value: item.meetingTrigger.recommendedMeetingType,
+        },
+        {
+          label: "Trigger reasons",
+          value:
+            item.meetingTrigger.triggerReasons.length > 0
+              ? item.meetingTrigger.triggerReasons.join(", ")
+              : "No trigger reasons recorded",
+        },
+        {
+          label: "Review flags",
+          value: this.renderReviewFlags(item.meetingTrigger.reviewFlags),
+        },
+        { label: "Assessed by", value: item.meetingTrigger.assessedBy },
+        { label: "Assessed at", value: item.meetingTrigger.assessedAt },
+      ],
+    };
+  }
+
+  private buildActionProposalSection(
+    agendaIndex: number,
+    proposalIndex: number,
+    proposal: AirSafetyMeetingPackExportActionProposal,
+  ): AirSafetyMeetingReportSection {
+    const prefix = `Agenda item ${agendaIndex + 1} action ${proposalIndex + 1}`;
+
+    return {
+      heading: prefix,
+      fields: [
+        { label: "Action proposal ID", value: proposal.id },
+        { label: "Proposal type", value: proposal.proposalType },
+        { label: "Proposal status", value: proposal.status },
+        { label: "Proposal summary", value: proposal.summary },
+        { label: "Rationale", value: proposal.rationale },
+        { label: "Proposed owner", value: proposal.proposedOwner },
+        { label: "Proposed due at", value: proposal.proposedDueAt },
+        { label: "Created by", value: proposal.createdBy },
+        {
+          label: "Decision history",
+          value:
+            proposal.decisions.length > 0
+              ? proposal.decisions
+                  .map((decision) =>
+                    [
+                      decision.decision,
+                      decision.decidedBy ?? "actor not recorded",
+                      decision.decidedAt,
+                      decision.decisionNotes ?? "no notes",
+                    ].join(" | "),
+                  )
+                  .join("; ")
+              : "No action decisions recorded",
+        },
+        {
+          label: "Implementation closure evidence",
+          value:
+            proposal.implementationEvidence.length > 0
+              ? proposal.implementationEvidence
+                  .map((evidence) =>
+                    [
+                      evidence.evidenceCategory,
+                      evidence.implementationSummary,
+                      evidence.evidenceReference ?? "no reference",
+                      evidence.completedBy ?? "completed by not recorded",
+                      evidence.completedAt,
+                      evidence.reviewedBy ?? "reviewer not recorded",
+                      evidence.reviewNotes ?? "no review notes",
+                    ].join(" | "),
+                  )
+                  .join("; ")
+              : "No implementation closure evidence recorded",
+        },
+      ],
+    };
+  }
+
+  private renderReviewFlags(flags: Record<string, boolean>): string {
+    const enabledFlags = Object.entries(flags)
+      .filter(([, enabled]) => enabled)
+      .map(([flag]) => flag);
+
+    return enabledFlags.length > 0
+      ? enabledFlags.join(", ")
+      : "No review flags recorded";
+  }
+
+  private renderSectionsAsPlainText(
+    sections: AirSafetyMeetingReportSection[],
+  ): string {
+    return sections
+      .map((section) => {
+        const fields = section.fields
+          .map((field) => `${field.label}: ${field.value ?? "Not recorded"}`)
+          .join("\n");
+
+        return `${section.heading}\n${fields}`;
+      })
+      .join("\n\n");
   }
 }

--- a/src/air-safety-meetings/air-safety-meeting.types.ts
+++ b/src/air-safety-meetings/air-safety-meeting.types.ts
@@ -158,3 +158,25 @@ export interface AirSafetyMeetingPackExport {
   meeting: AirSafetyMeeting;
   agendaItems: AirSafetyMeetingPackExportAgendaItem[];
 }
+
+export interface AirSafetyMeetingReportField {
+  label: string;
+  value: string | number | boolean | null;
+}
+
+export interface AirSafetyMeetingReportSection {
+  heading: string;
+  fields: AirSafetyMeetingReportField[];
+}
+
+export interface AirSafetyMeetingPackRenderedReport {
+  renderType: "air_safety_meeting_pack_report";
+  formatVersion: 1;
+  generatedAt: string;
+  sourceExport: AirSafetyMeetingPackExport;
+  report: {
+    title: string;
+    sections: AirSafetyMeetingReportSection[];
+    plainText: string;
+  };
+}

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -542,6 +542,226 @@ describe("air safety meetings", () => {
     expect(await countRows()).toEqual(before);
   });
 
+  it("renders an empty safety meeting pack without mutating source records", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const before = await countRows();
+
+    const response = await request(app).get(
+      `/air-safety-meetings/${meeting.id}/export/render`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.report).toMatchObject({
+      renderType: "air_safety_meeting_pack_report",
+      formatVersion: 1,
+      sourceExport: {
+        exportType: "air_safety_meeting_pack",
+        meetingId: meeting.id,
+        agendaItems: [],
+      },
+      report: {
+        title: `Air safety meeting pack for meeting ${meeting.id}`,
+        sections: [
+          expect.objectContaining({
+            heading: "Meeting summary",
+            fields: expect.arrayContaining([
+              { label: "Meeting ID", value: meeting.id },
+              { label: "Meeting type", value: "event_triggered_safety_review" },
+              { label: "Status", value: "scheduled" },
+            ]),
+          }),
+          expect.objectContaining({
+            heading: "Meeting metadata",
+            fields: expect.arrayContaining([
+              {
+                label: "Standing agenda",
+                value: "Review safety events; Review action closure",
+              },
+            ]),
+          }),
+          {
+            heading: "Agenda-linked safety events",
+            fields: [
+              {
+                label: "Agenda items",
+                value: "No agenda-linked safety events recorded",
+              },
+              {
+                label: "Action proposals",
+                value: "No safety action proposals recorded",
+              },
+              {
+                label: "Implementation closure evidence",
+                value: "No implementation closure evidence recorded",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(response.body.report.generatedAt).toEqual(expect.any(String));
+    expect(response.body.report.report.plainText).toContain(
+      "Agenda items: No agenda-linked safety events recorded",
+    );
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("renders agenda events, trigger rationale, decisions, and closure evidence", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const source = await createCompletedActionWithEvidence(meeting.id);
+    const before = await countRows();
+
+    const response = await request(app).get(
+      `/air-safety-meetings/${meeting.id}/export/render`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.report.report.sections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          heading: "Agenda item 1",
+          fields: expect.arrayContaining([
+            { label: "Agenda link ID", value: source.agendaLink.id },
+            {
+              label: "Agenda item",
+              value: "Review completed action evidence",
+            },
+            { label: "Safety event ID", value: source.event.id },
+            { label: "Safety event type", value: "sop_breach" },
+            { label: "Severity", value: "high" },
+            { label: "Event summary", value: "Safety event for meeting pack" },
+            { label: "Recommended meeting type", value: "sop_breach_review" },
+            {
+              label: "Trigger reasons",
+              value: "severity:high, event_type:sop_breach",
+            },
+            { label: "Review flags", value: "sopReviewRequired" },
+          ]),
+        }),
+        expect.objectContaining({
+          heading: "Agenda item 1 action 1",
+          fields: expect.arrayContaining([
+            { label: "Action proposal ID", value: source.proposal.id },
+            { label: "Proposal type", value: "sop_change" },
+            { label: "Proposal status", value: "completed" },
+            { label: "Proposal summary", value: "Update safety procedure" },
+            {
+              label: "Decision history",
+              value: expect.stringContaining("accepted | accountable-manager"),
+            },
+            {
+              label: "Implementation closure evidence",
+              value: expect.stringContaining(
+                "sop_implementation | Procedure update completed",
+              ),
+            },
+          ]),
+        }),
+      ]),
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Meeting summary",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Decision history: accepted | accountable-manager",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Implementation closure evidence: sop_implementation | Procedure update completed",
+    );
+    expect(response.body.report.report.title).toBe(
+      `Air safety meeting pack for meeting ${meeting.id}`,
+    );
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("renders multiple agenda items and empty action states clearly", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const sop = await createAgendaLinkedEvent(meeting.id, {
+      eventType: "sop_breach",
+      agendaItem: "Review SOP breach",
+    });
+    const training = await createAgendaLinkedEvent(meeting.id, {
+      eventType: "training_need",
+      severity: "medium",
+      agendaItem: "Review training need",
+    });
+    const proposalResponse = await request(app)
+      .post(`/safety-events/${training.event.id}/agenda-links/${training.agendaLink.id}/action-proposals`)
+      .send({
+        proposalType: "training_action",
+        summary: "Training action proposed",
+      });
+
+    expect(proposalResponse.status).toBe(201);
+    const before = await countRows();
+
+    const response = await request(app).get(
+      `/air-safety-meetings/${meeting.id}/export/render`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.report.sourceExport.agendaItems).toHaveLength(2);
+    expect(response.body.report.report.plainText).toContain(
+      `Safety event ID: ${sop.event.id}`,
+    );
+    expect(response.body.report.report.plainText).toContain(
+      `Safety event ID: ${training.event.id}`,
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Decision history: No action decisions recorded",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Implementation closure evidence: No implementation closure evidence recorded",
+    );
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("does not leak rendered safety meeting pack records from other meetings", async () => {
+    const firstMeeting = await createEventTriggeredMeeting();
+    const secondMeeting = await createEventTriggeredMeeting();
+    const secondSource = await createCompletedActionWithEvidence(
+      secondMeeting.id,
+      {
+        eventType: "maintenance_concern",
+        proposalType: "maintenance_action",
+        evidenceCategory: "maintenance_completion",
+      },
+    );
+    const before = await countRows();
+
+    const response = await request(app).get(
+      `/air-safety-meetings/${firstMeeting.id}/export/render`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.report.sourceExport.meetingId).toBe(firstMeeting.id);
+    expect(response.body.report.sourceExport.agendaItems).toEqual([]);
+    expect(JSON.stringify(response.body.report)).not.toContain(
+      secondSource.event.id,
+    );
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("rejects invalid or missing rendered meeting pack IDs", async () => {
+    const before = await countRows();
+    const invalidResponse = await request(app).get(
+      "/air-safety-meetings/not-a-uuid/export/render",
+    );
+    const missingResponse = await request(app).get(
+      `/air-safety-meetings/${randomUUID()}/export/render`,
+    );
+
+    expect(invalidResponse.status).toBe(400);
+    expect(invalidResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_validation_failed",
+    });
+    expect(missingResponse.status).toBe(404);
+    expect(missingResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_not_found",
+    });
+    expect(await countRows()).toEqual(before);
+  });
+
   it("rejects invalid air safety meeting records", async () => {
     const completedWithoutHeldAt = await request(app)
       .post("/air-safety-meetings")


### PR DESCRIPTION
## Summary

Implements GitHub issue #83 by adding a rendered safety meeting pack report endpoint for regulator-ready review packs.

## What changed

- Added `GET /air-safety-meetings/:meetingId/export/render`.
- Added rendered meeting-pack report types with:
  - render type
  - format version
  - generated timestamp
  - source export package
  - report title
  - report sections
  - plain text output
- Added rendering logic built from the existing structured meeting-pack export.
- Rendered sections now cover:
  - meeting summary
  - meeting metadata
  - agenda-linked safety events
  - trigger rationale and review flags
  - action proposals
  - decision history
  - implementation closure evidence
  - explicit empty-state wording where applicable
- Added integration coverage for:
  - populated rendered meeting packs
  - empty rendered meeting packs
  - multiple agenda items
  - proposals with and without closure evidence
  - meeting isolation
  - invalid/missing meeting ID handling
  - no mutation of source records
- Updated the save point to the next build step.

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 18 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 265 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `node scripts\\check-next-build-step-pr.mjs origin/main` passed.
- `git diff --cached --check` passed.

Closes #83.
