### PR TITLE
Add mission planning workspace endpoint

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add governance-summary approval distribution context so formal assurance summaries can be circulated and tracked without parsing raw PDF artifacts.",
+ "nextBuildStep": "Add mission dispatch workspace endpoint so operators can evaluate live go/no-go state, dispatch evidence, and launch blockers from a single mission view.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -151,7 +151,6 @@ const missionService = new MissionService(
   airspaceComplianceService,
   auditEvidenceRepository,
 );
-const missionController = new MissionController(missionService);
 const auditEvidenceService = new AuditEvidenceService(
   pool,
   auditEvidenceRepository,
@@ -167,6 +166,11 @@ const missionPlanningService = new MissionPlanningService(
   missionRiskRepository,
   airspaceComplianceRepository,
   auditEvidenceService,
+  missionService,
+);
+const missionController = new MissionController(
+  missionService,
+  missionPlanningService,
 );
 const missionPlanningController = new MissionPlanningController(
   missionPlanningService,

--- a/src/mission-planning/mission-planning.errors.ts
+++ b/src/mission-planning/mission-planning.errors.ts
@@ -12,6 +12,15 @@ export class MissionPlanningDraftNotFoundError extends Error {
   }
 }
 
+export class MissionPlanningMissionNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly code = "MISSION_NOT_FOUND";
+
+  constructor(missionId: string) {
+    super(`Mission not found: ${missionId}`);
+  }
+}
+
 export class MissionPlanningReferenceNotFoundError extends Error {
   readonly statusCode = 404;
   readonly code = "MISSION_PLANNING_REFERENCE_NOT_FOUND";

--- a/src/mission-planning/mission-planning.repository.ts
+++ b/src/mission-planning/mission-planning.repository.ts
@@ -12,6 +12,27 @@ interface MissionPlanningDraftRow extends QueryResultRow {
   airspace_input_present: boolean;
 }
 
+interface MissionPlanningWorkspaceRow extends QueryResultRow {
+  id: string;
+  status: string;
+  mission_plan_id: string | null;
+  platform_id: string | null;
+  pilot_id: string | null;
+  last_event_sequence_no: number;
+  risk_input_present: boolean;
+  airspace_input_present: boolean;
+}
+
+interface MissionPlanningApprovalHandoffTraceRow extends QueryResultRow {
+  id: string;
+  mission_id: string;
+  audit_evidence_snapshot_id: string;
+  mission_decision_evidence_link_id: string;
+  planning_review: MissionPlanningReview;
+  created_by: string | null;
+  created_at: string;
+}
+
 export class MissionPlanningRepository {
   async platformExists(tx: PoolClient, platformId: string): Promise<boolean> {
     const result = await tx.query(
@@ -142,6 +163,38 @@ export class MissionPlanningRepository {
     return result.rows[0] ?? null;
   }
 
+  async getMissionWorkspaceMission(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<MissionPlanningWorkspaceRow | null> {
+    const result = await tx.query<MissionPlanningWorkspaceRow>(
+      `
+      select
+        missions.id,
+        missions.status,
+        missions.mission_plan_id,
+        missions.platform_id,
+        missions.pilot_id,
+        missions.last_event_sequence_no,
+        exists (
+          select 1
+          from mission_risk_inputs risk
+          where risk.mission_id = missions.id
+        ) as risk_input_present,
+        exists (
+          select 1
+          from airspace_compliance_inputs airspace
+          where airspace.mission_id = missions.id
+        ) as airspace_input_present
+      from missions
+      where missions.id = $1
+      `,
+      [missionId],
+    );
+
+    return result.rows[0] ?? null;
+  }
+
   async insertApprovalHandoffTrace(
     tx: PoolClient,
     input: {
@@ -176,5 +229,30 @@ export class MissionPlanningRepository {
     );
 
     return result.rows[0].id;
+  }
+
+  async getLatestApprovalHandoffTrace(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<MissionPlanningApprovalHandoffTraceRow | null> {
+    const result = await tx.query<MissionPlanningApprovalHandoffTraceRow>(
+      `
+      select
+        id,
+        mission_id,
+        audit_evidence_snapshot_id,
+        mission_decision_evidence_link_id,
+        planning_review,
+        created_by,
+        created_at
+      from mission_planning_approval_handoffs
+      where mission_id = $1
+      order by created_at desc, id desc
+      limit 1
+      `,
+      [missionId],
+    );
+
+    return result.rows[0] ?? null;
   }
 }

--- a/src/mission-planning/mission-planning.service.ts
+++ b/src/mission-planning/mission-planning.service.ts
@@ -5,8 +5,10 @@ import { AuditEvidenceService } from "../audit-evidence/audit-evidence.service";
 import type { AuditReportSmsControlMapping } from "../audit-evidence/audit-evidence.types";
 import { MissionRiskRepository } from "../mission-risk/mission-risk.repository";
 import { validateCreateMissionRiskInput } from "../mission-risk/mission-risk.validators";
+import { MissionService } from "../missions/mission.service";
 import {
   MissionPlanningDraftNotFoundError,
+  MissionPlanningMissionNotFoundError,
   MissionPlanningReferenceNotFoundError,
   MissionPlanningReviewNotReadyError,
 } from "./mission-planning.errors";
@@ -15,9 +17,12 @@ import type {
   CreateMissionPlanningApprovalHandoffInput,
   CreateMissionPlanningDraftInput,
   MissionPlanningApprovalHandoff,
+  MissionPlanningApprovalHandoffTrace,
   MissionPlanningDraft,
   MissionPlanningChecklistItem,
   MissionPlanningReview,
+  MissionPlanningWorkspace,
+  MissionPlanningWorkspaceNextAction,
   UpdateMissionPlanningDraftInput,
 } from "./mission-planning.types";
 import {
@@ -27,12 +32,21 @@ import {
 } from "./mission-planning.validators";
 
 export class MissionPlanningService {
+  private static readonly LIFECYCLE_ACTIONS = [
+    "submit",
+    "approve",
+    "launch",
+    "complete",
+    "abort",
+  ] as const;
+
   constructor(
     private readonly pool: Pool,
     private readonly missionPlanningRepository: MissionPlanningRepository,
     private readonly missionRiskRepository: MissionRiskRepository,
     private readonly airspaceComplianceRepository: AirspaceComplianceRepository,
     private readonly auditEvidenceService: AuditEvidenceService,
+    private readonly missionService: MissionService,
   ) {}
 
   async createDraft(
@@ -237,6 +251,158 @@ export class MissionPlanningService {
     };
   }
 
+  async getWorkspace(missionId: string): Promise<MissionPlanningWorkspace> {
+    const client = await this.pool.connect();
+
+    try {
+      const mission = await this.missionPlanningRepository.getMissionWorkspaceMission(
+        client,
+        missionId,
+      );
+
+      if (!mission) {
+        throw new MissionPlanningMissionNotFoundError(missionId);
+      }
+
+      const latestApprovalHandoffRow =
+        await this.missionPlanningRepository.getLatestApprovalHandoffTrace(
+          client,
+          missionId,
+        );
+
+      const [
+        readiness,
+        readinessSnapshots,
+        decisionEvidenceLinks,
+        nextAllowedActions,
+      ] = await Promise.all([
+        this.missionService.checkMissionReadiness({ missionId }),
+        this.auditEvidenceService.listMissionReadinessSnapshots(missionId),
+        this.auditEvidenceService.listMissionDecisionEvidenceLinks(missionId),
+        Promise.all(
+          MissionPlanningService.LIFECYCLE_ACTIONS.map((action) =>
+            this.missionService.checkMissionTransition({ missionId, action }),
+          ),
+        ),
+      ]);
+
+      const placeholders = {
+        platformAssigned: mission.platform_id !== null,
+        pilotAssigned: mission.pilot_id !== null,
+        riskInputPresent: mission.risk_input_present,
+        airspaceInputPresent: mission.airspace_input_present,
+      };
+      const checklist = this.buildChecklist(placeholders);
+      const missingRequirements = checklist
+        .filter((item) => item.status === "missing")
+        .map((item) => item.message);
+      const readinessBlockingReasons = readiness.reasons
+        .filter((reason) => reason.severity !== "pass")
+        .map((reason) => reason.message);
+      const approvalBlockingReasons = Array.from(
+        new Set([...missingRequirements, ...readinessBlockingReasons]),
+      );
+      const launchTransition = nextAllowedActions.find(
+        (action) => action.action === "launch",
+      );
+      const dispatchBlockingReasons = Array.from(
+        new Set([
+          ...(launchTransition?.allowed === false && launchTransition.error
+            ? [launchTransition.error.message]
+            : []),
+          ...(
+            readiness.gate.blocksDispatch || readiness.gate.requiresReview
+              ? readinessBlockingReasons
+              : []
+          ),
+        ]),
+      );
+
+      return {
+        mission: {
+          id: mission.id,
+          missionPlanId: mission.mission_plan_id,
+          status: mission.status,
+          platformId: mission.platform_id,
+          pilotId: mission.pilot_id,
+          lastEventSequenceNo: Number(mission.last_event_sequence_no),
+        },
+        planning: {
+          status: mission.status,
+          missionPlanId: mission.mission_plan_id,
+          platformId: mission.platform_id,
+          pilotId: mission.pilot_id,
+          placeholders,
+          checklist,
+          readyForApproval: approvalBlockingReasons.length === 0,
+          blockingReasons: approvalBlockingReasons,
+        },
+        platform: {
+          assignedPlatformId: mission.platform_id,
+          state: this.getLinkedEntityState(
+            mission.platform_id,
+            readiness.platformReadiness !== null,
+          ),
+          summary: readiness.platformReadiness?.maintenanceStatus.platform ?? null,
+        },
+        pilot: {
+          assignedPilotId: mission.pilot_id,
+          state: this.getLinkedEntityState(
+            mission.pilot_id,
+            readiness.pilotReadiness !== null,
+          ),
+          summary: readiness.pilotReadiness?.readinessStatus.pilot ?? null,
+        },
+        missionRisk: readiness.missionRisk,
+        airspaceCompliance: readiness.airspaceCompliance,
+        readiness,
+        evidence: {
+          readinessSnapshotCount: readinessSnapshots.length,
+          latestReadinessSnapshot: readinessSnapshots[0] ?? null,
+          approvalEvidenceLinkCount: decisionEvidenceLinks.filter(
+            (link) => link.decisionType === "approval",
+          ).length,
+          latestApprovalEvidenceLink:
+            decisionEvidenceLinks.find(
+              (link) => link.decisionType === "approval",
+            ) ?? null,
+          dispatchEvidenceLinkCount: decisionEvidenceLinks.filter(
+            (link) => link.decisionType === "dispatch",
+          ).length,
+          latestDispatchEvidenceLink:
+            decisionEvidenceLinks.find(
+              (link) => link.decisionType === "dispatch",
+            ) ?? null,
+        },
+        approval: {
+          ready: approvalBlockingReasons.length === 0,
+          handoffCreated: latestApprovalHandoffRow !== null,
+          latestApprovalHandoff: latestApprovalHandoffRow
+            ? this.toApprovalHandoffTrace(latestApprovalHandoffRow)
+            : null,
+          blockingReasons: approvalBlockingReasons,
+        },
+        dispatch: {
+          ready: dispatchBlockingReasons.length === 0,
+          blockingReasons: dispatchBlockingReasons,
+        },
+        missingRequirements,
+        blockingReasons: approvalBlockingReasons,
+        nextAllowedActions: nextAllowedActions.map(
+          (action): MissionPlanningWorkspaceNextAction => ({
+            action: action.action,
+            currentStatus: action.currentStatus,
+            targetStatus: action.targetStatus,
+            allowed: action.allowed,
+            error: action.error,
+          }),
+        ),
+      };
+    } finally {
+      client.release();
+    }
+  }
+
   async createApprovalHandoff(
     missionId: string,
     input: CreateMissionPlanningApprovalHandoffInput | undefined,
@@ -317,6 +483,37 @@ export class MissionPlanningService {
     }
 
     return this.toDraft(row);
+  }
+
+  private toApprovalHandoffTrace(row: {
+    id: string;
+    mission_id: string;
+    audit_evidence_snapshot_id: string;
+    mission_decision_evidence_link_id: string;
+    planning_review: MissionPlanningReview;
+    created_by: string | null;
+    created_at: string;
+  }): MissionPlanningApprovalHandoffTrace {
+    return {
+      id: row.id,
+      missionId: row.mission_id,
+      auditEvidenceSnapshotId: row.audit_evidence_snapshot_id,
+      missionDecisionEvidenceLinkId: row.mission_decision_evidence_link_id,
+      planningReview: row.planning_review,
+      createdBy: row.created_by,
+      createdAt: row.created_at,
+    };
+  }
+
+  private getLinkedEntityState(
+    assignedId: string | null,
+    hasLoadedSummary: boolean,
+  ): "assigned" | "missing" | "not_found" {
+    if (!assignedId) {
+      return "missing";
+    }
+
+    return hasLoadedSummary ? "assigned" : "not_found";
   }
 
   private toDraft(row: {

--- a/src/mission-planning/mission-planning.types.ts
+++ b/src/mission-planning/mission-planning.types.ts
@@ -5,6 +5,12 @@ import type {
   MissionDecisionEvidenceLink,
 } from "../audit-evidence/audit-evidence.types";
 import type { CreateMissionRiskInput } from "../mission-risk/mission-risk.types";
+import type { MissionRiskAssessment } from "../mission-risk/mission-risk.types";
+import type { AirspaceComplianceAssessment } from "../airspace-compliance/airspace-compliance.types";
+import type { MissionReadinessCheck } from "../missions/mission-readiness.types";
+import type { Platform } from "../platforms/platform.types";
+import type { Pilot } from "../pilots/pilot.types";
+import type { MissionLifecycleAction } from "../modules/missions/domain/missionLifecycle";
 
 export interface CreateMissionPlanningDraftInput {
   missionPlanId?: string | null;
@@ -64,4 +70,90 @@ export interface MissionPlanningApprovalHandoff {
   snapshot: AuditEvidenceSnapshot;
   approvalEvidenceLink: MissionDecisionEvidenceLink;
   smsControlMappings: AuditReportSmsControlMapping[];
+}
+
+export interface MissionPlanningApprovalHandoffTrace {
+  id: string;
+  missionId: string;
+  auditEvidenceSnapshotId: string;
+  missionDecisionEvidenceLinkId: string;
+  planningReview: MissionPlanningReview;
+  createdBy: string | null;
+  createdAt: string;
+}
+
+export interface MissionPlanningWorkspacePlatformStatus {
+  assignedPlatformId: string | null;
+  state: "assigned" | "missing" | "not_found";
+  summary: Platform | null;
+}
+
+export interface MissionPlanningWorkspacePilotStatus {
+  assignedPilotId: string | null;
+  state: "assigned" | "missing" | "not_found";
+  summary: Pilot | null;
+}
+
+export interface MissionPlanningWorkspaceEvidenceStatus {
+  readinessSnapshotCount: number;
+  latestReadinessSnapshot: AuditEvidenceSnapshot | null;
+  approvalEvidenceLinkCount: number;
+  latestApprovalEvidenceLink: MissionDecisionEvidenceLink | null;
+  dispatchEvidenceLinkCount: number;
+  latestDispatchEvidenceLink: MissionDecisionEvidenceLink | null;
+}
+
+export interface MissionPlanningWorkspaceApprovalStatus {
+  ready: boolean;
+  handoffCreated: boolean;
+  latestApprovalHandoff: MissionPlanningApprovalHandoffTrace | null;
+  blockingReasons: string[];
+}
+
+export interface MissionPlanningWorkspaceDispatchStatus {
+  ready: boolean;
+  blockingReasons: string[];
+}
+
+export interface MissionPlanningWorkspaceNextAction {
+  action: MissionLifecycleAction;
+  currentStatus: string;
+  targetStatus: string;
+  allowed: boolean;
+  error: {
+    type: string;
+    message: string;
+  } | null;
+}
+
+export interface MissionPlanningWorkspace {
+  mission: {
+    id: string;
+    missionPlanId: string | null;
+    status: string;
+    platformId: string | null;
+    pilotId: string | null;
+    lastEventSequenceNo: number;
+  };
+  planning: {
+    status: string;
+    missionPlanId: string | null;
+    platformId: string | null;
+    pilotId: string | null;
+    placeholders: MissionPlanningDraft["placeholders"];
+    checklist: MissionPlanningChecklistItem[];
+    readyForApproval: boolean;
+    blockingReasons: string[];
+  };
+  platform: MissionPlanningWorkspacePlatformStatus;
+  pilot: MissionPlanningWorkspacePilotStatus;
+  missionRisk: MissionRiskAssessment | null;
+  airspaceCompliance: AirspaceComplianceAssessment | null;
+  readiness: MissionReadinessCheck;
+  evidence: MissionPlanningWorkspaceEvidenceStatus;
+  approval: MissionPlanningWorkspaceApprovalStatus;
+  dispatch: MissionPlanningWorkspaceDispatchStatus;
+  missingRequirements: string[];
+  blockingReasons: string[];
+  nextAllowedActions: MissionPlanningWorkspaceNextAction[];
 }

--- a/src/missions/mission.controller.ts
+++ b/src/missions/mission.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import { MissionService } from "./mission.service";
 import { InvalidMissionTransitionError } from "./errors";
 import { MissionLifecycleAction } from "../modules/missions/domain/missionLifecycle";
+import { MissionPlanningService } from "../mission-planning/mission-planning.service";
 
 const VALID_ACTIONS = new Set<MissionLifecycleAction>([
   "submit",
@@ -12,7 +13,26 @@ const VALID_ACTIONS = new Set<MissionLifecycleAction>([
 ]);
 
 export class MissionController {
-  constructor(private readonly missionService: MissionService) {}
+  constructor(
+    private readonly missionService: MissionService,
+    private readonly missionPlanningService: MissionPlanningService,
+  ) {}
+
+  getPlanningWorkspace = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const missionId = this.requireUuid(req.params.missionId, "missionId");
+      const workspace =
+        await this.missionPlanningService.getWorkspace(missionId);
+
+      res.status(200).json({ workspace });
+    } catch (error) {
+      next(error);
+    }
+  };
 
   getMissionEvents = async (
     req: Request,

--- a/src/missions/mission.routes.ts
+++ b/src/missions/mission.routes.ts
@@ -12,6 +12,10 @@ export function createMissionRouter(
   router.post("/:missionId/complete", missionController.completeMission);
   router.post("/:missionId/abort", missionController.abortMission);
 
+  router.get(
+    "/:missionId/planning-workspace",
+    missionController.getPlanningWorkspace,
+  );
   router.get("/:missionId/events", missionController.getMissionEvents);
   router.get("/:missionId/readiness", missionController.checkReadiness);
   router.get(

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -39,6 +39,19 @@ const createPilot = async () => {
   return response.body.pilot as { id: string };
 };
 
+const createPilotReadinessEvidence = async (pilotId: string) => {
+  const response = await request(app)
+    .post(`/pilots/${pilotId}/readiness-evidence`)
+    .send({
+      evidenceType: "operator_authorisation",
+      title: "Current operator authorisation",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+    });
+
+  expect(response.status).toBe(201);
+  return response.body.evidence as { id: string };
+};
+
 const lowRiskInput = {
   operatingCategory: "open",
   missionComplexity: "low",
@@ -854,5 +867,284 @@ describe("mission planning drafts", () => {
 
     expect(missingResponse.status).toBe(404);
     expect(approvedResponse.status).toBe(404);
+  });
+
+  it("returns a minimal planning workspace with missing-state guidance", async () => {
+    const createResponse = await request(app).post("/mission-plans/drafts").send({});
+
+    expect(createResponse.status).toBe(201);
+    const missionId = createResponse.body.draft.missionId as string;
+    const before = await countRows(missionId);
+
+    const workspaceResponse = await request(app).get(
+      `/missions/${missionId}/planning-workspace`,
+    );
+
+    expect(workspaceResponse.status).toBe(200);
+    expect(workspaceResponse.body.workspace).toMatchObject({
+      mission: {
+        id: missionId,
+        missionPlanId: null,
+        status: "draft",
+        platformId: null,
+        pilotId: null,
+      },
+      planning: {
+        status: "draft",
+        missionPlanId: null,
+        platformId: null,
+        pilotId: null,
+        placeholders: {
+          platformAssigned: false,
+          pilotAssigned: false,
+          riskInputPresent: false,
+          airspaceInputPresent: false,
+        },
+        readyForApproval: false,
+      },
+      platform: {
+        assignedPlatformId: null,
+        state: "missing",
+        summary: null,
+      },
+      pilot: {
+        assignedPilotId: null,
+        state: "missing",
+        summary: null,
+      },
+      missionRisk: expect.objectContaining({
+        missionId,
+        result: "fail",
+      }),
+      airspaceCompliance: expect.objectContaining({
+        missionId,
+        result: "fail",
+        input: null,
+      }),
+      evidence: {
+        readinessSnapshotCount: 0,
+        latestReadinessSnapshot: null,
+        approvalEvidenceLinkCount: 0,
+        latestApprovalEvidenceLink: null,
+        dispatchEvidenceLinkCount: 0,
+        latestDispatchEvidenceLink: null,
+      },
+      approval: {
+        ready: false,
+        handoffCreated: false,
+        latestApprovalHandoff: null,
+      },
+      dispatch: {
+        ready: false,
+      },
+    });
+    expect(workspaceResponse.body.workspace.missingRequirements).toEqual([
+      "Assign a platform before readiness can pass",
+      "Assign a pilot before readiness can pass",
+      "Add mission risk inputs before readiness can pass",
+      "Add airspace compliance inputs before readiness can pass",
+    ]);
+    expect(workspaceResponse.body.workspace.blockingReasons).toEqual(
+      expect.arrayContaining([
+        "Assign a platform before readiness can pass",
+        "Assign a pilot before readiness can pass",
+      ]),
+    );
+    expect(workspaceResponse.body.workspace.nextAllowedActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "submit",
+          currentStatus: "draft",
+          targetStatus: "submitted",
+          allowed: true,
+          error: null,
+        }),
+        expect.objectContaining({
+          action: "approve",
+          allowed: false,
+          error: expect.objectContaining({
+            type: "invalid_state_transition",
+          }),
+        }),
+      ]),
+    );
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("returns a populated planning workspace with readiness and evidence status", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    await createPilotReadinessEvidence(pilot.id);
+
+    const createResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-workspace-ready",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(createResponse.status).toBe(201);
+    const missionId = createResponse.body.draft.missionId as string;
+
+    const handoffResponse = await request(app)
+      .post(`/mission-plans/drafts/${missionId}/approval-handoff`)
+      .send({
+        createdBy: "planning lead",
+      });
+
+    expect(handoffResponse.status).toBe(201);
+
+    const workspaceResponse = await request(app).get(
+      `/missions/${missionId}/planning-workspace`,
+    );
+
+    expect(workspaceResponse.status).toBe(200);
+    expect(workspaceResponse.body.workspace).toMatchObject({
+      mission: {
+        id: missionId,
+        missionPlanId: "plan-workspace-ready",
+        status: "draft",
+        platformId: platform.id,
+        pilotId: pilot.id,
+      },
+      planning: {
+        readyForApproval: true,
+        blockingReasons: [],
+      },
+      platform: {
+        assignedPlatformId: platform.id,
+        state: "assigned",
+        summary: expect.objectContaining({
+          id: platform.id,
+          name: "Planning UAV",
+          status: "active",
+        }),
+      },
+      pilot: {
+        assignedPilotId: pilot.id,
+        state: "assigned",
+        summary: expect.objectContaining({
+          id: pilot.id,
+          displayName: "Planning Pilot",
+          status: "active",
+        }),
+      },
+      missionRisk: expect.objectContaining({
+        missionId,
+        result: "pass",
+      }),
+      airspaceCompliance: expect.objectContaining({
+        missionId,
+        result: "pass",
+      }),
+      readiness: expect.objectContaining({
+        missionId,
+        result: "pass",
+        gate: expect.objectContaining({
+          blocksApproval: false,
+          blocksDispatch: false,
+          requiresReview: false,
+        }),
+      }),
+      evidence: {
+        readinessSnapshotCount: 1,
+        latestReadinessSnapshot: expect.objectContaining({
+          missionId,
+        }),
+        approvalEvidenceLinkCount: 1,
+        latestApprovalEvidenceLink: expect.objectContaining({
+          missionId,
+          decisionType: "approval",
+        }),
+        dispatchEvidenceLinkCount: 0,
+        latestDispatchEvidenceLink: null,
+      },
+      approval: {
+        ready: true,
+        handoffCreated: true,
+        latestApprovalHandoff: expect.objectContaining({
+          missionId,
+          createdBy: "planning lead",
+        }),
+        blockingReasons: [],
+      },
+      dispatch: {
+        ready: false,
+        blockingReasons: expect.arrayContaining([
+          "Mission cannot be launched from status draft",
+        ]),
+      },
+    });
+    expect(workspaceResponse.body.workspace.missingRequirements).toEqual([]);
+    expect(workspaceResponse.body.workspace.nextAllowedActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "submit",
+          allowed: true,
+        }),
+        expect.objectContaining({
+          action: "approve",
+          allowed: false,
+        }),
+      ]),
+    );
+  });
+
+  it("keeps planning workspace evidence isolated by mission", async () => {
+    const firstMissionResponse = await request(app).post("/mission-plans/drafts").send({
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    await createPilotReadinessEvidence(pilot.id);
+    const secondMissionResponse = await request(app).post("/mission-plans/drafts").send({
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(firstMissionResponse.status).toBe(201);
+    expect(secondMissionResponse.status).toBe(201);
+
+    const secondMissionId = secondMissionResponse.body.draft.missionId as string;
+    const secondHandoffResponse = await request(app)
+      .post(`/mission-plans/drafts/${secondMissionId}/approval-handoff`)
+      .send({
+        createdBy: "planner-2",
+      });
+
+    expect(secondHandoffResponse.status).toBe(201);
+
+    const firstWorkspaceResponse = await request(app).get(
+      `/missions/${firstMissionResponse.body.draft.missionId}/planning-workspace`,
+    );
+
+    expect(firstWorkspaceResponse.status).toBe(200);
+    expect(firstWorkspaceResponse.body.workspace.evidence).toMatchObject({
+      readinessSnapshotCount: 0,
+      latestReadinessSnapshot: null,
+      approvalEvidenceLinkCount: 0,
+      latestApprovalEvidenceLink: null,
+    });
+    expect(firstWorkspaceResponse.body.workspace.approval).toMatchObject({
+      handoffCreated: false,
+      latestApprovalHandoff: null,
+    });
+  });
+
+  it("returns 404 for missing planning workspace missions", async () => {
+    const response = await request(app).get(
+      `/missions/${randomUUID()}/planning-workspace`,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "mission_not_found",
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

Implements GitHub issue #117 by adding a mission planning workspace endpoint so operators can load a single mission view with platform, pilot, risk, airspace, readiness, and evidence status.

## What changed

- Added `GET /missions/:missionId/planning-workspace`.
- Aggregated mission-centric planning state from existing mission, planning, readiness, risk, airspace, and audit evidence flows.
- Included:
  - mission core details and status
  - planning placeholders and checklist
  - linked platform and pilot summaries
  - mission risk and airspace compliance status
  - mission readiness result and gate state
  - readiness snapshot and decision evidence status
  - approval handoff status
  - dispatch readiness status
  - blocking reasons, missing requirements, and next allowed lifecycle actions
- Kept the endpoint read-only and mission-isolated.
- Added integration coverage for minimal, populated, isolated, and missing-mission workspace cases.
- Updated the save point to the next operational build step.

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/mission-planning.test.ts` passed: 22 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 305 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

Closes #117.
