### PR TITLE
Add approval rollup PDF sign-off block

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add accountable-manager signature block to governance-facing safety meeting approval PDFs so circulated assurance summaries can be formally signed off.",
+ "nextBuildStep": "Add stored governance-summary sign-off records so formal approval of circulated safety meeting assurance summaries can be captured and audited.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/air-safety-meetings/air-safety-meeting.service.ts
+++ b/src/air-safety-meetings/air-safety-meeting.service.ts
@@ -353,6 +353,7 @@ export class AirSafetyMeetingService {
     rollupExport: AirSafetyMeetingApprovalRollupExport,
   ): AirSafetyMeetingReportSection[] {
     const records = rollupExport.records;
+    const pendingSignoff = "Pending sign-off";
     const statuses: Array<AirSafetyMeetingApprovalRollupRecord["latestSignoffApprovalStatus"]> = [
       "approved",
       "rejected",
@@ -390,6 +391,35 @@ export class AirSafetyMeetingService {
             value: records.filter(
               (record) => record.latestSignoffApprovalStatus === "unsigned",
             ).length,
+          },
+        ],
+      },
+      {
+        heading: "Accountable manager sign-off",
+        fields: [
+          {
+            label: "Accountable manager name",
+            value: pendingSignoff,
+          },
+          {
+            label: "Role/title",
+            value: pendingSignoff,
+          },
+          {
+            label: "Signature",
+            value: pendingSignoff,
+          },
+          {
+            label: "Signed date/time",
+            value: pendingSignoff,
+          },
+          {
+            label: "Review decision/status",
+            value: pendingSignoff,
+          },
+          {
+            label: "Review notes/comments",
+            value: pendingSignoff,
           },
         ],
       },

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -760,6 +760,26 @@ describe("air safety meetings", () => {
               { label: "Unsigned meetings", value: 0 },
             ]),
           }),
+          expect.objectContaining({
+            heading: "Accountable manager sign-off",
+            fields: expect.arrayContaining([
+              {
+                label: "Accountable manager name",
+                value: "Pending sign-off",
+              },
+              { label: "Role/title", value: "Pending sign-off" },
+              { label: "Signature", value: "Pending sign-off" },
+              { label: "Signed date/time", value: "Pending sign-off" },
+              {
+                label: "Review decision/status",
+                value: "Pending sign-off",
+              },
+              {
+                label: "Review notes/comments",
+                value: "Pending sign-off",
+              },
+            ]),
+          }),
           {
             heading: "Approval rollup records",
             fields: [
@@ -773,6 +793,9 @@ describe("air safety meetings", () => {
       },
     });
     expect(response.body.report.generatedAt).toEqual(expect.any(String));
+    expect(response.body.report.report.plainText).toContain(
+      "Accountable manager sign-off",
+    );
     expect(response.body.report.report.plainText).toContain(
       "Meetings: No air safety meetings recorded",
     );
@@ -905,7 +928,26 @@ describe("air safety meetings", () => {
             },
           ],
         }),
+        expect.objectContaining({
+          heading: "Accountable manager sign-off",
+          fields: expect.arrayContaining([
+            {
+              label: "Accountable manager name",
+              value: "Pending sign-off",
+            },
+            {
+              label: "Review decision/status",
+              value: "Pending sign-off",
+            },
+          ]),
+        }),
       ]),
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Accountable manager sign-off",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Review decision/status: Pending sign-off",
     );
     expect(response.body.report.report.plainText).toContain(
       `Meetings: ${approvedMeeting.body.meeting.id} | event_triggered_safety_review | scheduled | 2026-04-24T10:00:00.000Z`,
@@ -943,6 +985,12 @@ describe("air safety meetings", () => {
     );
     expect(response.body.toString("latin1")).toContain(
       "Approval rollup summary",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Accountable manager sign-off",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Pending sign-off",
     );
     expect(response.body.toString("latin1")).toContain(
       "Total meetings:",
@@ -1019,6 +1067,12 @@ describe("air safety meetings", () => {
     );
     expect(response.body.toString("latin1")).toContain(
       "Air safety meeting approval assurance summary",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Accountable manager sign-off",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Pending sign-off",
     );
     expect(response.body.toString("latin1")).toContain(
       "Total meetings:",


### PR DESCRIPTION
## Summary

Implements GitHub issue #101 by adding an accountable-manager signature block to governance-facing safety meeting approval PDFs.

## What changed

- Added an `Accountable manager sign-off` section to the governance approval rollup rendered report.
- Included pending placeholder fields for:
  - accountable manager name
  - role/title
  - signature
  - signed date/time
  - review decision/status
  - review notes/comments
- Reused the existing governance approval rollup PDF generation path, so the sign-off section now appears in:
  - `GET /air-safety-meetings/approval-rollup/pdf`
- Kept the implementation presentation-only:
  - no new persistence
  - no mutation of meetings, sign-offs, agenda links, events, proposals, decisions, or evidence
- Added integration coverage for rendered and PDF sign-off placeholder output.

## Verification

- `npm.cmd ci` passed.
- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 38 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 285 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `git diff --cached --check` passed.

## Notes

`node scripts\\check-next-build-step-pr.mjs origin/main` still does not run correctly in these Windows worktrees because its internal `git diff` call fails with `spawnSync ... cmd.exe EPERM`. Direct git inspection confirmed this branch is limited to the air-safety-meetings service/tests and the save point.

Closes #101.
