### PR TITLE
Add meeting approval rollup export

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add governance-facing safety meeting approval rollup export so approved, rejected, follow-up, and unsigned meeting decisions can be reviewed across meetings.",
+ "nextBuildStep": "Add governance-facing safety meeting approval rendered report endpoint so cross-meeting approval states can be reviewed as an assurance summary.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/air-safety-meetings/air-safety-meeting.controller.ts
+++ b/src/air-safety-meetings/air-safety-meeting.controller.ts
@@ -34,6 +34,20 @@ export class AirSafetyMeetingController {
     }
   };
 
+  exportAirSafetyMeetingApprovalRollup = async (
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const rollup =
+        await this.airSafetyMeetingService.exportAirSafetyMeetingApprovalRollup();
+      res.status(200).json({ export: rollup });
+    } catch (error) {
+      next(error);
+    }
+  };
+
   createAirSafetyMeetingSignoff = async (
     req: Request,
     res: Response,

--- a/src/air-safety-meetings/air-safety-meeting.repository.ts
+++ b/src/air-safety-meetings/air-safety-meeting.repository.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import type { PoolClient, QueryResultRow } from "pg";
 import type {
   AirSafetyMeeting,
+  AirSafetyMeetingApprovalRollupRecord,
   AirSafetyMeetingSignoff,
   AirSafetyMeetingSignoffDecision,
   AirSafetyMeetingPackExportAgendaItem,
@@ -68,6 +69,23 @@ interface AirSafetyMeetingPackExportAgendaItemRow extends QueryResultRow {
   agenda_item: AirSafetyMeetingPackExportAgendaItem;
 }
 
+interface AirSafetyMeetingApprovalRollupRow extends QueryResultRow {
+  meeting_id: string;
+  meeting_type: AirSafetyMeetingType;
+  meeting_status: AirSafetyMeetingStatus;
+  due_at: Date;
+  held_at: Date | null;
+  chairperson: string | null;
+  created_at: Date;
+  latest_signoff_approval_status: "unsigned" | AirSafetyMeetingSignoffDecision;
+  latest_signoff_id: string | null;
+  accountable_manager_name: string | null;
+  accountable_manager_role: string | null;
+  signed_at: Date | null;
+  signature_reference: string | null;
+  review_notes: string | null;
+}
+
 const toDateOnly = (value: Date | string | null): string | null => {
   if (!value) {
     return null;
@@ -113,6 +131,25 @@ const toAirSafetyMeetingSignoff = (
   reviewNotes: row.review_notes,
   createdBy: row.created_by,
   createdAt: row.created_at.toISOString(),
+});
+
+const toAirSafetyMeetingApprovalRollupRecord = (
+  row: AirSafetyMeetingApprovalRollupRow,
+): AirSafetyMeetingApprovalRollupRecord => ({
+  meetingId: row.meeting_id,
+  meetingType: row.meeting_type,
+  meetingStatus: row.meeting_status,
+  dueAt: row.due_at.toISOString(),
+  heldAt: row.held_at?.toISOString() ?? null,
+  chairperson: row.chairperson,
+  createdAt: row.created_at.toISOString(),
+  latestSignoffApprovalStatus: row.latest_signoff_approval_status,
+  latestSignoffId: row.latest_signoff_id,
+  accountableManagerName: row.accountable_manager_name,
+  accountableManagerRole: row.accountable_manager_role,
+  signedAt: row.signed_at?.toISOString() ?? null,
+  signatureReference: row.signature_reference,
+  reviewNotes: row.review_notes,
 });
 
 export class AirSafetyMeetingRepository {
@@ -183,6 +220,41 @@ export class AirSafetyMeetingRepository {
     );
 
     return result.rows.map(toAirSafetyMeeting);
+  }
+
+  async listAirSafetyMeetingApprovalRollup(
+    tx: PoolClient,
+  ): Promise<AirSafetyMeetingApprovalRollupRecord[]> {
+    const result = await tx.query<AirSafetyMeetingApprovalRollupRow>(
+      `
+      select
+        meetings.id as meeting_id,
+        meetings.meeting_type,
+        meetings.status as meeting_status,
+        meetings.due_at,
+        meetings.held_at,
+        meetings.chairperson,
+        meetings.created_at,
+        coalesce(signoffs.review_decision::text, 'unsigned') as latest_signoff_approval_status,
+        signoffs.id as latest_signoff_id,
+        signoffs.accountable_manager_name,
+        signoffs.accountable_manager_role,
+        signoffs.signed_at,
+        signoffs.signature_reference,
+        signoffs.review_notes
+      from air_safety_meetings meetings
+      left join lateral (
+        select *
+        from air_safety_meeting_signoffs
+        where air_safety_meeting_id = meetings.id
+        order by signed_at desc, created_at desc, id desc
+        limit 1
+      ) signoffs on true
+      order by meetings.due_at desc, meetings.created_at desc, meetings.id desc
+      `,
+    );
+
+    return result.rows.map(toAirSafetyMeetingApprovalRollupRecord);
   }
 
   async insertAirSafetyMeetingSignoff(

--- a/src/air-safety-meetings/air-safety-meeting.routes.ts
+++ b/src/air-safety-meetings/air-safety-meeting.routes.ts
@@ -8,6 +8,7 @@ export function createAirSafetyMeetingRouter(
 
   router.post("/", controller.createAirSafetyMeeting);
   router.get("/", controller.listAirSafetyMeetings);
+  router.get("/approval-rollup", controller.exportAirSafetyMeetingApprovalRollup);
   router.get("/quarterly-compliance", controller.getQuarterlyCompliance);
   router.post("/:meetingId/signoffs", controller.createAirSafetyMeetingSignoff);
   router.get("/:meetingId/signoffs", controller.listAirSafetyMeetingSignoffs);

--- a/src/air-safety-meetings/air-safety-meeting.service.ts
+++ b/src/air-safety-meetings/air-safety-meeting.service.ts
@@ -3,6 +3,7 @@ import { AirSafetyMeetingNotFoundError } from "./air-safety-meeting.errors";
 import { AirSafetyMeetingRepository } from "./air-safety-meeting.repository";
 import type {
   AirSafetyMeeting,
+  AirSafetyMeetingApprovalRollupExport,
   AirSafetyMeetingSignoff,
   AirSafetyMeetingPackExportActionProposal,
   AirSafetyMeetingPackExportAgendaItem,
@@ -53,6 +54,24 @@ export class AirSafetyMeetingService {
 
     try {
       return await this.airSafetyMeetingRepository.listAirSafetyMeetings(client);
+    } finally {
+      client.release();
+    }
+  }
+
+  async exportAirSafetyMeetingApprovalRollup(): Promise<AirSafetyMeetingApprovalRollupExport> {
+    const client = await this.pool.connect();
+
+    try {
+      const records = await this.airSafetyMeetingRepository
+        .listAirSafetyMeetingApprovalRollup(client);
+
+      return {
+        exportType: "air_safety_meeting_approval_rollup",
+        formatVersion: 1,
+        generatedAt: new Date().toISOString(),
+        records,
+      };
     } finally {
       client.release();
     }

--- a/src/air-safety-meetings/air-safety-meeting.types.ts
+++ b/src/air-safety-meetings/air-safety-meeting.types.ts
@@ -195,6 +195,30 @@ export interface AirSafetyMeetingPackExport {
   agendaItems: AirSafetyMeetingPackExportAgendaItem[];
 }
 
+export interface AirSafetyMeetingApprovalRollupRecord {
+  meetingId: string;
+  meetingType: AirSafetyMeetingType;
+  meetingStatus: AirSafetyMeetingStatus;
+  dueAt: string;
+  heldAt: string | null;
+  chairperson: string | null;
+  createdAt: string;
+  latestSignoffApprovalStatus: "unsigned" | AirSafetyMeetingSignoffDecision;
+  latestSignoffId: string | null;
+  accountableManagerName: string | null;
+  accountableManagerRole: string | null;
+  signedAt: string | null;
+  signatureReference: string | null;
+  reviewNotes: string | null;
+}
+
+export interface AirSafetyMeetingApprovalRollupExport {
+  exportType: "air_safety_meeting_approval_rollup";
+  formatVersion: 1;
+  generatedAt: string;
+  records: AirSafetyMeetingApprovalRollupRecord[];
+}
+
 export interface AirSafetyMeetingReportField {
   label: string;
   value: string | number | boolean | null;

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -559,6 +559,179 @@ describe("air safety meetings", () => {
     });
   });
 
+  it("exports an empty safety meeting approval rollup without mutating source records", async () => {
+    const before = await countRows();
+
+    const response = await request(app).get(
+      "/air-safety-meetings/approval-rollup",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.export).toMatchObject({
+      exportType: "air_safety_meeting_approval_rollup",
+      formatVersion: 1,
+      records: [],
+    });
+    expect(response.body.export.generatedAt).toEqual(expect.any(String));
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("exports governance approval rollup records for approved, rejected, follow-up, and unsigned meetings", async () => {
+    const approvedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "event_triggered_safety_review",
+      dueAt: "2026-04-24T10:00:00.000Z",
+      chairperson: "Safety Manager",
+      createdBy: "safety-admin",
+    });
+    const rejectedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "sop_breach_review",
+      dueAt: "2026-04-23T10:00:00.000Z",
+      chairperson: "Chief Pilot",
+      createdBy: "safety-admin",
+    });
+    const followUpMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "training_review",
+      dueAt: "2026-04-22T10:00:00.000Z",
+      chairperson: "Training Manager",
+      createdBy: "safety-admin",
+    });
+    const unsignedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "maintenance_safety_review",
+      dueAt: "2026-04-21T10:00:00.000Z",
+      chairperson: "Engineering Lead",
+      createdBy: "safety-admin",
+    });
+
+    expect(approvedMeeting.status).toBe(201);
+    expect(rejectedMeeting.status).toBe(201);
+    expect(followUpMeeting.status).toBe(201);
+    expect(unsignedMeeting.status).toBe(201);
+
+    const approvedSignoff = await createMeetingSignoff(approvedMeeting.body.meeting.id, {
+      accountableManagerName: "Alex Morgan",
+      reviewDecision: "approved",
+      signedAt: "2026-04-24T11:00:00.000Z",
+      reviewNotes: "Approved for governance closure.",
+    });
+    const rejectedSignoff = await createMeetingSignoff(rejectedMeeting.body.meeting.id, {
+      accountableManagerName: "Jordan Lee",
+      reviewDecision: "rejected",
+      signedAt: "2026-04-23T11:00:00.000Z",
+      signatureReference: null,
+      reviewNotes: "Rejected pending corrective action.",
+    });
+    const followUpSignoff = await createMeetingSignoff(followUpMeeting.body.meeting.id, {
+      accountableManagerName: "Taylor Shaw",
+      reviewDecision: "requires_follow_up",
+      signedAt: "2026-04-22T11:00:00.000Z",
+      reviewNotes: "Follow-up review required.",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get(
+      "/air-safety-meetings/approval-rollup",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.export.records).toEqual([
+      {
+        meetingId: approvedMeeting.body.meeting.id,
+        meetingType: "event_triggered_safety_review",
+        meetingStatus: "scheduled",
+        dueAt: "2026-04-24T10:00:00.000Z",
+        heldAt: null,
+        chairperson: "Safety Manager",
+        createdAt: approvedMeeting.body.meeting.createdAt,
+        latestSignoffApprovalStatus: "approved",
+        latestSignoffId: approvedSignoff.id,
+        accountableManagerName: "Alex Morgan",
+        accountableManagerRole: "Accountable Manager",
+        signedAt: "2026-04-24T11:00:00.000Z",
+        signatureReference: approvedSignoff.signatureReference,
+        reviewNotes: "Approved for governance closure.",
+      },
+      {
+        meetingId: rejectedMeeting.body.meeting.id,
+        meetingType: "sop_breach_review",
+        meetingStatus: "scheduled",
+        dueAt: "2026-04-23T10:00:00.000Z",
+        heldAt: null,
+        chairperson: "Chief Pilot",
+        createdAt: rejectedMeeting.body.meeting.createdAt,
+        latestSignoffApprovalStatus: "rejected",
+        latestSignoffId: rejectedSignoff.id,
+        accountableManagerName: "Jordan Lee",
+        accountableManagerRole: "Accountable Manager",
+        signedAt: "2026-04-23T11:00:00.000Z",
+        signatureReference: rejectedSignoff.signatureReference,
+        reviewNotes: "Rejected pending corrective action.",
+      },
+      {
+        meetingId: followUpMeeting.body.meeting.id,
+        meetingType: "training_review",
+        meetingStatus: "scheduled",
+        dueAt: "2026-04-22T10:00:00.000Z",
+        heldAt: null,
+        chairperson: "Training Manager",
+        createdAt: followUpMeeting.body.meeting.createdAt,
+        latestSignoffApprovalStatus: "requires_follow_up",
+        latestSignoffId: followUpSignoff.id,
+        accountableManagerName: "Taylor Shaw",
+        accountableManagerRole: "Accountable Manager",
+        signedAt: "2026-04-22T11:00:00.000Z",
+        signatureReference: followUpSignoff.signatureReference,
+        reviewNotes: "Follow-up review required.",
+      },
+      {
+        meetingId: unsignedMeeting.body.meeting.id,
+        meetingType: "maintenance_safety_review",
+        meetingStatus: "scheduled",
+        dueAt: "2026-04-21T10:00:00.000Z",
+        heldAt: null,
+        chairperson: "Engineering Lead",
+        createdAt: unsignedMeeting.body.meeting.createdAt,
+        latestSignoffApprovalStatus: "unsigned",
+        latestSignoffId: null,
+        accountableManagerName: null,
+        accountableManagerRole: null,
+        signedAt: null,
+        signatureReference: null,
+        reviewNotes: null,
+      },
+    ]);
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("uses the newest sign-off when multiple approvals exist on one meeting", async () => {
+    const meeting = await createEventTriggeredMeeting();
+    await createMeetingSignoff(meeting.id, {
+      reviewDecision: "requires_follow_up",
+      signedAt: "2026-04-20T10:00:00.000Z",
+      reviewNotes: "Initial follow-up required.",
+    });
+    const latestSignoff = await createMeetingSignoff(meeting.id, {
+      reviewDecision: "approved",
+      signedAt: "2026-04-20T12:00:00.000Z",
+      reviewNotes: "Follow-up completed and approved.",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get(
+      "/air-safety-meetings/approval-rollup",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.export.records).toHaveLength(1);
+    expect(response.body.export.records[0]).toMatchObject({
+      meetingId: meeting.id,
+      latestSignoffApprovalStatus: "approved",
+      latestSignoffId: latestSignoff.id,
+      signedAt: latestSignoff.signedAt,
+      reviewNotes: "Follow-up completed and approved.",
+    });
+    expect(await countRows()).toEqual(before);
+  });
+
   it("exports an empty safety meeting pack without mutating source records", async () => {
     const meeting = await createEventTriggeredMeeting();
     const before = await countRows();


### PR DESCRIPTION
## Summary

Implements GitHub issue #95 by adding a governance-facing safety meeting approval rollup export across meetings.

## What changed

- Added `GET /air-safety-meetings/approval-rollup`.
- Added a structured rollup export with:
  - meeting ID
  - meeting type
  - meeting status
  - due at
  - held at
  - chairperson
  - created at
  - latest sign-off approval status
  - latest sign-off ID
  - accountable manager name
  - accountable manager role
  - signed at
  - signature reference
  - review notes
- Represented unsigned meetings explicitly as `unsigned`.
- Used a latest-signoff-per-meeting query so the newest sign-off wins where multiple sign-offs exist.
- Kept the endpoint read-only.
- Added integration coverage for:
  - empty rollup state
  - mixed approved/rejected/requires_follow_up/unsigned states
  - newest sign-off selection
  - stable ordering
  - no mutation of source records
- Updated the save point to the next build step.

## Verification

- `npm.cmd ci` passed.
- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 34 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 281 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `git diff --cached --check` passed.

## Notes

`node scripts\\check-next-build-step-pr.mjs origin/main` still does not run correctly in these Windows worktrees because its internal `git diff` call fails with `spawnSync ... cmd.exe EPERM`. Direct git inspection confirmed this branch is limited to the air-safety-meetings module, its tests, and the save point.

Closes #95.
