### PR TITLE
Add governance summary signoff records

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add stored governance-summary sign-off records so formal approval of circulated safety meeting assurance summaries can be captured and audited.",
+ "nextBuildStep": "Connect migration-backed governance-summary sign-off records into rendered and PDF approval summaries so placeholders are replaced by audited approval data.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/air-safety-meetings/air-safety-meeting.controller.ts
+++ b/src/air-safety-meetings/air-safety-meeting.controller.ts
@@ -84,6 +84,36 @@ export class AirSafetyMeetingController {
     }
   };
 
+  createGovernanceApprovalRollupSignoff = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const signoff =
+        await this.airSafetyMeetingService.createGovernanceApprovalRollupSignoff(
+          req.body,
+        );
+      res.status(201).json({ signoff });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listGovernanceApprovalRollupSignoffs = async (
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const signoffs =
+        await this.airSafetyMeetingService.listGovernanceApprovalRollupSignoffs();
+      res.status(200).json({ signoffs });
+    } catch (error) {
+      next(error);
+    }
+  };
+
   createAirSafetyMeetingSignoff = async (
     req: Request,
     res: Response,

--- a/src/air-safety-meetings/air-safety-meeting.repository.ts
+++ b/src/air-safety-meetings/air-safety-meeting.repository.ts
@@ -5,6 +5,7 @@ import type {
   AirSafetyMeetingApprovalRollupRecord,
   AirSafetyMeetingSignoff,
   AirSafetyMeetingSignoffDecision,
+  GovernanceApprovalRollupSignoff,
   AirSafetyMeetingPackExportAgendaItem,
   AirSafetyMeetingStatus,
   AirSafetyMeetingType,
@@ -56,6 +57,28 @@ interface AirSafetyMeetingSignoffRow extends QueryResultRow {
 
 interface CreateAirSafetyMeetingSignoffRow {
   airSafetyMeetingId: string;
+  accountableManagerName: string;
+  accountableManagerRole: string;
+  reviewDecision: AirSafetyMeetingSignoffDecision;
+  signedAt: string;
+  signatureReference: string | null;
+  reviewNotes: string | null;
+  createdBy: string | null;
+}
+
+interface GovernanceApprovalRollupSignoffRow extends QueryResultRow {
+  id: string;
+  accountable_manager_name: string;
+  accountable_manager_role: string;
+  review_decision: AirSafetyMeetingSignoffDecision;
+  signed_at: Date;
+  signature_reference: string | null;
+  review_notes: string | null;
+  created_by: string | null;
+  created_at: Date;
+}
+
+interface CreateGovernanceApprovalRollupSignoffRow {
   accountableManagerName: string;
   accountableManagerRole: string;
   reviewDecision: AirSafetyMeetingSignoffDecision;
@@ -150,6 +173,20 @@ const toAirSafetyMeetingApprovalRollupRecord = (
   signedAt: row.signed_at?.toISOString() ?? null,
   signatureReference: row.signature_reference,
   reviewNotes: row.review_notes,
+});
+
+const toGovernanceApprovalRollupSignoff = (
+  row: GovernanceApprovalRollupSignoffRow,
+): GovernanceApprovalRollupSignoff => ({
+  id: row.id,
+  accountableManagerName: row.accountable_manager_name,
+  accountableManagerRole: row.accountable_manager_role,
+  reviewDecision: row.review_decision,
+  signedAt: row.signed_at.toISOString(),
+  signatureReference: row.signature_reference,
+  reviewNotes: row.review_notes,
+  createdBy: row.created_by,
+  createdAt: row.created_at.toISOString(),
 });
 
 export class AirSafetyMeetingRepository {
@@ -293,6 +330,40 @@ export class AirSafetyMeetingRepository {
     return toAirSafetyMeetingSignoff(result.rows[0]);
   }
 
+  async insertGovernanceApprovalRollupSignoff(
+    tx: PoolClient,
+    input: CreateGovernanceApprovalRollupSignoffRow,
+  ): Promise<GovernanceApprovalRollupSignoff> {
+    const result = await tx.query<GovernanceApprovalRollupSignoffRow>(
+      `
+      insert into governance_approval_rollup_signoffs (
+        id,
+        accountable_manager_name,
+        accountable_manager_role,
+        review_decision,
+        signed_at,
+        signature_reference,
+        review_notes,
+        created_by
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8)
+      returning *
+      `,
+      [
+        randomUUID(),
+        input.accountableManagerName,
+        input.accountableManagerRole,
+        input.reviewDecision,
+        input.signedAt,
+        input.signatureReference,
+        input.reviewNotes,
+        input.createdBy,
+      ],
+    );
+
+    return toGovernanceApprovalRollupSignoff(result.rows[0]);
+  }
+
   async listAirSafetyMeetingSignoffs(
     tx: PoolClient,
     meetingId: string,
@@ -308,6 +379,20 @@ export class AirSafetyMeetingRepository {
     );
 
     return result.rows.map(toAirSafetyMeetingSignoff);
+  }
+
+  async listGovernanceApprovalRollupSignoffs(
+    tx: PoolClient,
+  ): Promise<GovernanceApprovalRollupSignoff[]> {
+    const result = await tx.query<GovernanceApprovalRollupSignoffRow>(
+      `
+      select *
+      from governance_approval_rollup_signoffs
+      order by signed_at desc, created_at desc, id desc
+      `,
+    );
+
+    return result.rows.map(toGovernanceApprovalRollupSignoff);
   }
 
   async getLatestAirSafetyMeetingSignoff(

--- a/src/air-safety-meetings/air-safety-meeting.routes.ts
+++ b/src/air-safety-meetings/air-safety-meeting.routes.ts
@@ -8,6 +8,8 @@ export function createAirSafetyMeetingRouter(
 
   router.post("/", controller.createAirSafetyMeeting);
   router.get("/", controller.listAirSafetyMeetings);
+  router.post("/approval-rollup/signoffs", controller.createGovernanceApprovalRollupSignoff);
+  router.get("/approval-rollup/signoffs", controller.listGovernanceApprovalRollupSignoffs);
   router.get("/approval-rollup/pdf", controller.generateAirSafetyMeetingApprovalRollupPdf);
   router.get("/approval-rollup/render", controller.renderAirSafetyMeetingApprovalRollup);
   router.get("/approval-rollup", controller.exportAirSafetyMeetingApprovalRollup);

--- a/src/air-safety-meetings/air-safety-meeting.service.ts
+++ b/src/air-safety-meetings/air-safety-meeting.service.ts
@@ -8,6 +8,8 @@ import type {
   AirSafetyMeetingApprovalRollupRecord,
   AirSafetyMeetingApprovalRollupRenderedReport,
   AirSafetyMeetingSignoff,
+  CreateGovernanceApprovalRollupSignoffInput,
+  GovernanceApprovalRollupSignoff,
   AirSafetyMeetingPackExportActionProposal,
   AirSafetyMeetingPackExportAgendaItem,
   AirSafetyMeetingPackExport,
@@ -22,6 +24,7 @@ import type {
 import {
   validateAirSafetyMeetingId,
   validateCreateAirSafetyMeetingInput,
+  validateCreateGovernanceApprovalRollupSignoffInput,
   validateCreateAirSafetyMeetingSignoffInput,
   validateQuarterlyComplianceQuery,
 } from "./air-safety-meeting.validators";
@@ -154,6 +157,20 @@ export class AirSafetyMeetingService {
     }
   }
 
+  async createGovernanceApprovalRollupSignoff(
+    input: CreateGovernanceApprovalRollupSignoffInput | undefined,
+  ): Promise<GovernanceApprovalRollupSignoff> {
+    const validated = validateCreateGovernanceApprovalRollupSignoffInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      return await this.airSafetyMeetingRepository
+        .insertGovernanceApprovalRollupSignoff(client, validated);
+    } finally {
+      client.release();
+    }
+  }
+
   async listAirSafetyMeetingSignoffs(
     meetingIdInput: unknown,
   ): Promise<AirSafetyMeetingSignoff[]> {
@@ -174,6 +191,19 @@ export class AirSafetyMeetingService {
         client,
         meetingId,
       );
+    } finally {
+      client.release();
+    }
+  }
+
+  async listGovernanceApprovalRollupSignoffs(): Promise<
+    GovernanceApprovalRollupSignoff[]
+  > {
+    const client = await this.pool.connect();
+
+    try {
+      return await this.airSafetyMeetingRepository
+        .listGovernanceApprovalRollupSignoffs(client);
     } finally {
       client.release();
     }

--- a/src/air-safety-meetings/air-safety-meeting.types.ts
+++ b/src/air-safety-meetings/air-safety-meeting.types.ts
@@ -45,6 +45,16 @@ export interface CreateAirSafetyMeetingSignoffInput {
   createdBy?: string | null;
 }
 
+export interface CreateGovernanceApprovalRollupSignoffInput {
+  accountableManagerName?: string;
+  accountableManagerRole?: string;
+  reviewDecision?: AirSafetyMeetingSignoffDecision;
+  signedAt?: string;
+  signatureReference?: string | null;
+  reviewNotes?: string | null;
+  createdBy?: string | null;
+}
+
 export interface AirSafetyMeeting {
   id: string;
   meetingType: AirSafetyMeetingType;
@@ -65,6 +75,18 @@ export interface AirSafetyMeeting {
 export interface AirSafetyMeetingSignoff {
   id: string;
   airSafetyMeetingId: string;
+  accountableManagerName: string;
+  accountableManagerRole: string;
+  reviewDecision: AirSafetyMeetingSignoffDecision;
+  signedAt: string;
+  signatureReference: string | null;
+  reviewNotes: string | null;
+  createdBy: string | null;
+  createdAt: string;
+}
+
+export interface GovernanceApprovalRollupSignoff {
+  id: string;
   accountableManagerName: string;
   accountableManagerRole: string;
   reviewDecision: AirSafetyMeetingSignoffDecision;

--- a/src/air-safety-meetings/air-safety-meeting.validators.ts
+++ b/src/air-safety-meetings/air-safety-meeting.validators.ts
@@ -4,6 +4,7 @@ import type {
   AirSafetyMeetingSignoffDecision,
   AirSafetyMeetingType,
   CreateAirSafetyMeetingInput,
+  CreateGovernanceApprovalRollupSignoffInput,
   CreateAirSafetyMeetingSignoffInput,
 } from "./air-safety-meeting.types";
 
@@ -208,6 +209,33 @@ export function validateCreateAirSafetyMeetingInput(
 
 export function validateCreateAirSafetyMeetingSignoffInput(
   input: CreateAirSafetyMeetingSignoffInput | undefined,
+) {
+  if (!input || typeof input !== "object") {
+    throw new AirSafetyMeetingValidationError("Request body must be an object");
+  }
+
+  return {
+    accountableManagerName: requiredString(
+      input.accountableManagerName,
+      "accountableManagerName",
+    ),
+    accountableManagerRole: requiredString(
+      input.accountableManagerRole,
+      "accountableManagerRole",
+    ),
+    reviewDecision: requiredSignoffDecision(input.reviewDecision),
+    signedAt: requiredIsoDate(input.signedAt, "signedAt"),
+    signatureReference: optionalTrimmed(
+      input.signatureReference,
+      "signatureReference",
+    ),
+    reviewNotes: optionalTrimmed(input.reviewNotes, "reviewNotes"),
+    createdBy: optionalTrimmed(input.createdBy, "createdBy"),
+  };
+}
+
+export function validateCreateGovernanceApprovalRollupSignoffInput(
+  input: CreateGovernanceApprovalRollupSignoffInput | undefined,
 ) {
   if (!input || typeof input !== "object") {
     throw new AirSafetyMeetingValidationError("Request body must be an object");

--- a/src/migrations/028_create_governance_approval_rollup_signoffs.sql
+++ b/src/migrations/028_create_governance_approval_rollup_signoffs.sql
@@ -1,0 +1,13 @@
+create table if not exists governance_approval_rollup_signoffs (
+  id uuid primary key,
+  accountable_manager_name text not null,
+  accountable_manager_role text not null,
+  review_decision text not null check (
+    review_decision in ('approved', 'rejected', 'requires_follow_up')
+  ),
+  signed_at timestamptz not null,
+  signature_reference text null,
+  review_notes text null,
+  created_by text null,
+  created_at timestamptz not null default now()
+);

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -18,6 +18,7 @@ const parseBinaryResponse = (
 };
 
 const clearTables = async () => {
+  await pool.query("delete from governance_approval_rollup_signoffs");
   await pool.query("delete from air_safety_meeting_signoffs");
   await pool.query("delete from safety_action_implementation_evidence");
   await pool.query("delete from safety_action_decisions");
@@ -51,6 +52,7 @@ const countRows = async () => {
     select
       (select count(*)::int from air_safety_meetings) as meeting_count,
       (select count(*)::int from air_safety_meeting_signoffs) as signoff_count,
+      (select count(*)::int from governance_approval_rollup_signoffs) as governance_signoff_count,
       (select count(*)::int from safety_events) as safety_event_count,
       (select count(*)::int from safety_event_meeting_triggers) as trigger_count,
       (select count(*)::int from safety_event_agenda_links) as agenda_link_count,
@@ -63,6 +65,7 @@ const countRows = async () => {
   return result.rows[0] as {
     meeting_count: number;
     signoff_count: number;
+    governance_signoff_count: number;
     safety_event_count: number;
     trigger_count: number;
     agenda_link_count: number;
@@ -70,6 +73,36 @@ const countRows = async () => {
     decision_count: number;
     implementation_evidence_count: number;
   };
+};
+
+const createGovernanceRollupSignoff = async (overrides?: {
+  accountableManagerName?: string;
+  accountableManagerRole?: string;
+  reviewDecision?: string;
+  signedAt?: string;
+  signatureReference?: string | null;
+  reviewNotes?: string | null;
+  createdBy?: string | null;
+}) => {
+  const response = await request(app)
+    .post("/air-safety-meetings/approval-rollup/signoffs")
+    .send({
+      accountableManagerName:
+        overrides?.accountableManagerName ?? "Alex Morgan",
+      accountableManagerRole:
+        overrides?.accountableManagerRole ?? "Accountable Manager",
+      reviewDecision: overrides?.reviewDecision ?? "approved",
+      signedAt: overrides?.signedAt ?? "2026-04-20T17:00:00.000Z",
+      signatureReference:
+        overrides?.signatureReference ??
+        "signature://accountable-manager/alex-morgan",
+      reviewNotes:
+        overrides?.reviewNotes ?? "Governance summary reviewed and approved.",
+      createdBy: overrides?.createdBy ?? "safety-admin",
+    });
+
+  expect(response.status).toBe(201);
+  return response.body.signoff;
 };
 
 const createEventTriggeredMeeting = async () => {
@@ -464,6 +497,106 @@ describe("air safety meetings", () => {
     });
     expect(missingListResponse.body.error).toMatchObject({
       type: "air_safety_meeting_not_found",
+    });
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("creates and lists stored governance rollup sign-offs without mutating source records", async () => {
+    const before = await countRows();
+
+    const signoff = await createGovernanceRollupSignoff();
+
+    expect(signoff).toMatchObject({
+      accountableManagerName: "Alex Morgan",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "approved",
+      signedAt: "2026-04-20T17:00:00.000Z",
+      signatureReference: "signature://accountable-manager/alex-morgan",
+      reviewNotes: "Governance summary reviewed and approved.",
+      createdBy: "safety-admin",
+    });
+    expect(signoff.id).toEqual(expect.any(String));
+    expect(signoff.createdAt).toEqual(expect.any(String));
+
+    const listResponse = await request(app).get(
+      "/air-safety-meetings/approval-rollup/signoffs",
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.signoffs).toHaveLength(1);
+    expect(listResponse.body.signoffs[0]).toEqual(signoff);
+    expect(await countRows()).toEqual({
+      ...before,
+      governance_signoff_count: before.governance_signoff_count + 1,
+    });
+  });
+
+  it("orders stored governance rollup sign-offs newest first", async () => {
+    const before = await countRows();
+
+    const firstSignoff = await createGovernanceRollupSignoff({
+      reviewDecision: "requires_follow_up",
+      signedAt: "2026-04-20T10:00:00.000Z",
+      reviewNotes: "Initial follow-up required.",
+    });
+    const secondSignoff = await createGovernanceRollupSignoff({
+      reviewDecision: "approved",
+      signedAt: "2026-04-20T12:00:00.000Z",
+      reviewNotes: "Follow-up completed and approved.",
+    });
+
+    const listResponse = await request(app).get(
+      "/air-safety-meetings/approval-rollup/signoffs",
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.signoffs).toHaveLength(2);
+    expect(listResponse.body.signoffs[0].id).toBe(secondSignoff.id);
+    expect(listResponse.body.signoffs[1].id).toBe(firstSignoff.id);
+    expect(await countRows()).toEqual({
+      ...before,
+      governance_signoff_count: before.governance_signoff_count + 2,
+    });
+  });
+
+  it("rejects invalid governance rollup sign-off requests", async () => {
+    const before = await countRows();
+
+    const missingNameResponse = await request(app)
+      .post("/air-safety-meetings/approval-rollup/signoffs")
+      .send({
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "approved",
+        signedAt: "2026-04-20T17:00:00.000Z",
+      });
+    const invalidDecisionResponse = await request(app)
+      .post("/air-safety-meetings/approval-rollup/signoffs")
+      .send({
+        accountableManagerName: "Alex Morgan",
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "maybe",
+        signedAt: "2026-04-20T17:00:00.000Z",
+      });
+    const invalidDateResponse = await request(app)
+      .post("/air-safety-meetings/approval-rollup/signoffs")
+      .send({
+        accountableManagerName: "Alex Morgan",
+        accountableManagerRole: "Accountable Manager",
+        reviewDecision: "approved",
+        signedAt: "not-a-date",
+      });
+
+    expect(missingNameResponse.status).toBe(400);
+    expect(invalidDecisionResponse.status).toBe(400);
+    expect(invalidDateResponse.status).toBe(400);
+    expect(missingNameResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_validation_failed",
+    });
+    expect(invalidDecisionResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_validation_failed",
+    });
+    expect(invalidDateResponse.body.error).toMatchObject({
+      type: "air_safety_meeting_validation_failed",
     });
     expect(await countRows()).toEqual(before);
   });


### PR DESCRIPTION
## Summary

Implements GitHub issue #103 by adding stored governance-summary sign-off records so formal approval of circulated safety meeting assurance summaries can be captured and audited.

## What changed

- Added migration-backed `governance_approval_rollup_signoffs`.
- Added governance-summary sign-off types and validation for:
  - accountable manager name
  - role/title
  - review decision/status
  - signed at
  - signature reference
  - review notes/comments
  - created by
- Added endpoints:
  - `POST /air-safety-meetings/approval-rollup/signoffs`
  - `GET /air-safety-meetings/approval-rollup/signoffs`
- Added repository and service logic scoped to governance-summary approval storage.
- Allowed multiple governance-summary sign-offs and return them newest-first.
- Added integration coverage for:
  - sign-off creation
  - sign-off listing
  - multiple sign-offs ordering
  - invalid request bodies
  - no mutation of underlying meeting, event, proposal, decision, or evidence records
- Updated the save point to the next build step.

## Verification

- `npm.cmd ci` passed.
- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 41 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 288 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `git diff --cached --check` passed.

## Notes

`node scripts\\check-next-build-step-pr.mjs origin/main` still does not run correctly in these Windows worktrees because its internal `git diff` call fails with `spawnSync ... cmd.exe EPERM`. Direct git inspection confirmed this branch is limited to the new migration, the air-safety-meetings module, its tests, and the save point.

Closes #103.
