### PR TITLE
Add safety meeting pack PDF generation

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add safety meeting pack PDF generation endpoint so rendered meeting packs can be downloaded for formal review.",
+ "nextBuildStep": "Add accountable-manager signature block to safety meeting pack PDF reports so formal meeting reviews can be signed off.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/air-safety-meetings/air-safety-meeting.controller.ts
+++ b/src/air-safety-meetings/air-safety-meeting.controller.ts
@@ -81,4 +81,28 @@ export class AirSafetyMeetingController {
       next(error);
     }
   };
+
+  generateAirSafetyMeetingPackPdf = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const pdf =
+        await this.airSafetyMeetingService.generateAirSafetyMeetingPackPdf(
+          req.params.meetingId,
+        );
+      res
+        .status(200)
+        .setHeader("Content-Type", pdf.contentType)
+        .setHeader(
+          "Content-Disposition",
+          `attachment; filename="${pdf.fileName}"`,
+        )
+        .setHeader("Content-Length", pdf.content.byteLength.toString())
+        .send(pdf.content);
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/air-safety-meetings/air-safety-meeting.routes.ts
+++ b/src/air-safety-meetings/air-safety-meeting.routes.ts
@@ -9,6 +9,7 @@ export function createAirSafetyMeetingRouter(
   router.post("/", controller.createAirSafetyMeeting);
   router.get("/", controller.listAirSafetyMeetings);
   router.get("/quarterly-compliance", controller.getQuarterlyCompliance);
+  router.get("/:meetingId/export/pdf", controller.generateAirSafetyMeetingPackPdf);
   router.get("/:meetingId/export/render", controller.renderAirSafetyMeetingPack);
   router.get("/:meetingId/export", controller.exportAirSafetyMeetingPack);
 

--- a/src/air-safety-meetings/air-safety-meeting.service.ts
+++ b/src/air-safety-meetings/air-safety-meeting.service.ts
@@ -6,6 +6,7 @@ import type {
   AirSafetyMeetingPackExportActionProposal,
   AirSafetyMeetingPackExportAgendaItem,
   AirSafetyMeetingPackExport,
+  AirSafetyMeetingPackPdf,
   AirSafetyMeetingPackRenderedReport,
   AirSafetyMeetingReportSection,
   CreateAirSafetyMeetingInput,
@@ -119,6 +120,23 @@ export class AirSafetyMeetingService {
         sections,
         plainText: this.renderSectionsAsPlainText(sections),
       },
+    };
+  }
+
+  async generateAirSafetyMeetingPackPdf(
+    meetingIdInput: unknown,
+  ): Promise<AirSafetyMeetingPackPdf> {
+    const renderedReport = await this.renderAirSafetyMeetingPack(meetingIdInput);
+    const content = this.buildSimplePdf([
+      renderedReport.report.title,
+      "",
+      renderedReport.report.plainText,
+    ]);
+
+    return {
+      fileName: `air-safety-meeting-${renderedReport.sourceExport.meetingId}-pack.pdf`,
+      contentType: "application/pdf",
+      content,
     };
   }
 
@@ -421,5 +439,70 @@ export class AirSafetyMeetingService {
         return `${section.heading}\n${fields}`;
       })
       .join("\n\n");
+  }
+
+  private buildSimplePdf(lines: string[]): Buffer {
+    const flattenedLines = lines.flatMap((line) => this.wrapPdfText(line, 92));
+    const contentLines = flattenedLines
+      .map((line, index) => {
+        const y = 780 - index * 14;
+        return `BT /F1 10 Tf 40 ${y} Td (${this.escapePdfText(line)}) Tj ET`;
+      })
+      .join("\n");
+
+    const contentStream = `${contentLines}\n`;
+    const objects = [
+      "<< /Type /Catalog /Pages 2 0 R >>",
+      "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+      "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+      "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+      `<< /Length ${Buffer.byteLength(contentStream, "latin1")} >>\nstream\n${contentStream}endstream`,
+    ];
+
+    let pdf = "%PDF-1.4\n";
+    const offsets = [0];
+
+    objects.forEach((object, index) => {
+      offsets.push(Buffer.byteLength(pdf, "latin1"));
+      pdf += `${index + 1} 0 obj\n${object}\nendobj\n`;
+    });
+
+    const xrefOffset = Buffer.byteLength(pdf, "latin1");
+    pdf += `xref\n0 ${objects.length + 1}\n`;
+    pdf += "0000000000 65535 f \n";
+    pdf += offsets
+      .slice(1)
+      .map((offset) => `${String(offset).padStart(10, "0")} 00000 n \n`)
+      .join("");
+    pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n`;
+    pdf += `startxref\n${xrefOffset}\n%%EOF\n`;
+
+    return Buffer.from(pdf, "latin1");
+  }
+
+  private wrapPdfText(line: string, maxLength: number): string[] {
+    if (line.length <= maxLength) {
+      return [line];
+    }
+
+    const wrapped: string[] = [];
+    let remaining = line;
+
+    while (remaining.length > maxLength) {
+      const breakAt = remaining.lastIndexOf(" ", maxLength);
+      const splitAt = breakAt > 0 ? breakAt : maxLength;
+      wrapped.push(remaining.slice(0, splitAt));
+      remaining = remaining.slice(splitAt).trimStart();
+    }
+
+    wrapped.push(remaining);
+    return wrapped;
+  }
+
+  private escapePdfText(value: string): string {
+    return value
+      .replace(/\\/g, "\\\\")
+      .replace(/\(/g, "\\(")
+      .replace(/\)/g, "\\)");
   }
 }

--- a/src/air-safety-meetings/air-safety-meeting.types.ts
+++ b/src/air-safety-meetings/air-safety-meeting.types.ts
@@ -180,3 +180,9 @@ export interface AirSafetyMeetingPackRenderedReport {
     plainText: string;
   };
 }
+
+export interface AirSafetyMeetingPackPdf {
+  fileName: string;
+  contentType: "application/pdf";
+  content: Buffer;
+}

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -4,6 +4,19 @@ import app, { pool } from "../app";
 import { runMigrations } from "../migrations/runMigrations";
 import { randomUUID } from "crypto";
 
+const parseBinaryResponse = (
+  res: NodeJS.ReadableStream,
+  callback: (error: Error | null, body?: Buffer) => void,
+) => {
+  const chunks: Buffer[] = [];
+
+  res.on("data", (chunk) => {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  });
+  res.on("end", () => callback(null, Buffer.concat(chunks)));
+  res.on("error", (error) => callback(error));
+};
+
 const clearTables = async () => {
   await pool.query("delete from safety_action_implementation_evidence");
   await pool.query("delete from safety_action_decisions");
@@ -739,6 +752,120 @@ describe("air safety meetings", () => {
     expect(JSON.stringify(response.body.report)).not.toContain(
       secondSource.event.id,
     );
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("generates a populated safety meeting pack PDF without mutating source records", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const source = await createCompletedActionWithEvidence(meeting.id);
+    const before = await countRows();
+
+    const response = await request(app)
+      .get(`/air-safety-meetings/${meeting.id}/export/pdf`)
+      .buffer(true)
+      .parse(parseBinaryResponse);
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("application/pdf");
+    expect(response.headers["content-disposition"]).toContain("attachment");
+    expect(response.headers["content-disposition"]).toContain(
+      `air-safety-meeting-${meeting.id}-pack.pdf`,
+    );
+    expect(Buffer.isBuffer(response.body)).toBe(true);
+    expect(response.body.toString("latin1", 0, 8)).toBe("%PDF-1.4");
+    expect(response.body.toString("latin1")).toContain(
+      `Air safety meeting pack for meeting ${meeting.id}`,
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Agenda link ID:",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      source.agendaLink.id,
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Decision history: accepted |",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "accountable-manager",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Implementation closure evidence: sop_implementation | Procedure update completed",
+    );
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("generates an empty safety meeting pack PDF with explicit empty-state wording", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const before = await countRows();
+
+    const response = await request(app)
+      .get(`/air-safety-meetings/${meeting.id}/export/pdf`)
+      .buffer(true)
+      .parse(parseBinaryResponse);
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("application/pdf");
+    expect(response.body.toString("latin1")).toContain(
+      `Air safety meeting pack for meeting ${meeting.id}`,
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Agenda-linked safety events",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "agenda-linked safety events recorded",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "No safety action proposals",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "No implementation closure evidence recorded",
+    );
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("does not leak safety meeting pack PDF records from other meetings", async () => {
+    const firstMeeting = await createEventTriggeredMeeting();
+    const secondMeeting = await createEventTriggeredMeeting();
+    const secondSource = await createCompletedActionWithEvidence(
+      secondMeeting.id,
+      {
+        eventType: "maintenance_concern",
+        proposalType: "maintenance_action",
+        evidenceCategory: "maintenance_completion",
+      },
+    );
+    const before = await countRows();
+
+    const response = await request(app)
+      .get(`/air-safety-meetings/${firstMeeting.id}/export/pdf`)
+      .buffer(true)
+      .parse(parseBinaryResponse);
+
+    expect(response.status).toBe(200);
+    expect(response.body.toString("latin1")).toContain(
+      `Air safety meeting pack for meeting ${firstMeeting.id}`,
+    );
+    expect(response.body.toString("latin1")).not.toContain(secondSource.event.id);
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("rejects invalid or missing safety meeting pack PDF IDs", async () => {
+    const before = await countRows();
+    const invalidResponse = await request(app).get(
+      "/air-safety-meetings/not-a-uuid/export/pdf",
+    );
+    const missingResponse = await request(app).get(
+      `/air-safety-meetings/${randomUUID()}/export/pdf`,
+    );
+
+    expect(invalidResponse.status).toBe(400);
+    expect(invalidResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_validation_failed",
+    });
+    expect(missingResponse.status).toBe(404);
+    expect(missingResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_not_found",
+    });
     expect(await countRows()).toEqual(before);
   });
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #85 by adding a PDF generation endpoint for rendered safety meeting packs.

## What changed

- Added `GET /air-safety-meetings/:meetingId/export/pdf`.
- Added `AirSafetyMeetingPackPdf` response type.
- Added PDF generation built from the existing rendered meeting-pack report instead of introducing a separate query path.
- Reused the existing simple PDF generation pattern already used for audit evidence exports.
- Added integration coverage for:
  - populated meeting-pack PDF generation
  - empty-state meeting-pack PDF generation
  - meeting isolation
  - invalid/missing meeting ID handling
  - no mutation of source records
- Updated the save point to the next build step.

## Verification

- `npm.cmd ci` passed.
- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 22 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 269 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `git diff --cached --check` passed.

## Notes

`node scripts\\check-next-build-step-pr.mjs origin/main` did not run correctly in this Windows worktree because its internal `git diff` call did not inherit the worktree context. Direct git diff inspection confirmed this PR only changes air-safety meeting files, tests, and the save point.

Closes #85.
