### PR TITLE
Add governance summary approval render

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add governance-facing summary approval rendered report so downstream audit and governance users can review summary decisions in a human-readable assurance format.",
+ "nextBuildStep": "Add governance-facing summary approval PDF export so the rendered assurance summary can be circulated as a formal review artifact.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/air-safety-meetings/air-safety-meeting.controller.ts
+++ b/src/air-safety-meetings/air-safety-meeting.controller.ts
@@ -76,6 +76,20 @@ export class AirSafetyMeetingController {
     }
   };
 
+  renderAirSafetyMeetingApprovalRollupSummary = async (
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const report =
+        await this.airSafetyMeetingService.renderAirSafetyMeetingApprovalRollupSummary();
+      res.status(200).json({ report });
+    } catch (error) {
+      next(error);
+    }
+  };
+
   generateAirSafetyMeetingApprovalRollupPdf = async (
     _req: Request,
     res: Response,

--- a/src/air-safety-meetings/air-safety-meeting.routes.ts
+++ b/src/air-safety-meetings/air-safety-meeting.routes.ts
@@ -11,6 +11,7 @@ export function createAirSafetyMeetingRouter(
   router.post("/approval-rollup/signoffs", controller.createGovernanceApprovalRollupSignoff);
   router.get("/approval-rollup/signoffs", controller.listGovernanceApprovalRollupSignoffs);
   router.get("/approval-rollup/pdf", controller.generateAirSafetyMeetingApprovalRollupPdf);
+  router.get("/approval-rollup/summary/render", controller.renderAirSafetyMeetingApprovalRollupSummary);
   router.get("/approval-rollup/render", controller.renderAirSafetyMeetingApprovalRollup);
   router.get("/approval-rollup/summary", controller.summarizeAirSafetyMeetingApprovalRollup);
   router.get("/approval-rollup", controller.exportAirSafetyMeetingApprovalRollup);

--- a/src/air-safety-meetings/air-safety-meeting.service.ts
+++ b/src/air-safety-meetings/air-safety-meeting.service.ts
@@ -5,6 +5,7 @@ import type {
   AirSafetyMeeting,
   AirSafetyMeetingApprovalRollupExport,
   AirSafetyMeetingApprovalRollupSummary,
+  AirSafetyMeetingApprovalRollupSummaryRenderedReport,
   AirSafetyMeetingApprovalRollupPdf,
   AirSafetyMeetingApprovalRollupRecord,
   AirSafetyMeetingApprovalRollupRenderedReport,
@@ -143,6 +144,23 @@ export class AirSafetyMeetingService {
       rejectedMeetings,
       requiresFollowUpMeetings,
       unsignedMeetings,
+    };
+  }
+
+  async renderAirSafetyMeetingApprovalRollupSummary(): Promise<AirSafetyMeetingApprovalRollupSummaryRenderedReport> {
+    const summary = await this.summarizeAirSafetyMeetingApprovalRollup();
+    const sections = this.buildApprovalRollupSummaryReportSections(summary);
+
+    return {
+      renderType: "air_safety_meeting_approval_rollup_summary_report",
+      formatVersion: 1,
+      generatedAt: new Date().toISOString(),
+      sourceSummary: summary,
+      report: {
+        title: "Governance summary approval assurance report",
+        sections,
+        plainText: this.renderSectionsAsPlainText(sections),
+      },
     };
   }
 
@@ -531,6 +549,108 @@ export class AirSafetyMeetingService {
                     .map((record) => this.renderApprovalRollupRecord(record))
                     .join("; ")
                 : `No ${status.replaceAll("_", " ")} meetings`,
+          },
+        ],
+      });
+    });
+
+    return sections;
+  }
+
+  private buildApprovalRollupSummaryReportSections(
+    summary: AirSafetyMeetingApprovalRollupSummary,
+  ): AirSafetyMeetingReportSection[] {
+    const pendingSignoff = "Pending sign-off";
+    const signoff = summary.governanceSignoffApproval.latestSignoff;
+    const sections: AirSafetyMeetingReportSection[] = [
+      {
+        heading: "Summary approval overview",
+        fields: [
+          { label: "Summary generated at", value: summary.generatedAt },
+          {
+            label: "Governance summary approval status",
+            value: summary.governanceSignoffApproval.status,
+          },
+          { label: "Total meetings", value: summary.counts.total },
+          { label: "Approved meetings", value: summary.counts.approved },
+          { label: "Rejected meetings", value: summary.counts.rejected },
+          {
+            label: "Requires follow-up meetings",
+            value: summary.counts.requiresFollowUp,
+          },
+          { label: "Unsigned meetings", value: summary.counts.unsigned },
+        ],
+      },
+      {
+        heading: "Latest governance summary sign-off",
+        fields: [
+          {
+            label: "Accountable manager name",
+            value: signoff?.accountableManagerName ?? pendingSignoff,
+          },
+          {
+            label: "Role/title",
+            value: signoff?.accountableManagerRole ?? pendingSignoff,
+          },
+          {
+            label: "Signature",
+            value: signoff?.signatureReference ?? pendingSignoff,
+          },
+          {
+            label: "Signed date/time",
+            value: signoff?.signedAt ?? pendingSignoff,
+          },
+          {
+            label: "Review decision/status",
+            value: signoff?.reviewDecision ?? pendingSignoff,
+          },
+          {
+            label: "Review notes/comments",
+            value: signoff?.reviewNotes ?? pendingSignoff,
+          },
+        ],
+      },
+    ];
+
+    const groupedSections: Array<{
+      heading: string;
+      records: AirSafetyMeetingApprovalRollupRecord[];
+      emptyLabel: string;
+    }> = [
+      {
+        heading: "Approved meetings",
+        records: summary.approvedMeetings,
+        emptyLabel: "No approved meetings",
+      },
+      {
+        heading: "Rejected meetings",
+        records: summary.rejectedMeetings,
+        emptyLabel: "No rejected meetings",
+      },
+      {
+        heading: "Requires follow-up meetings",
+        records: summary.requiresFollowUpMeetings,
+        emptyLabel: "No requires follow-up meetings",
+      },
+      {
+        heading: "Unsigned meetings",
+        records: summary.unsignedMeetings,
+        emptyLabel: "No unsigned meetings",
+      },
+    ];
+
+    groupedSections.forEach(({ heading, records, emptyLabel }) => {
+      sections.push({
+        heading,
+        fields: [
+          {
+            label: "Meetings",
+            value:
+              records.length > 0
+                ? records
+                    .map((record) => this.renderApprovalRollupRecord(record))
+                    .join("; ")
+                : emptyLabel,
           },
         ],
       });

--- a/src/air-safety-meetings/air-safety-meeting.types.ts
+++ b/src/air-safety-meetings/air-safety-meeting.types.ts
@@ -267,6 +267,18 @@ export interface AirSafetyMeetingApprovalRollupSummary {
   unsignedMeetings: AirSafetyMeetingApprovalRollupRecord[];
 }
 
+export interface AirSafetyMeetingApprovalRollupSummaryRenderedReport {
+  renderType: "air_safety_meeting_approval_rollup_summary_report";
+  formatVersion: 1;
+  generatedAt: string;
+  sourceSummary: AirSafetyMeetingApprovalRollupSummary;
+  report: {
+    title: string;
+    sections: AirSafetyMeetingReportSection[];
+    plainText: string;
+  };
+}
+
 export interface AirSafetyMeetingApprovalRollupRenderedReport {
   renderType: "air_safety_meeting_approval_rollup_report";
   formatVersion: 1;

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -744,6 +744,74 @@ describe("air safety meetings", () => {
     expect(await countRows()).toEqual(before);
   });
 
+  it("renders an empty governance summary approval report without mutating source records", async () => {
+    const before = await countRows();
+
+    const response = await request(app).get(
+      "/air-safety-meetings/approval-rollup/summary/render",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.report).toMatchObject({
+      renderType: "air_safety_meeting_approval_rollup_summary_report",
+      formatVersion: 1,
+      sourceSummary: {
+        summaryType: "air_safety_meeting_approval_rollup_summary",
+        governanceSignoffApproval: {
+          status: "unsigned",
+          latestSignoff: null,
+        },
+        counts: {
+          total: 0,
+          approved: 0,
+          rejected: 0,
+          requiresFollowUp: 0,
+          unsigned: 0,
+        },
+      },
+      report: {
+        title: "Governance summary approval assurance report",
+        sections: expect.arrayContaining([
+          expect.objectContaining({
+            heading: "Summary approval overview",
+            fields: expect.arrayContaining([
+              { label: "Governance summary approval status", value: "unsigned" },
+              { label: "Total meetings", value: 0 },
+            ]),
+          }),
+          expect.objectContaining({
+            heading: "Latest governance summary sign-off",
+            fields: expect.arrayContaining([
+              {
+                label: "Accountable manager name",
+                value: "Pending sign-off",
+              },
+              {
+                label: "Review decision/status",
+                value: "Pending sign-off",
+              },
+            ]),
+          }),
+          expect.objectContaining({
+            heading: "Approved meetings",
+            fields: [{ label: "Meetings", value: "No approved meetings" }],
+          }),
+          expect.objectContaining({
+            heading: "Unsigned meetings",
+            fields: [{ label: "Meetings", value: "No unsigned meetings" }],
+          }),
+        ]),
+      },
+    });
+    expect(response.body.report.report.title).toBe(
+      "Governance summary approval assurance report",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Governance summary approval status: unsigned",
+    );
+    expect(await countRows()).toEqual(before);
+  });
+
   it("exports governance approval rollup records for approved, rejected, follow-up, and unsigned meetings", async () => {
     const approvedMeeting = await request(app).post("/air-safety-meetings").send({
       meetingType: "event_triggered_safety_review",
@@ -993,6 +1061,159 @@ describe("air safety meetings", () => {
     expect(await countRows()).toEqual(before);
   });
 
+  it("renders governance summary approval report with grouped meetings and counts without mutating source records", async () => {
+    const approvedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "event_triggered_safety_review",
+      dueAt: "2026-04-24T10:00:00.000Z",
+      chairperson: "Safety Manager",
+      createdBy: "safety-admin",
+    });
+    const rejectedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "sop_breach_review",
+      dueAt: "2026-04-23T10:00:00.000Z",
+      chairperson: "Chief Pilot",
+      createdBy: "safety-admin",
+    });
+    const followUpMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "training_review",
+      dueAt: "2026-04-22T10:00:00.000Z",
+      chairperson: "Training Manager",
+      createdBy: "safety-admin",
+    });
+    const unsignedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "maintenance_safety_review",
+      dueAt: "2026-04-21T10:00:00.000Z",
+      chairperson: "Engineering Lead",
+      createdBy: "safety-admin",
+    });
+
+    expect(approvedMeeting.status).toBe(201);
+    expect(rejectedMeeting.status).toBe(201);
+    expect(followUpMeeting.status).toBe(201);
+    expect(unsignedMeeting.status).toBe(201);
+
+    await createMeetingSignoff(approvedMeeting.body.meeting.id, {
+      accountableManagerName: "Alex Morgan",
+      reviewDecision: "approved",
+      signedAt: "2026-04-24T11:00:00.000Z",
+      reviewNotes: "Approved for governance closure.",
+    });
+    await createMeetingSignoff(rejectedMeeting.body.meeting.id, {
+      accountableManagerName: "Jordan Lee",
+      reviewDecision: "rejected",
+      signedAt: "2026-04-23T11:00:00.000Z",
+      reviewNotes: "Rejected pending corrective action.",
+    });
+    await createMeetingSignoff(followUpMeeting.body.meeting.id, {
+      accountableManagerName: "Taylor Shaw",
+      reviewDecision: "requires_follow_up",
+      signedAt: "2026-04-22T11:00:00.000Z",
+      reviewNotes: "Follow-up review required.",
+    });
+    const governanceSignoff = await createGovernanceRollupSignoff({
+      accountableManagerName: "Morgan Blake",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "approved",
+      signedAt: "2026-04-25T09:00:00.000Z",
+      signatureReference: "signature://governance/morgan-blake",
+      reviewNotes: "Governance summary approved for circulation.",
+      createdBy: "governance-admin",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get(
+      "/air-safety-meetings/approval-rollup/summary/render",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.report).toMatchObject({
+      renderType: "air_safety_meeting_approval_rollup_summary_report",
+      sourceSummary: {
+        governanceSignoffApproval: {
+          status: "approved",
+          latestSignoff: governanceSignoff,
+        },
+        counts: {
+          total: 4,
+          approved: 1,
+          rejected: 1,
+          requiresFollowUp: 1,
+          unsigned: 1,
+        },
+      },
+      report: {
+        sections: expect.arrayContaining([
+          expect.objectContaining({
+            heading: "Summary approval overview",
+            fields: expect.arrayContaining([
+              { label: "Governance summary approval status", value: "approved" },
+              { label: "Approved meetings", value: 1 },
+              { label: "Rejected meetings", value: 1 },
+              { label: "Requires follow-up meetings", value: 1 },
+              { label: "Unsigned meetings", value: 1 },
+            ]),
+          }),
+          expect.objectContaining({
+            heading: "Latest governance summary sign-off",
+            fields: expect.arrayContaining([
+              {
+                label: "Accountable manager name",
+                value: governanceSignoff.accountableManagerName,
+              },
+              {
+                label: "Review decision/status",
+                value: governanceSignoff.reviewDecision,
+              },
+            ]),
+          }),
+          expect.objectContaining({
+            heading: "Approved meetings",
+            fields: [
+              {
+                label: "Meetings",
+                value: expect.stringContaining(approvedMeeting.body.meeting.id),
+              },
+            ],
+          }),
+          expect.objectContaining({
+            heading: "Rejected meetings",
+            fields: [
+              {
+                label: "Meetings",
+                value: expect.stringContaining(rejectedMeeting.body.meeting.id),
+              },
+            ],
+          }),
+          expect.objectContaining({
+            heading: "Requires follow-up meetings",
+            fields: [
+              {
+                label: "Meetings",
+                value: expect.stringContaining(followUpMeeting.body.meeting.id),
+              },
+            ],
+          }),
+          expect.objectContaining({
+            heading: "Unsigned meetings",
+            fields: [
+              {
+                label: "Meetings",
+                value: expect.stringContaining(unsignedMeeting.body.meeting.id),
+              },
+            ],
+          }),
+        ]),
+      },
+    });
+    expect(response.body.report.report.plainText).toContain(
+      "Governance summary approval status: approved",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      governanceSignoff.signatureReference,
+    );
+    expect(await countRows()).toEqual(before);
+  });
+
   it("summarizes rejected governance-summary sign-off state without mutating source records", async () => {
     const governanceSignoff = await createGovernanceRollupSignoff({
       accountableManagerName: "Jordan Lee",
@@ -1017,6 +1238,33 @@ describe("air safety meetings", () => {
     expect(await countRows()).toEqual(before);
   });
 
+  it("renders rejected governance-summary sign-off state without mutating source records", async () => {
+    const governanceSignoff = await createGovernanceRollupSignoff({
+      accountableManagerName: "Jordan Lee",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "rejected",
+      signedAt: "2026-04-20T11:00:00.000Z",
+      signatureReference: "signature://governance/jordan-rejected",
+      reviewNotes: "Rejected pending governance remediation.",
+      createdBy: "governance-admin",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get(
+      "/air-safety-meetings/approval-rollup/summary/render",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.report.sourceSummary.governanceSignoffApproval).toEqual({
+      status: "rejected",
+      latestSignoff: governanceSignoff,
+    });
+    expect(response.body.report.report.plainText).toContain(
+      "Governance summary approval status: rejected",
+    );
+    expect(await countRows()).toEqual(before);
+  });
+
   it("summarizes requires-follow-up governance-summary sign-off state without mutating source records", async () => {
     const governanceSignoff = await createGovernanceRollupSignoff({
       accountableManagerName: "Taylor Shaw",
@@ -1038,6 +1286,33 @@ describe("air safety meetings", () => {
       status: "requires_follow_up",
       latestSignoff: governanceSignoff,
     });
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("renders requires-follow-up governance-summary sign-off state without mutating source records", async () => {
+    const governanceSignoff = await createGovernanceRollupSignoff({
+      accountableManagerName: "Taylor Shaw",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "requires_follow_up",
+      signedAt: "2026-04-20T11:00:00.000Z",
+      signatureReference: "signature://governance/taylor-follow-up",
+      reviewNotes: "Follow-up review required before circulation.",
+      createdBy: "governance-admin",
+    });
+    const before = await countRows();
+
+    const response = await request(app).get(
+      "/air-safety-meetings/approval-rollup/summary/render",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.report.sourceSummary.governanceSignoffApproval).toEqual({
+      status: "requires_follow_up",
+      latestSignoff: governanceSignoff,
+    });
+    expect(response.body.report.report.plainText).toContain(
+      "Governance summary approval status: requires_follow_up",
+    );
     expect(await countRows()).toEqual(before);
   });
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #111 by adding a governance-facing rendered report endpoint for the summary approval consumer.

## What changed

- Added `GET /air-safety-meetings/approval-rollup/summary/render`.
- Added a rendered report type for the governance summary approval consumer.
- Built the rendered report from the existing summary consumer response instead of introducing a second query path.
- The report presents:
  - overall governance-summary approval status
  - latest governance-summary sign-off details
  - counts by state
  - grouped meetings for approved, rejected, requires-follow-up, and unsigned states
- Added explicit empty-state wording for each grouped section.
- Kept the endpoint read-only.
- Added integration coverage for:
  - empty rendered summary report
  - approved governance-summary state
  - rejected governance-summary state
  - requires-follow-up governance-summary state
  - unsigned governance-summary state
  - grouped meeting sections and counts
  - no mutation of source records
- Updated the save point to the next build step.

## Verification

- `npm.cmd ci` passed.
- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 52 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 299 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `git diff --cached --check` passed.

## Notes

`node scripts\\check-next-build-step-pr.mjs origin/main` still does not run correctly in these Windows worktrees because its internal `git diff` call fails with `spawnSync ... cmd.exe EPERM`. Direct git inspection confirmed the change scope is limited to the governance summary render controller/routes/service/types/tests and the save point.

Closes #111.
