### PR TITLE
Add stored air safety meeting signoffs

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add stored safety meeting sign-off records so accountable-manager meeting pack approvals can be captured and audited.",
+ "nextBuildStep": "Connect stored safety meeting sign-offs into rendered and PDF meeting pack outputs so placeholders are replaced by audited approval data.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Connect stored safety meeting sign-offs into rendered and PDF meeting pack outputs so placeholders are replaced by audited approval data.",
+ "nextBuildStep": "Connect migration-backed safety meeting sign-off records into rendered and PDF meeting pack outputs so placeholders are replaced by audited approval data.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/air-safety-meetings/air-safety-meeting.controller.ts
+++ b/src/air-safety-meetings/air-safety-meeting.controller.ts
@@ -34,6 +34,39 @@ export class AirSafetyMeetingController {
     }
   };
 
+  createAirSafetyMeetingSignoff = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const signoff =
+        await this.airSafetyMeetingService.createAirSafetyMeetingSignoff(
+          req.params.meetingId,
+          req.body,
+        );
+      res.status(201).json({ signoff });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listAirSafetyMeetingSignoffs = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const signoffs =
+        await this.airSafetyMeetingService.listAirSafetyMeetingSignoffs(
+          req.params.meetingId,
+        );
+      res.status(200).json({ signoffs });
+    } catch (error) {
+      next(error);
+    }
+  };
+
   getQuarterlyCompliance = async (
     req: Request,
     res: Response,

--- a/src/air-safety-meetings/air-safety-meeting.errors.ts
+++ b/src/air-safety-meetings/air-safety-meeting.errors.ts
@@ -11,3 +11,12 @@ export class AirSafetyMeetingNotFoundError extends Error {
     super(`Air safety meeting not found: ${meetingId}`);
   }
 }
+
+export class AirSafetyMeetingSignoffNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "AIR_SAFETY_MEETING_SIGNOFF_NOT_FOUND";
+
+  constructor(signoffId: string) {
+    super(`Air safety meeting sign-off not found: ${signoffId}`);
+  }
+}

--- a/src/air-safety-meetings/air-safety-meeting.repository.ts
+++ b/src/air-safety-meetings/air-safety-meeting.repository.ts
@@ -2,6 +2,8 @@ import { randomUUID } from "crypto";
 import type { PoolClient, QueryResultRow } from "pg";
 import type {
   AirSafetyMeeting,
+  AirSafetyMeetingSignoff,
+  AirSafetyMeetingSignoffDecision,
   AirSafetyMeetingPackExportAgendaItem,
   AirSafetyMeetingStatus,
   AirSafetyMeetingType,
@@ -35,6 +37,30 @@ interface CreateAirSafetyMeetingRow {
   attendees: string[];
   agenda: string[];
   minutes: string | null;
+  createdBy: string | null;
+}
+
+interface AirSafetyMeetingSignoffRow extends QueryResultRow {
+  id: string;
+  air_safety_meeting_id: string;
+  accountable_manager_name: string;
+  accountable_manager_role: string;
+  review_decision: AirSafetyMeetingSignoffDecision;
+  signed_at: Date;
+  signature_reference: string | null;
+  review_notes: string | null;
+  created_by: string | null;
+  created_at: Date;
+}
+
+interface CreateAirSafetyMeetingSignoffRow {
+  airSafetyMeetingId: string;
+  accountableManagerName: string;
+  accountableManagerRole: string;
+  reviewDecision: AirSafetyMeetingSignoffDecision;
+  signedAt: string;
+  signatureReference: string | null;
+  reviewNotes: string | null;
   createdBy: string | null;
 }
 
@@ -72,6 +98,21 @@ const toAirSafetyMeeting = (row: AirSafetyMeetingRow): AirSafetyMeeting => ({
   createdBy: row.created_by,
   createdAt: row.created_at.toISOString(),
   closedAt: row.closed_at?.toISOString() ?? null,
+});
+
+const toAirSafetyMeetingSignoff = (
+  row: AirSafetyMeetingSignoffRow,
+): AirSafetyMeetingSignoff => ({
+  id: row.id,
+  airSafetyMeetingId: row.air_safety_meeting_id,
+  accountableManagerName: row.accountable_manager_name,
+  accountableManagerRole: row.accountable_manager_role,
+  reviewDecision: row.review_decision,
+  signedAt: row.signed_at.toISOString(),
+  signatureReference: row.signature_reference,
+  reviewNotes: row.review_notes,
+  createdBy: row.created_by,
+  createdAt: row.created_at.toISOString(),
 });
 
 export class AirSafetyMeetingRepository {
@@ -142,6 +183,59 @@ export class AirSafetyMeetingRepository {
     );
 
     return result.rows.map(toAirSafetyMeeting);
+  }
+
+  async insertAirSafetyMeetingSignoff(
+    tx: PoolClient,
+    input: CreateAirSafetyMeetingSignoffRow,
+  ): Promise<AirSafetyMeetingSignoff> {
+    const result = await tx.query<AirSafetyMeetingSignoffRow>(
+      `
+      insert into air_safety_meeting_signoffs (
+        id,
+        air_safety_meeting_id,
+        accountable_manager_name,
+        accountable_manager_role,
+        review_decision,
+        signed_at,
+        signature_reference,
+        review_notes,
+        created_by
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.airSafetyMeetingId,
+        input.accountableManagerName,
+        input.accountableManagerRole,
+        input.reviewDecision,
+        input.signedAt,
+        input.signatureReference,
+        input.reviewNotes,
+        input.createdBy,
+      ],
+    );
+
+    return toAirSafetyMeetingSignoff(result.rows[0]);
+  }
+
+  async listAirSafetyMeetingSignoffs(
+    tx: PoolClient,
+    meetingId: string,
+  ): Promise<AirSafetyMeetingSignoff[]> {
+    const result = await tx.query<AirSafetyMeetingSignoffRow>(
+      `
+      select *
+      from air_safety_meeting_signoffs
+      where air_safety_meeting_id = $1
+      order by signed_at desc, created_at desc, id desc
+      `,
+      [meetingId],
+    );
+
+    return result.rows.map(toAirSafetyMeetingSignoff);
   }
 
   async getAirSafetyMeetingById(

--- a/src/air-safety-meetings/air-safety-meeting.routes.ts
+++ b/src/air-safety-meetings/air-safety-meeting.routes.ts
@@ -9,6 +9,8 @@ export function createAirSafetyMeetingRouter(
   router.post("/", controller.createAirSafetyMeeting);
   router.get("/", controller.listAirSafetyMeetings);
   router.get("/quarterly-compliance", controller.getQuarterlyCompliance);
+  router.post("/:meetingId/signoffs", controller.createAirSafetyMeetingSignoff);
+  router.get("/:meetingId/signoffs", controller.listAirSafetyMeetingSignoffs);
   router.get("/:meetingId/export/pdf", controller.generateAirSafetyMeetingPackPdf);
   router.get("/:meetingId/export/render", controller.renderAirSafetyMeetingPack);
   router.get("/:meetingId/export", controller.exportAirSafetyMeetingPack);

--- a/src/air-safety-meetings/air-safety-meeting.service.ts
+++ b/src/air-safety-meetings/air-safety-meeting.service.ts
@@ -3,6 +3,7 @@ import { AirSafetyMeetingNotFoundError } from "./air-safety-meeting.errors";
 import { AirSafetyMeetingRepository } from "./air-safety-meeting.repository";
 import type {
   AirSafetyMeeting,
+  AirSafetyMeetingSignoff,
   AirSafetyMeetingPackExportActionProposal,
   AirSafetyMeetingPackExportAgendaItem,
   AirSafetyMeetingPackExport,
@@ -10,12 +11,14 @@ import type {
   AirSafetyMeetingPackRenderedReport,
   AirSafetyMeetingReportSection,
   CreateAirSafetyMeetingInput,
+  CreateAirSafetyMeetingSignoffInput,
   QuarterlyAirSafetyMeetingCompliance,
   QuarterlyComplianceStatus,
 } from "./air-safety-meeting.types";
 import {
   validateAirSafetyMeetingId,
   validateCreateAirSafetyMeetingInput,
+  validateCreateAirSafetyMeetingSignoffInput,
   validateQuarterlyComplianceQuery,
 } from "./air-safety-meeting.validators";
 
@@ -50,6 +53,73 @@ export class AirSafetyMeetingService {
 
     try {
       return await this.airSafetyMeetingRepository.listAirSafetyMeetings(client);
+    } finally {
+      client.release();
+    }
+  }
+
+  async createAirSafetyMeetingSignoff(
+    meetingIdInput: unknown,
+    input: CreateAirSafetyMeetingSignoffInput | undefined,
+  ): Promise<AirSafetyMeetingSignoff> {
+    const meetingId = validateAirSafetyMeetingId(meetingIdInput);
+    const validated = validateCreateAirSafetyMeetingSignoffInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      await client.query("BEGIN");
+
+      const meeting = await this.airSafetyMeetingRepository.getAirSafetyMeetingById(
+        client,
+        meetingId,
+      );
+
+      if (!meeting) {
+        throw new AirSafetyMeetingNotFoundError(meetingId);
+      }
+
+      const signoff = await this.airSafetyMeetingRepository
+        .insertAirSafetyMeetingSignoff(client, {
+          airSafetyMeetingId: meetingId,
+          accountableManagerName: validated.accountableManagerName,
+          accountableManagerRole: validated.accountableManagerRole,
+          reviewDecision: validated.reviewDecision,
+          signedAt: validated.signedAt,
+          signatureReference: validated.signatureReference,
+          reviewNotes: validated.reviewNotes,
+          createdBy: validated.createdBy,
+        });
+
+      await client.query("COMMIT");
+      return signoff;
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async listAirSafetyMeetingSignoffs(
+    meetingIdInput: unknown,
+  ): Promise<AirSafetyMeetingSignoff[]> {
+    const meetingId = validateAirSafetyMeetingId(meetingIdInput);
+    const client = await this.pool.connect();
+
+    try {
+      const meeting = await this.airSafetyMeetingRepository.getAirSafetyMeetingById(
+        client,
+        meetingId,
+      );
+
+      if (!meeting) {
+        throw new AirSafetyMeetingNotFoundError(meetingId);
+      }
+
+      return await this.airSafetyMeetingRepository.listAirSafetyMeetingSignoffs(
+        client,
+        meetingId,
+      );
     } finally {
       client.release();
     }

--- a/src/air-safety-meetings/air-safety-meeting.types.ts
+++ b/src/air-safety-meetings/air-safety-meeting.types.ts
@@ -16,6 +16,11 @@ export type QuarterlyComplianceStatus =
   | "due_soon"
   | "overdue";
 
+export type AirSafetyMeetingSignoffDecision =
+  | "approved"
+  | "rejected"
+  | "requires_follow_up";
+
 export interface CreateAirSafetyMeetingInput {
   meetingType?: AirSafetyMeetingType;
   scheduledPeriodStart?: string | null;
@@ -27,6 +32,16 @@ export interface CreateAirSafetyMeetingInput {
   attendees?: string[];
   agenda?: string[];
   minutes?: string | null;
+  createdBy?: string | null;
+}
+
+export interface CreateAirSafetyMeetingSignoffInput {
+  accountableManagerName?: string;
+  accountableManagerRole?: string;
+  reviewDecision?: AirSafetyMeetingSignoffDecision;
+  signedAt?: string;
+  signatureReference?: string | null;
+  reviewNotes?: string | null;
   createdBy?: string | null;
 }
 
@@ -45,6 +60,19 @@ export interface AirSafetyMeeting {
   createdBy: string | null;
   createdAt: string;
   closedAt: string | null;
+}
+
+export interface AirSafetyMeetingSignoff {
+  id: string;
+  airSafetyMeetingId: string;
+  accountableManagerName: string;
+  accountableManagerRole: string;
+  reviewDecision: AirSafetyMeetingSignoffDecision;
+  signedAt: string;
+  signatureReference: string | null;
+  reviewNotes: string | null;
+  createdBy: string | null;
+  createdAt: string;
 }
 
 export interface QuarterlyAirSafetyMeetingCompliance {

--- a/src/air-safety-meetings/air-safety-meeting.validators.ts
+++ b/src/air-safety-meetings/air-safety-meeting.validators.ts
@@ -1,8 +1,10 @@
 import { AirSafetyMeetingValidationError } from "./air-safety-meeting.errors";
 import type {
   AirSafetyMeetingStatus,
+  AirSafetyMeetingSignoffDecision,
   AirSafetyMeetingType,
   CreateAirSafetyMeetingInput,
+  CreateAirSafetyMeetingSignoffInput,
 } from "./air-safety-meeting.types";
 
 const MEETING_TYPES = new Set<AirSafetyMeetingType>([
@@ -18,6 +20,12 @@ const MEETING_STATUSES = new Set<AirSafetyMeetingStatus>([
   "scheduled",
   "completed",
   "cancelled",
+]);
+
+const SIGNOFF_DECISIONS = new Set<AirSafetyMeetingSignoffDecision>([
+  "approved",
+  "rejected",
+  "requires_follow_up",
 ]);
 
 const UUID_RE =
@@ -36,6 +44,14 @@ function optionalTrimmed(value: unknown, fieldName: string): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function requiredString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new AirSafetyMeetingValidationError(`${fieldName} is required`);
+  }
+
+  return value.trim();
+}
+
 function requiredDate(value: unknown, fieldName: string): Date {
   if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
     throw new AirSafetyMeetingValidationError(
@@ -52,6 +68,33 @@ function optionalDate(value: unknown, fieldName: string): Date | null {
   }
 
   return requiredDate(value, fieldName);
+}
+
+function requiredIsoDate(value: unknown, fieldName: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new AirSafetyMeetingValidationError(`${fieldName} is required`);
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new AirSafetyMeetingValidationError(`${fieldName} must be a valid date`);
+  }
+
+  return parsed.toISOString();
+}
+
+function requiredSignoffDecision(
+  value: unknown,
+): AirSafetyMeetingSignoffDecision {
+  if (
+    typeof value !== "string" ||
+    !SIGNOFF_DECISIONS.has(value as AirSafetyMeetingSignoffDecision)
+  ) {
+    throw new AirSafetyMeetingValidationError("reviewDecision is not supported");
+  }
+
+  return value as AirSafetyMeetingSignoffDecision;
 }
 
 function optionalDateOnly(value: unknown, fieldName: string): string | null {
@@ -159,6 +202,33 @@ export function validateCreateAirSafetyMeetingInput(
     attendees: optionalStringArray(input.attendees, "attendees"),
     agenda: optionalStringArray(input.agenda, "agenda"),
     minutes: optionalTrimmed(input.minutes, "minutes"),
+    createdBy: optionalTrimmed(input.createdBy, "createdBy"),
+  };
+}
+
+export function validateCreateAirSafetyMeetingSignoffInput(
+  input: CreateAirSafetyMeetingSignoffInput | undefined,
+) {
+  if (!input || typeof input !== "object") {
+    throw new AirSafetyMeetingValidationError("Request body must be an object");
+  }
+
+  return {
+    accountableManagerName: requiredString(
+      input.accountableManagerName,
+      "accountableManagerName",
+    ),
+    accountableManagerRole: requiredString(
+      input.accountableManagerRole,
+      "accountableManagerRole",
+    ),
+    reviewDecision: requiredSignoffDecision(input.reviewDecision),
+    signedAt: requiredIsoDate(input.signedAt, "signedAt"),
+    signatureReference: optionalTrimmed(
+      input.signatureReference,
+      "signatureReference",
+    ),
+    reviewNotes: optionalTrimmed(input.reviewNotes, "reviewNotes"),
     createdBy: optionalTrimmed(input.createdBy, "createdBy"),
   };
 }

--- a/src/migrations/027_create_air_safety_meeting_signoffs.sql
+++ b/src/migrations/027_create_air_safety_meeting_signoffs.sql
@@ -1,0 +1,19 @@
+create table if not exists air_safety_meeting_signoffs (
+  id uuid primary key,
+  air_safety_meeting_id uuid not null
+    references air_safety_meetings(id)
+    on delete cascade,
+  accountable_manager_name text not null,
+  accountable_manager_role text not null,
+  review_decision text not null,
+  signed_at timestamptz not null,
+  signature_reference text null,
+  review_notes text null,
+  created_by text null,
+  created_at timestamptz not null default now(),
+  constraint air_safety_meeting_signoff_decision_chk
+    check (review_decision in ('approved', 'rejected', 'requires_follow_up'))
+);
+
+create index if not exists idx_air_safety_meeting_signoffs_meeting_created
+  on air_safety_meeting_signoffs (air_safety_meeting_id, created_at desc);

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -18,6 +18,7 @@ const parseBinaryResponse = (
 };
 
 const clearTables = async () => {
+  await pool.query("delete from air_safety_meeting_signoffs");
   await pool.query("delete from safety_action_implementation_evidence");
   await pool.query("delete from safety_action_decisions");
   await pool.query("delete from safety_action_proposals");
@@ -49,6 +50,7 @@ const countRows = async () => {
     `
     select
       (select count(*)::int from air_safety_meetings) as meeting_count,
+      (select count(*)::int from air_safety_meeting_signoffs) as signoff_count,
       (select count(*)::int from safety_events) as safety_event_count,
       (select count(*)::int from safety_event_meeting_triggers) as trigger_count,
       (select count(*)::int from safety_event_agenda_links) as agenda_link_count,
@@ -60,6 +62,7 @@ const countRows = async () => {
 
   return result.rows[0] as {
     meeting_count: number;
+    signoff_count: number;
     safety_event_count: number;
     trigger_count: number;
     agenda_link_count: number;
@@ -244,6 +247,203 @@ describe("air safety meetings", () => {
     expect(listResponse.status).toBe(200);
     expect(listResponse.body.meetings).toHaveLength(1);
     expect(listResponse.body.meetings[0]).toEqual(response.body.meeting);
+  });
+
+  it("creates and lists stored air safety meeting sign-offs without mutating linked records", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const before = await countRows();
+
+    const createResponse = await request(app)
+      .post(`/air-safety-meetings/${meeting.id}/signoffs`)
+      .send({
+        accountableManagerName: "Alex Morgan",
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "approved",
+        signedAt: "2026-04-20T17:00:00.000Z",
+        signatureReference: "signature://accountable-manager/alex-morgan",
+        reviewNotes: "Meeting pack reviewed and approved.",
+        createdBy: "safety-admin",
+      });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.signoff).toMatchObject({
+      airSafetyMeetingId: meeting.id,
+      accountableManagerName: "Alex Morgan",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "approved",
+      signedAt: "2026-04-20T17:00:00.000Z",
+      signatureReference: "signature://accountable-manager/alex-morgan",
+      reviewNotes: "Meeting pack reviewed and approved.",
+      createdBy: "safety-admin",
+    });
+    expect(createResponse.body.signoff.id).toEqual(expect.any(String));
+    expect(createResponse.body.signoff.createdAt).toEqual(expect.any(String));
+
+    const listResponse = await request(app).get(
+      `/air-safety-meetings/${meeting.id}/signoffs`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.signoffs).toHaveLength(1);
+    expect(listResponse.body.signoffs[0]).toEqual(createResponse.body.signoff);
+    expect(await countRows()).toEqual({
+      ...before,
+      signoff_count: before.signoff_count + 1,
+    });
+  });
+
+  it("allows multiple stored sign-offs on the same meeting ordered newest first", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const before = await countRows();
+
+    const firstResponse = await request(app)
+      .post(`/air-safety-meetings/${meeting.id}/signoffs`)
+      .send({
+        accountableManagerName: "Alex Morgan",
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "requires_follow_up",
+        signedAt: "2026-04-20T10:00:00.000Z",
+        reviewNotes: "Follow-up required before approval.",
+      });
+    const secondResponse = await request(app)
+      .post(`/air-safety-meetings/${meeting.id}/signoffs`)
+      .send({
+        accountableManagerName: "Alex Morgan",
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "approved",
+        signedAt: "2026-04-20T12:00:00.000Z",
+        signatureReference: "signature://accountable-manager/alex-morgan",
+        reviewNotes: "Follow-up completed and approved.",
+      });
+
+    expect(firstResponse.status).toBe(201);
+    expect(secondResponse.status).toBe(201);
+
+    const listResponse = await request(app).get(
+      `/air-safety-meetings/${meeting.id}/signoffs`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.signoffs).toHaveLength(2);
+    expect(listResponse.body.signoffs[0].id).toBe(secondResponse.body.signoff.id);
+    expect(listResponse.body.signoffs[1].id).toBe(firstResponse.body.signoff.id);
+    expect(await countRows()).toEqual({
+      ...before,
+      signoff_count: before.signoff_count + 2,
+    });
+  });
+
+  it("does not leak stored air safety meeting sign-offs across meetings", async () => {
+    const firstMeeting = await createEventTriggeredMeeting();
+    const secondMeeting = await createEventTriggeredMeeting();
+    const before = await countRows();
+
+    const secondResponse = await request(app)
+      .post(`/air-safety-meetings/${secondMeeting.id}/signoffs`)
+      .send({
+        accountableManagerName: "Alex Morgan",
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "approved",
+        signedAt: "2026-04-20T17:00:00.000Z",
+        reviewNotes: "Second meeting approved.",
+      });
+
+    expect(secondResponse.status).toBe(201);
+
+    const listResponse = await request(app).get(
+      `/air-safety-meetings/${firstMeeting.id}/signoffs`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.signoffs).toEqual([]);
+    expect(await countRows()).toEqual({
+      ...before,
+      signoff_count: before.signoff_count + 1,
+    });
+  });
+
+  it("rejects invalid stored air safety meeting sign-off requests", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const before = await countRows();
+    const endpoint = `/air-safety-meetings/${meeting.id}/signoffs`;
+
+    const missingNameResponse = await request(app).post(endpoint).send({
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "approved",
+      signedAt: "2026-04-20T17:00:00.000Z",
+    });
+    const invalidDecisionResponse = await request(app).post(endpoint).send({
+      accountableManagerName: "Alex Morgan",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "maybe",
+      signedAt: "2026-04-20T17:00:00.000Z",
+    });
+    const invalidDateResponse = await request(app).post(endpoint).send({
+      accountableManagerName: "Alex Morgan",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "approved",
+      signedAt: "not-a-date",
+    });
+
+    expect(missingNameResponse.status).toBe(400);
+    expect(invalidDecisionResponse.status).toBe(400);
+    expect(invalidDateResponse.status).toBe(400);
+    expect(missingNameResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_validation_failed",
+    });
+    expect(invalidDecisionResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_validation_failed",
+    });
+    expect(invalidDateResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_validation_failed",
+    });
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("returns 404 for unknown stored air safety meeting sign-off meetings", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const before = await countRows();
+    const invalidCreateResponse = await request(app)
+      .post("/air-safety-meetings/not-a-uuid/signoffs")
+      .send({
+        accountableManagerName: "Alex Morgan",
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "approved",
+        signedAt: "2026-04-20T17:00:00.000Z",
+      });
+    const invalidListResponse = await request(app).get(
+      "/air-safety-meetings/not-a-uuid/signoffs",
+    );
+
+    const missingCreateResponse = await request(app)
+      .post(`/air-safety-meetings/${randomUUID()}/signoffs`)
+      .send({
+        accountableManagerName: "Alex Morgan",
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "approved",
+        signedAt: "2026-04-20T17:00:00.000Z",
+      });
+    const missingListResponse = await request(app).get(
+      `/air-safety-meetings/${randomUUID()}/signoffs`,
+    );
+
+    expect(invalidCreateResponse.status).toBe(400);
+    expect(invalidListResponse.status).toBe(400);
+    expect(missingCreateResponse.status).toBe(404);
+    expect(missingListResponse.status).toBe(404);
+    expect(invalidCreateResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_validation_failed",
+    });
+    expect(invalidListResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_validation_failed",
+    });
+    expect(missingCreateResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_not_found",
+    });
+    expect(missingListResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_not_found",
+    });
+    expect(await countRows()).toEqual(before);
   });
 
   it("reports overdue quarterly compliance when no completed quarterly meeting exists", async () => {


### PR DESCRIPTION
## Summary

Implements GitHub issue #89 by adding stored safety meeting sign-off records so accountable-manager meeting pack approvals can be captured and audited.

## What changed

- Added migration-backed `air_safety_meeting_signoffs`.
- Added sign-off types and validation for:
  - accountable manager name
  - role/title
  - review decision/status
  - signed at
  - signature reference
  - review notes/comments
  - created by
- Added endpoints:
  - `POST /air-safety-meetings/:meetingId/signoffs`
  - `GET /air-safety-meetings/:meetingId/signoffs`
- Added repository and service logic scoped to `air_safety_meetings`.
- Allowed multiple sign-offs per meeting and return them newest-first.
- Added integration coverage for:
  - sign-off creation
  - sign-off listing
  - multiple sign-offs on one meeting
  - meeting isolation
  - invalid request bodies
  - malformed meeting IDs
  - missing meeting handling
  - no mutation of linked safety event/action records
- Updated the save point to the next build step.

## Verification

- `npm.cmd ci` passed.
- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 27 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 274 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `git diff --cached --check` passed.

## Notes

`node scripts\\check-next-build-step-pr.mjs origin/main` still does not run correctly in these Windows worktrees because its internal `git diff` call does not inherit the worktree context. Direct git scope inspection confirmed this PR is limited to the air-safety-meetings module, its tests, the new migration, and the save point.

Closes #89.
