### PR TITLE
Add meeting signoff approval export context

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add safety meeting sign-off approval export context so downstream audit and governance outputs can distinguish approved, rejected, and follow-up meeting decisions.",
+ "nextBuildStep": "Add governance-facing safety meeting approval rollup export so approved, rejected, follow-up, and unsigned meeting decisions can be reviewed across meetings.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/air-safety-meetings/air-safety-meeting.service.ts
+++ b/src/air-safety-meetings/air-safety-meeting.service.ts
@@ -158,6 +158,8 @@ export class AirSafetyMeetingService {
         throw new AirSafetyMeetingNotFoundError(meetingId);
       }
 
+      const signoff = await this.airSafetyMeetingRepository
+        .getLatestAirSafetyMeetingSignoff(client, meetingId);
       const agendaItems = await this.airSafetyMeetingRepository
         .listAirSafetyMeetingPackAgendaItems(client, meetingId);
 
@@ -167,6 +169,10 @@ export class AirSafetyMeetingService {
         generatedAt: new Date().toISOString(),
         meetingId,
         meeting,
+        signoffApproval: {
+          status: signoff?.reviewDecision ?? "unsigned",
+          latestSignoff: signoff,
+        },
         agendaItems,
       };
     } finally {

--- a/src/air-safety-meetings/air-safety-meeting.types.ts
+++ b/src/air-safety-meetings/air-safety-meeting.types.ts
@@ -178,12 +178,20 @@ export interface AirSafetyMeetingPackExportAgendaItem {
   actionProposals: AirSafetyMeetingPackExportActionProposal[];
 }
 
+export interface AirSafetyMeetingPackSignoffApprovalContext {
+  status:
+    | "unsigned"
+    | AirSafetyMeetingSignoffDecision;
+  latestSignoff: AirSafetyMeetingSignoff | null;
+}
+
 export interface AirSafetyMeetingPackExport {
   exportType: "air_safety_meeting_pack";
   formatVersion: 1;
   generatedAt: string;
   meetingId: string;
   meeting: AirSafetyMeeting;
+  signoffApproval: AirSafetyMeetingPackSignoffApprovalContext;
   agendaItems: AirSafetyMeetingPackExportAgendaItem[];
 }
 

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -731,6 +731,83 @@ describe("air safety meetings", () => {
     expect(await countRows()).toEqual(before);
   });
 
+  it("exports an unsigned sign-off approval context when no meeting sign-off exists", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const before = await countRows();
+
+    const response = await request(app).get(
+      `/air-safety-meetings/${meeting.id}/export`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.export.signoffApproval).toEqual({
+      status: "unsigned",
+      latestSignoff: null,
+    });
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("exports approved meeting sign-off approval context", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const signoff = await createMeetingSignoff(meeting.id, {
+      reviewDecision: "approved",
+      reviewNotes: "Approved for closure.",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get(
+      `/air-safety-meetings/${meeting.id}/export`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.export.signoffApproval).toEqual({
+      status: "approved",
+      latestSignoff: signoff,
+    });
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("exports rejected meeting sign-off approval context", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const signoff = await createMeetingSignoff(meeting.id, {
+      reviewDecision: "rejected",
+      signatureReference: null,
+      reviewNotes: "Rejected pending corrective action.",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get(
+      `/air-safety-meetings/${meeting.id}/export`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.export.signoffApproval).toEqual({
+      status: "rejected",
+      latestSignoff: signoff,
+    });
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("exports requires-follow-up meeting sign-off approval context", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    const signoff = await createMeetingSignoff(meeting.id, {
+      reviewDecision: "requires_follow_up",
+      reviewNotes: "Further review required before approval.",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get(
+      `/air-safety-meetings/${meeting.id}/export`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.export.signoffApproval).toEqual({
+      status: "requires_follow_up",
+      latestSignoff: signoff,
+    });
+    expect(await countRows()).toEqual(before);
+  });
+
   it("does not leak meeting pack records from other meetings", async () => {
     const firstMeeting = await createEventTriggeredMeeting();
     const secondMeeting = await createEventTriggeredMeeting();
@@ -742,6 +819,12 @@ describe("air safety meetings", () => {
         evidenceCategory: "maintenance_completion",
       },
     );
+    const secondSignoff = await createMeetingSignoff(secondMeeting.id, {
+      accountableManagerName: "Jordan Lee",
+      signatureReference: "signature://accountable-manager/jordan-lee",
+      reviewDecision: "approved",
+      reviewNotes: "Second meeting approved.",
+    });
     const firstBefore = await countRows();
 
     const response = await request(app).get(
@@ -750,9 +833,16 @@ describe("air safety meetings", () => {
 
     expect(response.status).toBe(200);
     expect(response.body.export.meetingId).toBe(firstMeeting.id);
+    expect(response.body.export.signoffApproval).toEqual({
+      status: "unsigned",
+      latestSignoff: null,
+    });
     expect(response.body.export.agendaItems).toEqual([]);
     expect(JSON.stringify(response.body.export)).not.toContain(
       secondSource.event.id,
+    );
+    expect(JSON.stringify(response.body.export)).not.toContain(
+      secondSignoff.id,
     );
     expect(await countRows()).toEqual(firstBefore);
   });


### PR DESCRIPTION
## Summary

Implements GitHub issue #93 by adding structured safety meeting sign-off approval context to the existing meeting-pack export.

## What changed

- Added `signoffApproval` to the air safety meeting pack export.
- Export now distinguishes:
  - `unsigned`
  - `approved`
  - `rejected`
  - `requires_follow_up`
- Reused the existing latest-signoff lookup instead of introducing a second approval path.
- Included the latest stored sign-off record in export context when present.
- Kept the change read-only and limited to the existing `GET /air-safety-meetings/:meetingId/export` path.
- Added integration coverage for:
  - unsigned export state
  - approved sign-off export
  - rejected sign-off export
  - requires-follow-up sign-off export
  - meeting isolation
  - no mutation of source records
- Updated the save point to the next build step.

## Verification

- `npm.cmd ci` passed.
- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 31 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 278 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `git diff --cached --check` passed.

## Notes

`node scripts\\check-next-build-step-pr.mjs origin/main` still does not run correctly in these Windows worktrees because its internal `git diff` call fails with `spawnSync ... cmd.exe EPERM`. Direct git inspection confirmed the change scope is limited to the air-safety-meetings export/types/tests and the save point.

Closes #93.
