### PR TITLE
Add governance summary approval PDF

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add governance-facing summary approval PDF export so the rendered assurance summary can be circulated as a formal review artifact.",
+ "nextBuildStep": "Add accountable-manager signature block to governance-facing summary approval PDFs so circulated assurance summaries can be formally signed off.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/air-safety-meetings/air-safety-meeting.controller.ts
+++ b/src/air-safety-meetings/air-safety-meeting.controller.ts
@@ -90,6 +90,28 @@ export class AirSafetyMeetingController {
     }
   };
 
+  generateAirSafetyMeetingApprovalRollupSummaryPdf = async (
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const pdf =
+        await this.airSafetyMeetingService.generateAirSafetyMeetingApprovalRollupSummaryPdf();
+      res
+        .status(200)
+        .setHeader("Content-Type", pdf.contentType)
+        .setHeader(
+          "Content-Disposition",
+          `attachment; filename="${pdf.fileName}"`,
+        )
+        .setHeader("Content-Length", pdf.content.byteLength.toString())
+        .send(pdf.content);
+    } catch (error) {
+      next(error);
+    }
+  };
+
   generateAirSafetyMeetingApprovalRollupPdf = async (
     _req: Request,
     res: Response,

--- a/src/air-safety-meetings/air-safety-meeting.routes.ts
+++ b/src/air-safety-meetings/air-safety-meeting.routes.ts
@@ -11,6 +11,7 @@ export function createAirSafetyMeetingRouter(
   router.post("/approval-rollup/signoffs", controller.createGovernanceApprovalRollupSignoff);
   router.get("/approval-rollup/signoffs", controller.listGovernanceApprovalRollupSignoffs);
   router.get("/approval-rollup/pdf", controller.generateAirSafetyMeetingApprovalRollupPdf);
+  router.get("/approval-rollup/summary/pdf", controller.generateAirSafetyMeetingApprovalRollupSummaryPdf);
   router.get("/approval-rollup/summary/render", controller.renderAirSafetyMeetingApprovalRollupSummary);
   router.get("/approval-rollup/render", controller.renderAirSafetyMeetingApprovalRollup);
   router.get("/approval-rollup/summary", controller.summarizeAirSafetyMeetingApprovalRollup);

--- a/src/air-safety-meetings/air-safety-meeting.service.ts
+++ b/src/air-safety-meetings/air-safety-meeting.service.ts
@@ -6,6 +6,7 @@ import type {
   AirSafetyMeetingApprovalRollupExport,
   AirSafetyMeetingApprovalRollupSummary,
   AirSafetyMeetingApprovalRollupSummaryRenderedReport,
+  AirSafetyMeetingApprovalRollupSummaryPdf,
   AirSafetyMeetingApprovalRollupPdf,
   AirSafetyMeetingApprovalRollupRecord,
   AirSafetyMeetingApprovalRollupRenderedReport,
@@ -161,6 +162,21 @@ export class AirSafetyMeetingService {
         sections,
         plainText: this.renderSectionsAsPlainText(sections),
       },
+    };
+  }
+
+  async generateAirSafetyMeetingApprovalRollupSummaryPdf(): Promise<AirSafetyMeetingApprovalRollupSummaryPdf> {
+    const renderedReport = await this.renderAirSafetyMeetingApprovalRollupSummary();
+    const content = this.buildSimplePdf([
+      renderedReport.report.title,
+      "",
+      renderedReport.report.plainText,
+    ]);
+
+    return {
+      fileName: "air-safety-meeting-approval-rollup-summary.pdf",
+      contentType: "application/pdf",
+      content,
     };
   }
 

--- a/src/air-safety-meetings/air-safety-meeting.types.ts
+++ b/src/air-safety-meetings/air-safety-meeting.types.ts
@@ -324,3 +324,9 @@ export interface AirSafetyMeetingApprovalRollupPdf {
   contentType: "application/pdf";
   content: Buffer;
 }
+
+export interface AirSafetyMeetingApprovalRollupSummaryPdf {
+  fileName: string;
+  contentType: "application/pdf";
+  content: Buffer;
+}

--- a/src/tests/air-safety-meetings.test.ts
+++ b/src/tests/air-safety-meetings.test.ts
@@ -812,6 +812,46 @@ describe("air safety meetings", () => {
     expect(await countRows()).toEqual(before);
   });
 
+  it("generates an empty governance summary approval PDF with explicit empty-state wording", async () => {
+    const before = await countRows();
+
+    const response = await request(app)
+      .get("/air-safety-meetings/approval-rollup/summary/pdf")
+      .buffer(true)
+      .parse(parseBinaryResponse);
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("application/pdf");
+    expect(response.headers["content-disposition"]).toContain("attachment");
+    expect(response.headers["content-disposition"]).toContain(
+      "air-safety-meeting-approval-rollup-summary.pdf",
+    );
+    expect(Buffer.isBuffer(response.body)).toBe(true);
+    expect(response.body.toString("latin1", 0, 8)).toBe("%PDF-1.4");
+    expect(response.body.toString("latin1")).toContain(
+      "Governance summary approval assurance report",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Governance summary",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "approval status: unsigned",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Approved meetings",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "No approved",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Unsigned meetings",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "No unsigned",
+    );
+    expect(await countRows()).toEqual(before);
+  });
+
   it("exports governance approval rollup records for approved, rejected, follow-up, and unsigned meetings", async () => {
     const approvedMeeting = await request(app).post("/air-safety-meetings").send({
       meetingType: "event_triggered_safety_review",
@@ -1210,6 +1250,106 @@ describe("air safety meetings", () => {
     );
     expect(response.body.report.report.plainText).toContain(
       governanceSignoff.signatureReference,
+    );
+    expect(await countRows()).toEqual(before);
+  });
+
+  it("generates a populated governance summary approval PDF without mutating source records", async () => {
+    const approvedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "event_triggered_safety_review",
+      dueAt: "2026-04-24T10:00:00.000Z",
+      chairperson: "Safety Manager",
+      createdBy: "safety-admin",
+    });
+    const rejectedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "sop_breach_review",
+      dueAt: "2026-04-23T10:00:00.000Z",
+      chairperson: "Chief Pilot",
+      createdBy: "safety-admin",
+    });
+    const followUpMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "training_review",
+      dueAt: "2026-04-22T10:00:00.000Z",
+      chairperson: "Training Manager",
+      createdBy: "safety-admin",
+    });
+    const unsignedMeeting = await request(app).post("/air-safety-meetings").send({
+      meetingType: "maintenance_safety_review",
+      dueAt: "2026-04-21T10:00:00.000Z",
+      chairperson: "Engineering Lead",
+      createdBy: "safety-admin",
+    });
+
+    expect(approvedMeeting.status).toBe(201);
+    expect(rejectedMeeting.status).toBe(201);
+    expect(followUpMeeting.status).toBe(201);
+    expect(unsignedMeeting.status).toBe(201);
+
+    await createMeetingSignoff(approvedMeeting.body.meeting.id, {
+      accountableManagerName: "Alex Morgan",
+      reviewDecision: "approved",
+      signedAt: "2026-04-24T11:00:00.000Z",
+      reviewNotes: "Approved for governance closure.",
+    });
+    await createMeetingSignoff(rejectedMeeting.body.meeting.id, {
+      accountableManagerName: "Jordan Lee",
+      reviewDecision: "rejected",
+      signedAt: "2026-04-23T11:00:00.000Z",
+      reviewNotes: "Rejected pending corrective action.",
+    });
+    await createMeetingSignoff(followUpMeeting.body.meeting.id, {
+      accountableManagerName: "Taylor Shaw",
+      reviewDecision: "requires_follow_up",
+      signedAt: "2026-04-22T11:00:00.000Z",
+      reviewNotes: "Follow-up review required.",
+    });
+    const governanceSignoff = await createGovernanceRollupSignoff({
+      accountableManagerName: "Morgan Blake",
+      accountableManagerRole: "Accountable Manager",
+      reviewDecision: "approved",
+      signedAt: "2026-04-25T09:00:00.000Z",
+      signatureReference: "signature://governance/morgan-blake",
+      reviewNotes: "Governance summary approved for circulation.",
+      createdBy: "governance-admin",
+    });
+    const before = await countRows();
+
+    const response = await request(app)
+      .get("/air-safety-meetings/approval-rollup/summary/pdf")
+      .buffer(true)
+      .parse(parseBinaryResponse);
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("application/pdf");
+    expect(response.headers["content-disposition"]).toContain(
+      "air-safety-meeting-approval-rollup-summary.pdf",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Governance summary approval assurance report",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "Governance summary",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      "approval status: approved",
+    );
+    expect(response.body.toString("latin1")).toContain(
+      governanceSignoff.accountableManagerName,
+    );
+    expect(response.body.toString("latin1")).toContain(
+      governanceSignoff.signatureReference!,
+    );
+    expect(response.body.toString("latin1")).toContain(
+      approvedMeeting.body.meeting.id,
+    );
+    expect(response.body.toString("latin1")).toContain(
+      rejectedMeeting.body.meeting.id,
+    );
+    expect(response.body.toString("latin1")).toContain(
+      followUpMeeting.body.meeting.id,
+    );
+    expect(response.body.toString("latin1")).toContain(
+      unsignedMeeting.body.meeting.id,
     );
     expect(await countRows()).toEqual(before);
   });


### PR DESCRIPTION
## Summary

Implements GitHub issue #113 by adding a governance-facing summary approval PDF export.

## What changed

- Added `GET /air-safety-meetings/approval-rollup/summary/pdf`.
- Added a PDF response type for the governance summary approval report.
- Built the PDF from the existing rendered summary report rather than introducing a second query path.
- Reused the module’s existing simple PDF generation pattern.
- Added integration coverage for:
  - empty summary PDF generation
  - populated summary PDF generation
  - grouped meeting content carried into the PDF
  - no mutation of source records
- Updated the save point to the next build step.

## Verification

- `npm.cmd ci` passed.
- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/air-safety-meetings.test.ts` passed: 54 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 301 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `git diff --cached --check` passed.

## Notes

`node scripts\\check-next-build-step-pr.mjs origin/main` still does not run correctly in these Windows worktrees because its internal `git diff` call fails with `spawnSync ... cmd.exe EPERM`. Direct git inspection confirmed the change scope is limited to the governance summary PDF controller/routes/service/types/tests and the save point.

Closes #113.
