### PR TITLE
Add governance rollup summary consumer

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add governance-facing summary approval rollup consumer so downstream audit and governance tools can review summary decisions without parsing raw export payloads.",
+ "nextBuildStep": "Add governance-facing summary approval rendered report so downstream audit and governance users can review summary decisions in a human-readable assurance format.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/air-safety-meetings/air-safety-meeting.controller.ts
+++ b/src/air-safety-meetings/air-safety-meeting.controller.ts
@@ -62,6 +62,20 @@ export class AirSafetyMeetingController {
     }
   };
 
+  summarizeAirSafetyMeetingApprovalRollup = async (
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const summary =
+        await this.airSafetyMeetingService.summarizeAirSafetyMeetingApprovalRollup();
+      res.status(200).json({ summary });
+    } catch (error) {
+      next(error);
+    }
+  };
+
   generateAirSafetyMeetingApprovalRollupPdf = async (
     _req: Request,
     res: Response,

--- a/src/air-safety-meetings/air-safety-meeting.routes.ts
+++ b/src/air-safety-meetings/air-safety-meeting.routes.ts
@@ -12,6 +12,7 @@ export function createAirSafetyMeetingRouter(
   router.get("/approval-rollup/signoffs", controller.listGovernanceApprovalRollupSignoffs);
   router.get("/approval-rollup/pdf", controller.generateAirSafetyMeetingApprovalRollupPdf);
   router.get("/approval-rollup/render", controller.renderAirSafetyMeetingApprovalRollup);
+  router.get("/approval-rollup/summary", controller.summarizeAirSafetyMeetingApprovalRollup);
   router.get("/approval-rollup", controller.exportAirSafetyMeetingApprovalRollup);
   router.get("/quarterly-compliance", controller.getQuarterlyCompliance);
   router.post("/:meetingId/signoffs", controller.createAirSafetyMeetingSignoff);

--- a/src/air-safety-meetings/air-safety-meeting.service.ts
+++ b/src/air-safety-meetings/air-safety-meeting.service.ts
@@ -4,6 +4,7 @@ import { AirSafetyMeetingRepository } from "./air-safety-meeting.repository";
 import type {
   AirSafetyMeeting,
   AirSafetyMeetingApprovalRollupExport,
+  AirSafetyMeetingApprovalRollupSummary,
   AirSafetyMeetingApprovalRollupPdf,
   AirSafetyMeetingApprovalRollupRecord,
   AirSafetyMeetingApprovalRollupRenderedReport,
@@ -108,6 +109,40 @@ export class AirSafetyMeetingService {
         sections,
         plainText: this.renderSectionsAsPlainText(sections),
       },
+    };
+  }
+
+  async summarizeAirSafetyMeetingApprovalRollup(): Promise<AirSafetyMeetingApprovalRollupSummary> {
+    const rollupExport = await this.exportAirSafetyMeetingApprovalRollup();
+    const approvedMeetings = rollupExport.records.filter(
+      (record) => record.latestSignoffApprovalStatus === "approved",
+    );
+    const rejectedMeetings = rollupExport.records.filter(
+      (record) => record.latestSignoffApprovalStatus === "rejected",
+    );
+    const requiresFollowUpMeetings = rollupExport.records.filter(
+      (record) => record.latestSignoffApprovalStatus === "requires_follow_up",
+    );
+    const unsignedMeetings = rollupExport.records.filter(
+      (record) => record.latestSignoffApprovalStatus === "unsigned",
+    );
+
+    return {
+      summaryType: "air_safety_meeting_approval_rollup_summary",
+      formatVersion: 1,
+      generatedAt: new Date().toISOString(),
+      governanceSignoffApproval: rollupExport.governanceSignoffApproval,
+      counts: {
+        total: rollupExport.records.length,
+        approved: approvedMeetings.length,
+        rejected: rejectedMeetings.length,
+        requiresFollowUp: requiresFollowUpMeetings.length,
+        unsigned: unsignedMeetings.length,
+      },
+      approvedMeetings,
+      rejectedMeetings,
+      requiresFollowUpMeetings,
+      unsignedMeetings,
     };
   }
 

--- a/src/air-safety-meetings/air-safety-meeting.types.ts
+++ b/src/air-safety-meetings/air-safety-meeting.types.ts
@@ -247,6 +247,26 @@ export interface AirSafetyMeetingApprovalRollupExport {
   records: AirSafetyMeetingApprovalRollupRecord[];
 }
 
+export interface AirSafetyMeetingApprovalRollupSummaryCounts {
+  total: number;
+  approved: number;
+  rejected: number;
+  requiresFollowUp: number;
+  unsigned: number;
+}
+
+export interface AirSafetyMeetingApprovalRollupSummary {
+  summaryType: "air_safety_meeting_approval_rollup_summary";
+  formatVersion: 1;
+  generatedAt: string;
+  governanceSignoffApproval: GovernanceApprovalRollupSignoffApprovalContext;
+  counts: AirSafetyMeetingApprovalRollupSummaryCounts;
+  approvedMeetings: AirSafetyMeetingApprovalRollupRecord[];
+  rejectedMeetings: AirSafetyMeetingApprovalRollupRecord[];
+  requiresFollowUpMeetings: AirSafetyMeetingApprovalRollupRecord[];
+  unsignedMeetings: AirSafetyMeetingApprovalRollupRecord[];
+}
+
 export interface AirSafetyMeetingApprovalRollupRenderedReport {
   renderType: "air_safety_meeting_approval_rollup_report";
   formatVersion: 1;

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -713,6 +713,37 @@ describe("air safety meetings", () => {
     expect(await countRows()).toEqual(before);
   });
 
+  it("summarizes an empty safety meeting approval rollup without mutating source records", async () => {
+    const before = await countRows();
+
+    const response = await request(app).get(
+      "/air-safety-meetings/approval-rollup/summary",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.summary).toMatchObject({
+      summaryType: "air_safety_meeting_approval_rollup_summary",
+      formatVersion: 1,
+      governanceSignoffApproval: {
+        status: "unsigned",
+        latestSignoff: null,
+      },
+      counts: {
+        total: 0,
+        approved: 0,
+        rejected: 0,
+        requiresFollowUp: 0,
+        unsigned: 0,
+      },
+      approvedMeetings: [],
+      rejectedMeetings: [],
+      requiresFollowUpMeetings: [],
+      unsignedMeetings: [],
+    });
+    expect(response.body.summary.generatedAt).toEqual(expect.any(String));
+    expect(await countRows()).toEqual(before);
+  });
+
   it("exports governance approval rollup records for approved, rejected, follow-up, and unsigned meetings", async () => {
     const approvedMeeting = await request(app).post("/air-safety-meetings").send({
       meetingType: "event_triggered_safety_review",
@@ -849,6 +880,164 @@ describe("air safety meetings", () => {
         reviewNotes: null,
       },
     ]);
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("summarizes governance approval rollup records for consumer use without mutating source records", async () => {
+    const approvedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "event_triggered_safety_review",
+      dueAt: "2026-04-24T10:00:00.000Z",
+      chairperson: "Safety Manager",
+      createdBy: "safety-admin",
+    });
+    const rejectedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "sop_breach_review",
+      dueAt: "2026-04-23T10:00:00.000Z",
+      chairperson: "Chief Pilot",
+      createdBy: "safety-admin",
+    });
+    const followUpMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "training_review",
+      dueAt: "2026-04-22T10:00:00.000Z",
+      chairperson: "Training Manager",
+      createdBy: "safety-admin",
+    });
+    const unsignedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "maintenance_safety_review",
+      dueAt: "2026-04-21T10:00:00.000Z",
+      chairperson: "Engineering Lead",
+      createdBy: "safety-admin",
+    });
+
+    expect(approvedMeeting.status).toBe(201);
+    expect(rejectedMeeting.status).toBe(201);
+    expect(followUpMeeting.status).toBe(201);
+    expect(unsignedMeeting.status).toBe(201);
+
+    const approvedSignoff = await createMeetingSignoff(approvedMeeting.body.meeting.id, {
+      accountableManagerName: "Alex Morgan",
+      reviewDecision: "approved",
+      signedAt: "2026-04-24T11:00:00.000Z",
+      reviewNotes: "Approved for governance closure.",
+    });
+    const rejectedSignoff = await createMeetingSignoff(rejectedMeeting.body.meeting.id, {
+      accountableManagerName: "Jordan Lee",
+      reviewDecision: "rejected",
+      signedAt: "2026-04-23T11:00:00.000Z",
+      reviewNotes: "Rejected pending corrective action.",
+    });
+    const followUpSignoff = await createMeetingSignoff(followUpMeeting.body.meeting.id, {
+      accountableManagerName: "Taylor Shaw",
+      reviewDecision: "requires_follow_up",
+      signedAt: "2026-04-22T11:00:00.000Z",
+      reviewNotes: "Follow-up review required.",
+    });
+    const governanceSignoff = await createGovernanceRollupSignoff({
+      accountableManagerName: "Morgan Blake",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "approved",
+      signedAt: "2026-04-25T09:00:00.000Z",
+      signatureReference: "signature://governance/morgan-blake",
+      reviewNotes: "Governance summary approved for circulation.",
+      createdBy: "governance-admin",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get(
+      "/air-safety-meetings/approval-rollup/summary",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.summary).toMatchObject({
+      summaryType: "air_safety_meeting_approval_rollup_summary",
+      governanceSignoffApproval: {
+        status: "approved",
+        latestSignoff: governanceSignoff,
+      },
+      counts: {
+        total: 4,
+        approved: 1,
+        rejected: 1,
+        requiresFollowUp: 1,
+        unsigned: 1,
+      },
+      approvedMeetings: [
+        expect.objectContaining({
+          meetingId: approvedMeeting.body.meeting.id,
+          latestSignoffId: approvedSignoff.id,
+          latestSignoffApprovalStatus: "approved",
+        }),
+      ],
+      rejectedMeetings: [
+        expect.objectContaining({
+          meetingId: rejectedMeeting.body.meeting.id,
+          latestSignoffId: rejectedSignoff.id,
+          latestSignoffApprovalStatus: "rejected",
+        }),
+      ],
+      requiresFollowUpMeetings: [
+        expect.objectContaining({
+          meetingId: followUpMeeting.body.meeting.id,
+          latestSignoffId: followUpSignoff.id,
+          latestSignoffApprovalStatus: "requires_follow_up",
+        }),
+      ],
+      unsignedMeetings: [
+        expect.objectContaining({
+          meetingId: unsignedMeeting.body.meeting.id,
+          latestSignoffId: null,
+          latestSignoffApprovalStatus: "unsigned",
+        }),
+      ],
+    });
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("summarizes rejected governance-summary sign-off state without mutating source records", async () => {
+    const governanceSignoff = await createGovernanceRollupSignoff({
+      accountableManagerName: "Jordan Lee",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "rejected",
+      signedAt: "2026-04-20T11:00:00.000Z",
+      signatureReference: "signature://governance/jordan-rejected",
+      reviewNotes: "Rejected pending governance remediation.",
+      createdBy: "governance-admin",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get(
+      "/air-safety-meetings/approval-rollup/summary",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.summary.governanceSignoffApproval).toEqual({
+      status: "rejected",
+      latestSignoff: governanceSignoff,
+    });
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("summarizes requires-follow-up governance-summary sign-off state without mutating source records", async () => {
+    const governanceSignoff = await createGovernanceRollupSignoff({
+      accountableManagerName: "Taylor Shaw",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "requires_follow_up",
+      signedAt: "2026-04-20T11:00:00.000Z",
+      signatureReference: "signature://governance/taylor-follow-up",
+      reviewNotes: "Follow-up review required before circulation.",
+      createdBy: "governance-admin",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get(
+      "/air-safety-meetings/approval-rollup/summary",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.summary.governanceSignoffApproval).toEqual({
+      status: "requires_follow_up",
+      latestSignoff: governanceSignoff,
+    });
     expect(await countRows()).toEqual(before);
   });
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #109 by adding a governance-facing summary approval rollup consumer endpoint.

## What changed

- Added `GET /air-safety-meetings/approval-rollup/summary`.
- Added a consumer-facing summary response built from the existing approval-rollup export.
- The summary exposes:
  - governance summary sign-off approval context
  - counts by state
  - grouped meeting records for approved, rejected, requires-follow-up, and unsigned meetings
- Kept the implementation read-only and avoided introducing a second query path.
- Added integration coverage for:
  - empty summary response
  - approved governance-summary state
  - rejected governance-summary state
  - requires-follow-up governance-summary state
  - unsigned governance-summary state
  - grouped meeting records and counts
  - no mutation of source records
- Updated the save point to the next build step.

## Verification

- `npm.cmd ci` passed.
- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 48 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 295 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `git diff --cached --check` passed.

## Notes

`node scripts\\check-next-build-step-pr.mjs origin/main` still does not run correctly in these Windows worktrees because its internal `git diff` call fails with `spawnSync ... cmd.exe EPERM`. Direct git inspection confirmed the change scope is limited to the governance rollup summary controller/routes/service/types/tests and the save point.

Closes #109.
