### PR TITLE
Add meeting approval rollup render

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add governance-facing safety meeting approval rendered report endpoint so cross-meeting approval states can be reviewed as an assurance summary.",
+ "nextBuildStep": "Add governance-facing safety meeting approval PDF export so the rendered assurance summary can be circulated as a formal review artifact.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/air-safety-meetings/air-safety-meeting.controller.ts
+++ b/src/air-safety-meetings/air-safety-meeting.controller.ts
@@ -48,6 +48,20 @@ export class AirSafetyMeetingController {
     }
   };
 
+  renderAirSafetyMeetingApprovalRollup = async (
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const report =
+        await this.airSafetyMeetingService.renderAirSafetyMeetingApprovalRollup();
+      res.status(200).json({ report });
+    } catch (error) {
+      next(error);
+    }
+  };
+
   createAirSafetyMeetingSignoff = async (
     req: Request,
     res: Response,

--- a/src/air-safety-meetings/air-safety-meeting.routes.ts
+++ b/src/air-safety-meetings/air-safety-meeting.routes.ts
@@ -8,6 +8,7 @@ export function createAirSafetyMeetingRouter(
 
   router.post("/", controller.createAirSafetyMeeting);
   router.get("/", controller.listAirSafetyMeetings);
+  router.get("/approval-rollup/render", controller.renderAirSafetyMeetingApprovalRollup);
   router.get("/approval-rollup", controller.exportAirSafetyMeetingApprovalRollup);
   router.get("/quarterly-compliance", controller.getQuarterlyCompliance);
   router.post("/:meetingId/signoffs", controller.createAirSafetyMeetingSignoff);

--- a/src/air-safety-meetings/air-safety-meeting.service.ts
+++ b/src/air-safety-meetings/air-safety-meeting.service.ts
@@ -4,6 +4,8 @@ import { AirSafetyMeetingRepository } from "./air-safety-meeting.repository";
 import type {
   AirSafetyMeeting,
   AirSafetyMeetingApprovalRollupExport,
+  AirSafetyMeetingApprovalRollupRecord,
+  AirSafetyMeetingApprovalRollupRenderedReport,
   AirSafetyMeetingSignoff,
   AirSafetyMeetingPackExportActionProposal,
   AirSafetyMeetingPackExportAgendaItem,
@@ -75,6 +77,23 @@ export class AirSafetyMeetingService {
     } finally {
       client.release();
     }
+  }
+
+  async renderAirSafetyMeetingApprovalRollup(): Promise<AirSafetyMeetingApprovalRollupRenderedReport> {
+    const rollupExport = await this.exportAirSafetyMeetingApprovalRollup();
+    const sections = this.buildApprovalRollupReportSections(rollupExport);
+
+    return {
+      renderType: "air_safety_meeting_approval_rollup_report",
+      formatVersion: 1,
+      generatedAt: new Date().toISOString(),
+      sourceExport: rollupExport,
+      report: {
+        title: "Air safety meeting approval assurance summary",
+        sections,
+        plainText: this.renderSectionsAsPlainText(sections),
+      },
+    };
   }
 
   async createAirSafetyMeetingSignoff(
@@ -312,6 +331,120 @@ export class AirSafetyMeetingService {
     const result = new Date(value.getTime());
     result.setUTCMonth(result.getUTCMonth() + months);
     return result;
+  }
+
+  private buildApprovalRollupReportSections(
+    rollupExport: AirSafetyMeetingApprovalRollupExport,
+  ): AirSafetyMeetingReportSection[] {
+    const records = rollupExport.records;
+    const statuses: Array<AirSafetyMeetingApprovalRollupRecord["latestSignoffApprovalStatus"]> = [
+      "approved",
+      "rejected",
+      "requires_follow_up",
+      "unsigned",
+    ];
+
+    const sections: AirSafetyMeetingReportSection[] = [
+      {
+        heading: "Approval rollup summary",
+        fields: [
+          { label: "Export generated at", value: rollupExport.generatedAt },
+          { label: "Total meetings", value: records.length },
+          {
+            label: "Approved meetings",
+            value: records.filter(
+              (record) => record.latestSignoffApprovalStatus === "approved",
+            ).length,
+          },
+          {
+            label: "Rejected meetings",
+            value: records.filter(
+              (record) => record.latestSignoffApprovalStatus === "rejected",
+            ).length,
+          },
+          {
+            label: "Requires follow-up meetings",
+            value: records.filter(
+              (record) =>
+                record.latestSignoffApprovalStatus === "requires_follow_up",
+            ).length,
+          },
+          {
+            label: "Unsigned meetings",
+            value: records.filter(
+              (record) => record.latestSignoffApprovalStatus === "unsigned",
+            ).length,
+          },
+        ],
+      },
+    ];
+
+    if (records.length === 0) {
+      sections.push({
+        heading: "Approval rollup records",
+        fields: [
+          {
+            label: "Meetings",
+            value: "No air safety meetings recorded",
+          },
+        ],
+      });
+      return sections;
+    }
+
+    statuses.forEach((status) => {
+      const statusRecords = records.filter(
+        (record) => record.latestSignoffApprovalStatus === status,
+      );
+
+      sections.push({
+        heading: this.getApprovalRollupSectionHeading(status),
+        fields: [
+          {
+            label: "Meetings",
+            value:
+              statusRecords.length > 0
+                ? statusRecords
+                    .map((record) => this.renderApprovalRollupRecord(record))
+                    .join("; ")
+                : `No ${status.replaceAll("_", " ")} meetings`,
+          },
+        ],
+      });
+    });
+
+    return sections;
+  }
+
+  private getApprovalRollupSectionHeading(
+    status: AirSafetyMeetingApprovalRollupRecord["latestSignoffApprovalStatus"],
+  ): string {
+    if (status === "requires_follow_up") {
+      return "Requires follow-up meetings";
+    }
+
+    if (status === "unsigned") {
+      return "Unsigned meetings";
+    }
+
+    return `${status.charAt(0).toUpperCase()}${status.slice(1)} meetings`;
+  }
+
+  private renderApprovalRollupRecord(
+    record: AirSafetyMeetingApprovalRollupRecord,
+  ): string {
+    return [
+      record.meetingId,
+      record.meetingType,
+      record.meetingStatus,
+      record.dueAt,
+      record.heldAt ?? "held at not recorded",
+      record.chairperson ?? "chairperson not recorded",
+      record.latestSignoffApprovalStatus,
+      record.accountableManagerName ?? "accountable manager not recorded",
+      record.signedAt ?? "signed at not recorded",
+      record.reviewNotes ?? "no review notes",
+    ].join(" | ");
   }
 
   private buildMeetingPackReportSections(

--- a/src/air-safety-meetings/air-safety-meeting.types.ts
+++ b/src/air-safety-meetings/air-safety-meeting.types.ts
@@ -219,6 +219,18 @@ export interface AirSafetyMeetingApprovalRollupExport {
   records: AirSafetyMeetingApprovalRollupRecord[];
 }
 
+export interface AirSafetyMeetingApprovalRollupRenderedReport {
+  renderType: "air_safety_meeting_approval_rollup_report";
+  formatVersion: 1;
+  generatedAt: string;
+  sourceExport: AirSafetyMeetingApprovalRollupExport;
+  report: {
+    title: string;
+    sections: AirSafetyMeetingReportSection[];
+    plainText: string;
+  };
+}
+
 export interface AirSafetyMeetingReportField {
   label: string;
   value: string | number | boolean | null;

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -732,6 +732,196 @@ describe("air safety meetings", () => {
     expect(await countRows()).toEqual(before);
   });
 
+  it("renders an empty governance approval rollup without mutating source records", async () => {
+    const before = await countRows();
+
+    const response = await request(app).get(
+      "/air-safety-meetings/approval-rollup/render",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.report).toMatchObject({
+      renderType: "air_safety_meeting_approval_rollup_report",
+      formatVersion: 1,
+      sourceExport: {
+        exportType: "air_safety_meeting_approval_rollup",
+        records: [],
+      },
+      report: {
+        title: "Air safety meeting approval assurance summary",
+        sections: expect.arrayContaining([
+          expect.objectContaining({
+            heading: "Approval rollup summary",
+            fields: expect.arrayContaining([
+              { label: "Total meetings", value: 0 },
+              { label: "Approved meetings", value: 0 },
+              { label: "Rejected meetings", value: 0 },
+              { label: "Requires follow-up meetings", value: 0 },
+              { label: "Unsigned meetings", value: 0 },
+            ]),
+          }),
+          {
+            heading: "Approval rollup records",
+            fields: [
+              {
+                label: "Meetings",
+                value: "No air safety meetings recorded",
+              },
+            ],
+          },
+        ]),
+      },
+    });
+    expect(response.body.report.generatedAt).toEqual(expect.any(String));
+    expect(response.body.report.report.plainText).toContain(
+      "Meetings: No air safety meetings recorded",
+    );
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("renders governance approval rollup as an assurance summary with stable ordering", async () => {
+    const approvedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "event_triggered_safety_review",
+      dueAt: "2026-04-24T10:00:00.000Z",
+      chairperson: "Safety Manager",
+      createdBy: "safety-admin",
+    });
+    const rejectedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "sop_breach_review",
+      dueAt: "2026-04-23T10:00:00.000Z",
+      chairperson: "Chief Pilot",
+      createdBy: "safety-admin",
+    });
+    const followUpMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "training_review",
+      dueAt: "2026-04-22T10:00:00.000Z",
+      chairperson: "Training Manager",
+      createdBy: "safety-admin",
+    });
+    const unsignedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "maintenance_safety_review",
+      dueAt: "2026-04-21T10:00:00.000Z",
+      chairperson: "Engineering Lead",
+      createdBy: "safety-admin",
+    });
+
+    expect(approvedMeeting.status).toBe(201);
+    expect(rejectedMeeting.status).toBe(201);
+    expect(followUpMeeting.status).toBe(201);
+    expect(unsignedMeeting.status).toBe(201);
+
+    const approvedSignoff = await createMeetingSignoff(approvedMeeting.body.meeting.id, {
+      accountableManagerName: "Alex Morgan",
+      reviewDecision: "approved",
+      signedAt: "2026-04-24T11:00:00.000Z",
+      reviewNotes: "Approved for governance closure.",
+    });
+    const rejectedSignoff = await createMeetingSignoff(rejectedMeeting.body.meeting.id, {
+      accountableManagerName: "Jordan Lee",
+      reviewDecision: "rejected",
+      signedAt: "2026-04-23T11:00:00.000Z",
+      reviewNotes: "Rejected pending corrective action.",
+    });
+    const followUpSignoff = await createMeetingSignoff(followUpMeeting.body.meeting.id, {
+      accountableManagerName: "Taylor Shaw",
+      reviewDecision: "requires_follow_up",
+      signedAt: "2026-04-22T11:00:00.000Z",
+      reviewNotes: "Follow-up review required.",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get(
+      "/air-safety-meetings/approval-rollup/render",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.report.sourceExport.records).toEqual([
+      expect.objectContaining({
+        meetingId: approvedMeeting.body.meeting.id,
+        latestSignoffId: approvedSignoff.id,
+        latestSignoffApprovalStatus: "approved",
+      }),
+      expect.objectContaining({
+        meetingId: rejectedMeeting.body.meeting.id,
+        latestSignoffId: rejectedSignoff.id,
+        latestSignoffApprovalStatus: "rejected",
+      }),
+      expect.objectContaining({
+        meetingId: followUpMeeting.body.meeting.id,
+        latestSignoffId: followUpSignoff.id,
+        latestSignoffApprovalStatus: "requires_follow_up",
+      }),
+      expect.objectContaining({
+        meetingId: unsignedMeeting.body.meeting.id,
+        latestSignoffId: null,
+        latestSignoffApprovalStatus: "unsigned",
+      }),
+    ]);
+    expect(response.body.report.report.sections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          heading: "Approval rollup summary",
+          fields: expect.arrayContaining([
+            { label: "Total meetings", value: 4 },
+            { label: "Approved meetings", value: 1 },
+            { label: "Rejected meetings", value: 1 },
+            { label: "Requires follow-up meetings", value: 1 },
+            { label: "Unsigned meetings", value: 1 },
+          ]),
+        }),
+        expect.objectContaining({
+          heading: "Approved meetings",
+          fields: [
+            {
+              label: "Meetings",
+              value: expect.stringContaining(approvedMeeting.body.meeting.id),
+            },
+          ],
+        }),
+        expect.objectContaining({
+          heading: "Rejected meetings",
+          fields: [
+            {
+              label: "Meetings",
+              value: expect.stringContaining(rejectedMeeting.body.meeting.id),
+            },
+          ],
+        }),
+        expect.objectContaining({
+          heading: "Requires follow-up meetings",
+          fields: [
+            {
+              label: "Meetings",
+              value: expect.stringContaining(followUpMeeting.body.meeting.id),
+            },
+          ],
+        }),
+        expect.objectContaining({
+          heading: "Unsigned meetings",
+          fields: [
+            {
+              label: "Meetings",
+              value: expect.stringContaining(unsignedMeeting.body.meeting.id),
+            },
+          ],
+        }),
+      ]),
+    );
+    expect(response.body.report.report.plainText).toContain(
+      `Meetings: ${approvedMeeting.body.meeting.id} | event_triggered_safety_review | scheduled | 2026-04-24T10:00:00.000Z`,
+    );
+    expect(response.body.report.report.plainText).toContain(
+      `Meetings: ${rejectedMeeting.body.meeting.id} | sop_breach_review | scheduled | 2026-04-23T10:00:00.000Z`,
+    );
+    expect(response.body.report.report.plainText).toContain(
+      `Meetings: ${followUpMeeting.body.meeting.id} | training_review | scheduled | 2026-04-22T10:00:00.000Z`,
+    );
+    expect(response.body.report.report.plainText).toContain(
+      `Meetings: ${unsignedMeeting.body.meeting.id} | maintenance_safety_review | scheduled | 2026-04-21T10:00:00.000Z`,
+    );
+    expect(await countRows()).toEqual(before);
+  });
+
   it("exports an empty safety meeting pack without mutating source records", async () => {
     const meeting = await createEventTriggeredMeeting();
     const before = await countRows();


### PR DESCRIPTION
## Summary

Implements GitHub issue #97 by adding a governance-facing rendered report endpoint for safety meeting approval rollups.

## What changed

- Added `GET /air-safety-meetings/approval-rollup/render`.
- Added `AirSafetyMeetingApprovalRollupRenderedReport`.
- Built the rendered report from the existing structured rollup export rather than introducing a separate query path.
- Rendered the rollup as an assurance summary with:
  - overall counts
  - approved meetings
  - rejected meetings
  - requires-follow-up meetings
  - unsigned meetings
- Added clear empty-state wording when no meetings exist.
- Added integration coverage for:
  - empty rendered rollup
  - mixed-state rendered rollup
  - newest-signoff data appearing correctly through the source export
  - stable ordering in rendered output
  - no mutation of source records
- Updated the save point to the next build step.

## Verification

- `npm.cmd ci` passed.
- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 36 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 283 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `git diff --cached --check` passed.

## Notes

`node scripts\\check-next-build-step-pr.mjs origin/main` still does not run correctly in these Windows worktrees because its internal `git diff` call fails with `spawnSync ... cmd.exe EPERM`. Direct git inspection confirmed this branch is limited to the air-safety-meetings module, its tests, and the save point.

Closes #97.
