### PR TITLE
Add governance summary signoff export context

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add governance-summary sign-off approval export context so downstream audit and governance outputs can distinguish approved, rejected, and follow-up summary decisions.",
+ "nextBuildStep": "Add governance-facing summary approval rollup consumer so downstream audit and governance tools can review summary decisions without parsing raw export payloads.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/air-safety-meetings/air-safety-meeting.service.ts
+++ b/src/air-safety-meetings/air-safety-meeting.service.ts
@@ -69,13 +69,21 @@ export class AirSafetyMeetingService {
     const client = await this.pool.connect();
 
     try {
-      const records = await this.airSafetyMeetingRepository
-        .listAirSafetyMeetingApprovalRollup(client);
+      const [records, governanceSignoff] = await Promise.all([
+        this.airSafetyMeetingRepository.listAirSafetyMeetingApprovalRollup(client),
+        this.airSafetyMeetingRepository.getLatestGovernanceApprovalRollupSignoff(
+          client,
+        ),
+      ]);
 
       return {
         exportType: "air_safety_meeting_approval_rollup",
         formatVersion: 1,
         generatedAt: new Date().toISOString(),
+        governanceSignoffApproval: {
+          status: governanceSignoff?.reviewDecision ?? "unsigned",
+          latestSignoff: governanceSignoff,
+        },
         records,
       };
     } finally {
@@ -85,10 +93,9 @@ export class AirSafetyMeetingService {
 
   async renderAirSafetyMeetingApprovalRollup(): Promise<AirSafetyMeetingApprovalRollupRenderedReport> {
     const rollupExport = await this.exportAirSafetyMeetingApprovalRollup();
-    const governanceSignoff = await this.getLatestGovernanceApprovalRollupSignoff();
     const sections = this.buildApprovalRollupReportSections(
       rollupExport,
-      governanceSignoff,
+      rollupExport.governanceSignoffApproval.latestSignoff,
     );
 
     return {
@@ -864,16 +871,4 @@ export class AirSafetyMeetingService {
     }
   }
 
-  private async getLatestGovernanceApprovalRollupSignoff(): Promise<
-    GovernanceApprovalRollupSignoff | null
-  > {
-    const client = await this.pool.connect();
-
-    try {
-      return await this.airSafetyMeetingRepository
-        .getLatestGovernanceApprovalRollupSignoff(client);
-    } finally {
-      client.release();
-    }
-  }
 }

--- a/src/air-safety-meetings/air-safety-meeting.types.ts
+++ b/src/air-safety-meetings/air-safety-meeting.types.ts
@@ -234,10 +234,16 @@ export interface AirSafetyMeetingApprovalRollupRecord {
   reviewNotes: string | null;
 }
 
+export interface GovernanceApprovalRollupSignoffApprovalContext {
+  status: "unsigned" | AirSafetyMeetingSignoffDecision;
+  latestSignoff: GovernanceApprovalRollupSignoff | null;
+}
+
 export interface AirSafetyMeetingApprovalRollupExport {
   exportType: "air_safety_meeting_approval_rollup";
   formatVersion: 1;
   generatedAt: string;
+  governanceSignoffApproval: GovernanceApprovalRollupSignoffApprovalContext;
   records: AirSafetyMeetingApprovalRollupRecord[];
 }
 

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -703,6 +703,10 @@ describe("air safety meetings", () => {
     expect(response.body.export).toMatchObject({
       exportType: "air_safety_meeting_approval_rollup",
       formatVersion: 1,
+      governanceSignoffApproval: {
+        status: "unsigned",
+        latestSignoff: null,
+      },
       records: [],
     });
     expect(response.body.export.generatedAt).toEqual(expect.any(String));
@@ -759,6 +763,15 @@ describe("air safety meetings", () => {
       signedAt: "2026-04-22T11:00:00.000Z",
       reviewNotes: "Follow-up review required.",
     });
+    const governanceSignoff = await createGovernanceRollupSignoff({
+      accountableManagerName: "Morgan Blake",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "approved",
+      signedAt: "2026-04-25T09:00:00.000Z",
+      signatureReference: "signature://governance/morgan-blake",
+      reviewNotes: "Governance summary approved for circulation.",
+      createdBy: "governance-admin",
+    });
     const before = await countRows();
 
     const response = await request(app).get(
@@ -766,6 +779,10 @@ describe("air safety meetings", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(response.body.export.governanceSignoffApproval).toEqual({
+      status: "approved",
+      latestSignoff: governanceSignoff,
+    });
     expect(response.body.export.records).toEqual([
       {
         meetingId: approvedMeeting.body.meeting.id,
@@ -1265,6 +1282,50 @@ describe("air safety meetings", () => {
     expect(response.body.toString("latin1")).toContain(
       unsignedMeeting.body.meeting.id,
     );
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("exports rejected governance-summary sign-off approval context without mutating source records", async () => {
+    const governanceSignoff = await createGovernanceRollupSignoff({
+      accountableManagerName: "Jordan Lee",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "rejected",
+      signedAt: "2026-04-20T11:00:00.000Z",
+      signatureReference: "signature://governance/jordan-rejected",
+      reviewNotes: "Rejected pending governance remediation.",
+      createdBy: "governance-admin",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get("/air-safety-meetings/approval-rollup");
+
+    expect(response.status).toBe(200);
+    expect(response.body.export.governanceSignoffApproval).toEqual({
+      status: "rejected",
+      latestSignoff: governanceSignoff,
+    });
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("exports requires-follow-up governance-summary sign-off approval context without mutating source records", async () => {
+    const governanceSignoff = await createGovernanceRollupSignoff({
+      accountableManagerName: "Taylor Shaw",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "requires_follow_up",
+      signedAt: "2026-04-20T11:00:00.000Z",
+      signatureReference: "signature://governance/taylor-follow-up",
+      reviewNotes: "Follow-up review required before circulation.",
+      createdBy: "governance-admin",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get("/air-safety-meetings/approval-rollup");
+
+    expect(response.status).toBe(200);
+    expect(response.body.export.governanceSignoffApproval).toEqual({
+      status: "requires_follow_up",
+      latestSignoff: governanceSignoff,
+    });
     expect(await countRows()).toEqual(before);
   });
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #107 by adding structured governance-summary sign-off approval context to the existing governance approval rollup export.

## What changed

- Added `governanceSignoffApproval` to `GET /air-safety-meetings/approval-rollup`.
- Export now distinguishes:
  - `unsigned`
  - `approved`
  - `rejected`
  - `requires_follow_up`
- Included the latest stored governance-summary sign-off record in export context when present.
- Reused the existing latest governance-signoff lookup instead of introducing a second approval path.
- Updated the rendered approval summary path to consume the export’s sign-off context rather than duplicating lookup logic.
- Added integration coverage for:
  - unsigned governance-summary export state
  - approved governance-summary sign-off export
  - rejected governance-summary sign-off export
  - requires-follow-up governance-summary sign-off export
  - no mutation of source records
- Updated the save point to the next build step.

## Verification

- `npm.cmd ci` passed.
- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 44 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 291 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `git diff --cached --check` passed.

## Notes

`node scripts\\check-next-build-step-pr.mjs origin/main` still does not run correctly in these Windows worktrees because its internal `git diff` call fails with `spawnSync ... cmd.exe EPERM`. Direct git inspection confirmed the change scope is limited to the governance approval rollup types/service/tests and the save point.

Closes #107.
