### PR TITLE
Add mission dispatch workspace endpoint

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission dispatch workspace endpoint so operators can evaluate live go/no-go state, dispatch evidence, and launch blockers from a single mission view.",
+ "nextBuildStep": "Add mission operations timeline endpoint combining planning, approval, dispatch, telemetry, and post-operation evidence.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/mission-planning/mission-planning.service.ts
+++ b/src/mission-planning/mission-planning.service.ts
@@ -16,6 +16,7 @@ import { MissionPlanningRepository } from "./mission-planning.repository";
 import type {
   CreateMissionPlanningApprovalHandoffInput,
   CreateMissionPlanningDraftInput,
+  MissionDispatchWorkspace,
   MissionPlanningApprovalHandoff,
   MissionPlanningApprovalHandoffTrace,
   MissionPlanningDraft,
@@ -30,6 +31,39 @@ import {
   validateCreateMissionPlanningDraftInput,
   validateUpdateMissionPlanningDraftInput,
 } from "./mission-planning.validators";
+
+type MissionWorkspaceContext = {
+  mission: {
+    id: string;
+    status: string;
+    mission_plan_id: string | null;
+    platform_id: string | null;
+    pilot_id: string | null;
+    last_event_sequence_no: number;
+    risk_input_present: boolean;
+    airspace_input_present: boolean;
+  };
+  latestApprovalHandoff: MissionPlanningApprovalHandoffTrace | null;
+  readiness: Awaited<ReturnType<MissionService["checkMissionReadiness"]>>;
+  readinessSnapshots: Awaited<
+    ReturnType<AuditEvidenceService["listMissionReadinessSnapshots"]>
+  >;
+  decisionEvidenceLinks: Awaited<
+    ReturnType<AuditEvidenceService["listMissionDecisionEvidenceLinks"]>
+  >;
+  nextAllowedActions: Awaited<
+    ReturnType<MissionService["checkMissionTransition"]>
+  >[];
+  placeholders: {
+    platformAssigned: boolean;
+    pilotAssigned: boolean;
+    riskInputPresent: boolean;
+    airspaceInputPresent: boolean;
+  };
+  checklist: MissionPlanningChecklistItem[];
+  missingRequirements: string[];
+  readinessBlockingReasons: string[];
+};
 
 export class MissionPlanningService {
   private static readonly LIFECYCLE_ACTIONS = [
@@ -252,6 +286,274 @@ export class MissionPlanningService {
   }
 
   async getWorkspace(missionId: string): Promise<MissionPlanningWorkspace> {
+    const context = await this.getMissionWorkspaceContext(missionId);
+    const {
+      mission,
+      latestApprovalHandoff,
+      readiness,
+      readinessSnapshots,
+      decisionEvidenceLinks,
+      nextAllowedActions,
+      placeholders,
+      checklist,
+      missingRequirements,
+      readinessBlockingReasons,
+    } = context;
+    const latestApprovalEvidenceLink =
+      decisionEvidenceLinks.find((link) => link.decisionType === "approval") ??
+      null;
+    const latestDispatchEvidenceLink =
+      decisionEvidenceLinks.find((link) => link.decisionType === "dispatch") ??
+      null;
+    const approvalBlockingReasons = Array.from(
+      new Set([...missingRequirements, ...readinessBlockingReasons]),
+    );
+    const launchTransition = nextAllowedActions.find(
+      (action) => action.action === "launch",
+    );
+    const dispatchBlockingReasons = Array.from(
+      new Set([
+        ...(launchTransition?.allowed === false && launchTransition.error
+          ? [launchTransition.error.message]
+          : []),
+        ...(readiness.gate.blocksDispatch || readiness.gate.requiresReview
+          ? readinessBlockingReasons
+          : []),
+      ]),
+    );
+
+    return {
+      mission: {
+        id: mission.id,
+        missionPlanId: mission.mission_plan_id,
+        status: mission.status,
+        platformId: mission.platform_id,
+        pilotId: mission.pilot_id,
+        lastEventSequenceNo: Number(mission.last_event_sequence_no),
+      },
+      planning: {
+        status: mission.status,
+        missionPlanId: mission.mission_plan_id,
+        platformId: mission.platform_id,
+        pilotId: mission.pilot_id,
+        placeholders,
+        checklist,
+        readyForApproval: approvalBlockingReasons.length === 0,
+        blockingReasons: approvalBlockingReasons,
+      },
+      platform: {
+        assignedPlatformId: mission.platform_id,
+        state: this.getLinkedEntityState(
+          mission.platform_id,
+          readiness.platformReadiness !== null,
+        ),
+        summary: readiness.platformReadiness?.maintenanceStatus.platform ?? null,
+      },
+      pilot: {
+        assignedPilotId: mission.pilot_id,
+        state: this.getLinkedEntityState(
+          mission.pilot_id,
+          readiness.pilotReadiness !== null,
+        ),
+        summary: readiness.pilotReadiness?.readinessStatus.pilot ?? null,
+      },
+      missionRisk: readiness.missionRisk,
+      airspaceCompliance: readiness.airspaceCompliance,
+      readiness,
+      evidence: {
+        readinessSnapshotCount: readinessSnapshots.length,
+        latestReadinessSnapshot: readinessSnapshots[0] ?? null,
+        approvalEvidenceLinkCount: decisionEvidenceLinks.filter(
+          (link) => link.decisionType === "approval",
+        ).length,
+        latestApprovalEvidenceLink,
+        dispatchEvidenceLinkCount: decisionEvidenceLinks.filter(
+          (link) => link.decisionType === "dispatch",
+        ).length,
+        latestDispatchEvidenceLink,
+      },
+      approval: {
+        ready: approvalBlockingReasons.length === 0,
+        handoffCreated: latestApprovalHandoff !== null,
+        latestApprovalHandoff,
+        blockingReasons: approvalBlockingReasons,
+      },
+      dispatch: {
+        ready: dispatchBlockingReasons.length === 0,
+        blockingReasons: dispatchBlockingReasons,
+      },
+      missingRequirements,
+      blockingReasons: approvalBlockingReasons,
+      nextAllowedActions: nextAllowedActions.map(
+        (action): MissionPlanningWorkspaceNextAction => ({
+          action: action.action,
+          currentStatus: action.currentStatus,
+          targetStatus: action.targetStatus,
+          allowed: action.allowed,
+          error: action.error,
+        }),
+      ),
+    };
+  }
+
+  async getDispatchWorkspace(missionId: string): Promise<MissionDispatchWorkspace> {
+    const context = await this.getMissionWorkspaceContext(missionId);
+    const {
+      mission,
+      latestApprovalHandoff,
+      readiness,
+      readinessSnapshots,
+      decisionEvidenceLinks,
+      nextAllowedActions,
+      readinessBlockingReasons,
+    } = context;
+    const latestApprovalEvidenceLink =
+      decisionEvidenceLinks.find((link) => link.decisionType === "approval") ??
+      null;
+    const latestDispatchEvidenceLink =
+      decisionEvidenceLinks.find((link) => link.decisionType === "dispatch") ??
+      null;
+    const launchTransition = nextAllowedActions.find(
+      (action) => action.action === "launch",
+    );
+
+    if (!launchTransition) {
+      throw new Error("Launch transition preflight was not produced");
+    }
+
+    const dispatchMissingRequirements: string[] = [];
+
+    if (!latestApprovalHandoff) {
+      dispatchMissingRequirements.push(
+        "Create planning approval handoff before dispatch",
+      );
+    }
+
+    if (!latestApprovalEvidenceLink) {
+      dispatchMissingRequirements.push(
+        "Link approval evidence before dispatch",
+      );
+    }
+
+    if (!latestDispatchEvidenceLink) {
+      dispatchMissingRequirements.push(
+        "Create linked dispatch evidence before launch",
+      );
+    }
+
+    const approvalBlockingReasons = Array.from(
+      new Set([
+        ...(mission.status === "approved" ||
+        mission.status === "active" ||
+        mission.status === "completed"
+          ? []
+          : ["Mission must be approved before launch can proceed"]),
+        ...(latestApprovalHandoff
+          ? []
+          : ["Planning approval handoff is not recorded for this mission"]),
+        ...(latestApprovalEvidenceLink
+          ? []
+          : ["Approval evidence link is not recorded for this mission"]),
+      ]),
+    );
+    const dispatchBlockingReasons = Array.from(
+      new Set([
+        ...(launchTransition.allowed || !launchTransition.error
+          ? []
+          : [launchTransition.error.message]),
+        ...approvalBlockingReasons,
+        ...dispatchMissingRequirements,
+        ...(readiness.gate.blocksDispatch || readiness.gate.requiresReview
+          ? readinessBlockingReasons
+          : []),
+      ]),
+    );
+
+    return {
+      mission: {
+        id: mission.id,
+        missionPlanId: mission.mission_plan_id,
+        status: mission.status,
+        platformId: mission.platform_id,
+        pilotId: mission.pilot_id,
+        lastEventSequenceNo: Number(mission.last_event_sequence_no),
+      },
+      platform: {
+        assignedPlatformId: mission.platform_id,
+        state: this.getLinkedEntityState(
+          mission.platform_id,
+          readiness.platformReadiness !== null,
+        ),
+        summary: readiness.platformReadiness?.maintenanceStatus.platform ?? null,
+      },
+      pilot: {
+        assignedPilotId: mission.pilot_id,
+        state: this.getLinkedEntityState(
+          mission.pilot_id,
+          readiness.pilotReadiness !== null,
+        ),
+        summary: readiness.pilotReadiness?.readinessStatus.pilot ?? null,
+      },
+      missionRisk: readiness.missionRisk,
+      airspaceCompliance: readiness.airspaceCompliance,
+      readiness,
+      evidence: {
+        readinessSnapshotCount: readinessSnapshots.length,
+        latestReadinessSnapshot: readinessSnapshots[0] ?? null,
+        approvalEvidenceLinkCount: decisionEvidenceLinks.filter(
+          (link) => link.decisionType === "approval",
+        ).length,
+        latestApprovalEvidenceLink,
+        dispatchEvidenceLinkCount: decisionEvidenceLinks.filter(
+          (link) => link.decisionType === "dispatch",
+        ).length,
+        latestDispatchEvidenceLink,
+      },
+      approval: {
+        currentStatus: mission.status,
+        approvedForDispatch:
+          mission.status === "approved" ||
+          mission.status === "active" ||
+          mission.status === "completed",
+        handoffCreated: latestApprovalHandoff !== null,
+        latestApprovalHandoff,
+        latestApprovalEvidenceLink,
+        blockingReasons: approvalBlockingReasons,
+      },
+      dispatch: {
+        ready: dispatchBlockingReasons.length === 0,
+        latestDispatchEvidenceLink,
+        launchPreflight: {
+          action: launchTransition.action,
+          currentStatus: launchTransition.currentStatus,
+          targetStatus: launchTransition.targetStatus,
+          allowed: launchTransition.allowed,
+          error: launchTransition.error,
+        },
+        blockingReasons: dispatchBlockingReasons,
+        missingRequirements: dispatchMissingRequirements,
+      },
+      blockingReasons: dispatchBlockingReasons,
+      nextAllowedActions: nextAllowedActions
+        .filter(
+          (action) =>
+            action.action === "launch" ||
+            action.action === "complete" ||
+            action.action === "abort",
+        )
+        .map((action): MissionPlanningWorkspaceNextAction => ({
+          action: action.action,
+          currentStatus: action.currentStatus,
+          targetStatus: action.targetStatus,
+          allowed: action.allowed,
+          error: action.error,
+      })),
+    };
+  }
+
+  private async getMissionWorkspaceContext(
+    missionId: string,
+  ): Promise<MissionWorkspaceContext> {
     const client = await this.pool.connect();
 
     try {
@@ -269,7 +571,6 @@ export class MissionPlanningService {
           client,
           missionId,
         );
-
       const [
         readiness,
         readinessSnapshots,
@@ -285,7 +586,6 @@ export class MissionPlanningService {
           ),
         ),
       ]);
-
       const placeholders = {
         platformAssigned: mission.platform_id !== null,
         pilotAssigned: mission.pilot_id !== null,
@@ -299,104 +599,20 @@ export class MissionPlanningService {
       const readinessBlockingReasons = readiness.reasons
         .filter((reason) => reason.severity !== "pass")
         .map((reason) => reason.message);
-      const approvalBlockingReasons = Array.from(
-        new Set([...missingRequirements, ...readinessBlockingReasons]),
-      );
-      const launchTransition = nextAllowedActions.find(
-        (action) => action.action === "launch",
-      );
-      const dispatchBlockingReasons = Array.from(
-        new Set([
-          ...(launchTransition?.allowed === false && launchTransition.error
-            ? [launchTransition.error.message]
-            : []),
-          ...(
-            readiness.gate.blocksDispatch || readiness.gate.requiresReview
-              ? readinessBlockingReasons
-              : []
-          ),
-        ]),
-      );
 
       return {
-        mission: {
-          id: mission.id,
-          missionPlanId: mission.mission_plan_id,
-          status: mission.status,
-          platformId: mission.platform_id,
-          pilotId: mission.pilot_id,
-          lastEventSequenceNo: Number(mission.last_event_sequence_no),
-        },
-        planning: {
-          status: mission.status,
-          missionPlanId: mission.mission_plan_id,
-          platformId: mission.platform_id,
-          pilotId: mission.pilot_id,
-          placeholders,
-          checklist,
-          readyForApproval: approvalBlockingReasons.length === 0,
-          blockingReasons: approvalBlockingReasons,
-        },
-        platform: {
-          assignedPlatformId: mission.platform_id,
-          state: this.getLinkedEntityState(
-            mission.platform_id,
-            readiness.platformReadiness !== null,
-          ),
-          summary: readiness.platformReadiness?.maintenanceStatus.platform ?? null,
-        },
-        pilot: {
-          assignedPilotId: mission.pilot_id,
-          state: this.getLinkedEntityState(
-            mission.pilot_id,
-            readiness.pilotReadiness !== null,
-          ),
-          summary: readiness.pilotReadiness?.readinessStatus.pilot ?? null,
-        },
-        missionRisk: readiness.missionRisk,
-        airspaceCompliance: readiness.airspaceCompliance,
+        mission,
+        latestApprovalHandoff: latestApprovalHandoffRow
+          ? this.toApprovalHandoffTrace(latestApprovalHandoffRow)
+          : null,
         readiness,
-        evidence: {
-          readinessSnapshotCount: readinessSnapshots.length,
-          latestReadinessSnapshot: readinessSnapshots[0] ?? null,
-          approvalEvidenceLinkCount: decisionEvidenceLinks.filter(
-            (link) => link.decisionType === "approval",
-          ).length,
-          latestApprovalEvidenceLink:
-            decisionEvidenceLinks.find(
-              (link) => link.decisionType === "approval",
-            ) ?? null,
-          dispatchEvidenceLinkCount: decisionEvidenceLinks.filter(
-            (link) => link.decisionType === "dispatch",
-          ).length,
-          latestDispatchEvidenceLink:
-            decisionEvidenceLinks.find(
-              (link) => link.decisionType === "dispatch",
-            ) ?? null,
-        },
-        approval: {
-          ready: approvalBlockingReasons.length === 0,
-          handoffCreated: latestApprovalHandoffRow !== null,
-          latestApprovalHandoff: latestApprovalHandoffRow
-            ? this.toApprovalHandoffTrace(latestApprovalHandoffRow)
-            : null,
-          blockingReasons: approvalBlockingReasons,
-        },
-        dispatch: {
-          ready: dispatchBlockingReasons.length === 0,
-          blockingReasons: dispatchBlockingReasons,
-        },
+        readinessSnapshots,
+        decisionEvidenceLinks,
+        nextAllowedActions,
+        placeholders,
+        checklist,
         missingRequirements,
-        blockingReasons: approvalBlockingReasons,
-        nextAllowedActions: nextAllowedActions.map(
-          (action): MissionPlanningWorkspaceNextAction => ({
-            action: action.action,
-            currentStatus: action.currentStatus,
-            targetStatus: action.targetStatus,
-            allowed: action.allowed,
-            error: action.error,
-          }),
-        ),
+        readinessBlockingReasons,
       };
     } finally {
       client.release();

--- a/src/mission-planning/mission-planning.types.ts
+++ b/src/mission-planning/mission-planning.types.ts
@@ -115,6 +115,23 @@ export interface MissionPlanningWorkspaceDispatchStatus {
   blockingReasons: string[];
 }
 
+export interface MissionDispatchWorkspaceApprovalStatus {
+  currentStatus: string;
+  approvedForDispatch: boolean;
+  handoffCreated: boolean;
+  latestApprovalHandoff: MissionPlanningApprovalHandoffTrace | null;
+  latestApprovalEvidenceLink: MissionDecisionEvidenceLink | null;
+  blockingReasons: string[];
+}
+
+export interface MissionDispatchWorkspaceDispatchStatus {
+  ready: boolean;
+  latestDispatchEvidenceLink: MissionDecisionEvidenceLink | null;
+  launchPreflight: MissionPlanningWorkspaceNextAction;
+  blockingReasons: string[];
+  missingRequirements: string[];
+}
+
 export interface MissionPlanningWorkspaceNextAction {
   action: MissionLifecycleAction;
   currentStatus: string;
@@ -154,6 +171,27 @@ export interface MissionPlanningWorkspace {
   approval: MissionPlanningWorkspaceApprovalStatus;
   dispatch: MissionPlanningWorkspaceDispatchStatus;
   missingRequirements: string[];
+  blockingReasons: string[];
+  nextAllowedActions: MissionPlanningWorkspaceNextAction[];
+}
+
+export interface MissionDispatchWorkspace {
+  mission: {
+    id: string;
+    missionPlanId: string | null;
+    status: string;
+    platformId: string | null;
+    pilotId: string | null;
+    lastEventSequenceNo: number;
+  };
+  platform: MissionPlanningWorkspacePlatformStatus;
+  pilot: MissionPlanningWorkspacePilotStatus;
+  missionRisk: MissionRiskAssessment | null;
+  airspaceCompliance: AirspaceComplianceAssessment | null;
+  readiness: MissionReadinessCheck;
+  evidence: MissionPlanningWorkspaceEvidenceStatus;
+  approval: MissionDispatchWorkspaceApprovalStatus;
+  dispatch: MissionDispatchWorkspaceDispatchStatus;
   blockingReasons: string[];
   nextAllowedActions: MissionPlanningWorkspaceNextAction[];
 }

--- a/src/missions/mission.controller.ts
+++ b/src/missions/mission.controller.ts
@@ -34,6 +34,22 @@ export class MissionController {
     }
   };
 
+  getDispatchWorkspace = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const missionId = this.requireUuid(req.params.missionId, "missionId");
+      const workspace =
+        await this.missionPlanningService.getDispatchWorkspace(missionId);
+
+      res.status(200).json({ workspace });
+    } catch (error) {
+      next(error);
+    }
+  };
+
   getMissionEvents = async (
     req: Request,
     res: Response,

--- a/src/missions/mission.routes.ts
+++ b/src/missions/mission.routes.ts
@@ -16,6 +16,10 @@ export function createMissionRouter(
     "/:missionId/planning-workspace",
     missionController.getPlanningWorkspace,
   );
+  router.get(
+    "/:missionId/dispatch-workspace",
+    missionController.getDispatchWorkspace,
+  );
   router.get("/:missionId/events", missionController.getMissionEvents);
   router.get("/:missionId/readiness", missionController.checkReadiness);
   router.get(

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -52,6 +52,27 @@ const createPilotReadinessEvidence = async (pilotId: string) => {
   return response.body.evidence as { id: string };
 };
 
+const createDispatchEvidenceLink = async (missionId: string) => {
+  const snapshotResponse = await request(app)
+    .post(`/missions/${missionId}/readiness/audit-snapshots`)
+    .send({
+      createdBy: "dispatcher-1",
+    });
+
+  expect(snapshotResponse.status).toBe(201);
+
+  const linkResponse = await request(app)
+    .post(`/missions/${missionId}/decision-evidence-links`)
+    .send({
+      snapshotId: snapshotResponse.body.snapshot.id,
+      decisionType: "dispatch",
+      createdBy: "dispatcher-1",
+    });
+
+  expect(linkResponse.status).toBe(201);
+  return linkResponse.body.link as { id: string };
+};
+
 const lowRiskInput = {
   operatingCategory: "open",
   missionComplexity: "low",
@@ -1138,6 +1159,320 @@ describe("mission planning drafts", () => {
   it("returns 404 for missing planning workspace missions", async () => {
     const response = await request(app).get(
       `/missions/${randomUUID()}/planning-workspace`,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "mission_not_found",
+      },
+    });
+  });
+
+  it("returns a dispatch workspace for submitted missions with live launch blockers", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    await createPilotReadinessEvidence(pilot.id);
+
+    const createResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-dispatch-submitted",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(createResponse.status).toBe(201);
+    const missionId = createResponse.body.draft.missionId as string;
+
+    const submitResponse = await request(app)
+      .post(`/missions/${missionId}/submit`)
+      .send({
+        userId: "operator-1",
+      });
+
+    expect(submitResponse.status).toBe(204);
+
+    const workspaceResponse = await request(app).get(
+      `/missions/${missionId}/dispatch-workspace`,
+    );
+
+    expect(workspaceResponse.status).toBe(200);
+    expect(workspaceResponse.body.workspace).toMatchObject({
+      mission: {
+        id: missionId,
+        status: "submitted",
+      },
+      approval: {
+        currentStatus: "submitted",
+        approvedForDispatch: false,
+        handoffCreated: false,
+        latestApprovalHandoff: null,
+        latestApprovalEvidenceLink: null,
+      },
+      dispatch: {
+        ready: false,
+        latestDispatchEvidenceLink: null,
+        launchPreflight: {
+          action: "launch",
+          currentStatus: "submitted",
+          targetStatus: "active",
+          allowed: false,
+          error: {
+            type: "invalid_state_transition",
+            message: "Mission cannot be launched from status submitted",
+          },
+        },
+        missingRequirements: expect.arrayContaining([
+          "Create planning approval handoff before dispatch",
+          "Link approval evidence before dispatch",
+          "Create linked dispatch evidence before launch",
+        ]),
+      },
+    });
+    expect(workspaceResponse.body.workspace.blockingReasons).toEqual(
+      expect.arrayContaining([
+        "Mission cannot be launched from status submitted",
+        "Mission must be approved before launch can proceed",
+      ]),
+    );
+    expect(workspaceResponse.body.workspace.nextAllowedActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: "launch",
+          allowed: false,
+        }),
+        expect.objectContaining({
+          action: "abort",
+          allowed: true,
+        }),
+      ]),
+    );
+  });
+
+  it("returns a dispatch workspace for approved missions without dispatch evidence", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    await createPilotReadinessEvidence(pilot.id);
+
+    const createResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-dispatch-approved",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(createResponse.status).toBe(201);
+    const missionId = createResponse.body.draft.missionId as string;
+
+    const handoffResponse = await request(app)
+      .post(`/mission-plans/drafts/${missionId}/approval-handoff`)
+      .send({
+        createdBy: "planning lead",
+      });
+
+    expect(handoffResponse.status).toBe(201);
+
+    const submitResponse = await request(app)
+      .post(`/missions/${missionId}/submit`)
+      .send({
+        userId: "operator-1",
+      });
+    expect(submitResponse.status).toBe(204);
+
+    const approveResponse = await request(app)
+      .post(`/missions/${missionId}/approve`)
+      .send({
+        reviewerId: "approver-1",
+        decisionEvidenceLinkId:
+          handoffResponse.body.handoff.approvalEvidenceLink.id,
+      });
+    expect(approveResponse.status).toBe(204);
+
+    const before = await countRows(missionId);
+    const workspaceResponse = await request(app).get(
+      `/missions/${missionId}/dispatch-workspace`,
+    );
+
+    expect(workspaceResponse.status).toBe(200);
+    expect(workspaceResponse.body.workspace).toMatchObject({
+      mission: {
+        id: missionId,
+        status: "approved",
+      },
+      approval: {
+        currentStatus: "approved",
+        approvedForDispatch: true,
+        handoffCreated: true,
+        latestApprovalHandoff: expect.objectContaining({
+          missionId,
+        }),
+        latestApprovalEvidenceLink: expect.objectContaining({
+          missionId,
+          decisionType: "approval",
+        }),
+        blockingReasons: [],
+      },
+      dispatch: {
+        ready: false,
+        latestDispatchEvidenceLink: null,
+        launchPreflight: {
+          action: "launch",
+          currentStatus: "approved",
+          targetStatus: "active",
+          allowed: true,
+          error: null,
+        },
+        missingRequirements: ["Create linked dispatch evidence before launch"],
+      },
+    });
+    expect(await countRows(missionId)).toEqual(before);
+  });
+
+  it("returns a dispatch workspace for approved missions with dispatch evidence", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    await createPilotReadinessEvidence(pilot.id);
+
+    const createResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-dispatch-ready",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(createResponse.status).toBe(201);
+    const missionId = createResponse.body.draft.missionId as string;
+
+    const handoffResponse = await request(app)
+      .post(`/mission-plans/drafts/${missionId}/approval-handoff`)
+      .send({
+        createdBy: "planning lead",
+      });
+    expect(handoffResponse.status).toBe(201);
+
+    expect(
+      (
+        await request(app).post(`/missions/${missionId}/submit`).send({
+          userId: "operator-1",
+        })
+      ).status,
+    ).toBe(204);
+    expect(
+      (
+        await request(app).post(`/missions/${missionId}/approve`).send({
+          reviewerId: "approver-1",
+          decisionEvidenceLinkId:
+            handoffResponse.body.handoff.approvalEvidenceLink.id,
+        })
+      ).status,
+    ).toBe(204);
+
+    const dispatchLink = await createDispatchEvidenceLink(missionId);
+
+    const workspaceResponse = await request(app).get(
+      `/missions/${missionId}/dispatch-workspace`,
+    );
+
+    expect(workspaceResponse.status).toBe(200);
+    expect(workspaceResponse.body.workspace).toMatchObject({
+      mission: {
+        id: missionId,
+        status: "approved",
+      },
+      evidence: {
+        dispatchEvidenceLinkCount: 1,
+        latestDispatchEvidenceLink: expect.objectContaining({
+          id: dispatchLink.id,
+          missionId,
+          decisionType: "dispatch",
+        }),
+      },
+      dispatch: {
+        ready: true,
+        latestDispatchEvidenceLink: expect.objectContaining({
+          id: dispatchLink.id,
+        }),
+        launchPreflight: {
+          action: "launch",
+          currentStatus: "approved",
+          targetStatus: "active",
+          allowed: true,
+          error: null,
+        },
+        blockingReasons: [],
+        missingRequirements: [],
+      },
+    });
+  });
+
+  it("keeps dispatch workspace evidence isolated by mission", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    await createPilotReadinessEvidence(pilot.id);
+
+    const firstMissionResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "dispatch-isolated-1",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+    const secondMissionResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "dispatch-isolated-2",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(firstMissionResponse.status).toBe(201);
+    expect(secondMissionResponse.status).toBe(201);
+
+    const secondMissionId = secondMissionResponse.body.draft.missionId as string;
+    const secondHandoffResponse = await request(app)
+      .post(`/mission-plans/drafts/${secondMissionId}/approval-handoff`)
+      .send({
+        createdBy: "planning lead",
+      });
+
+    expect(secondHandoffResponse.status).toBe(201);
+    expect(
+      (
+        await request(app).post(`/missions/${secondMissionId}/submit`).send({
+          userId: "operator-1",
+        })
+      ).status,
+    ).toBe(204);
+    expect(
+      (
+        await request(app).post(`/missions/${secondMissionId}/approve`).send({
+          reviewerId: "approver-1",
+          decisionEvidenceLinkId:
+            secondHandoffResponse.body.handoff.approvalEvidenceLink.id,
+        })
+      ).status,
+    ).toBe(204);
+    await createDispatchEvidenceLink(secondMissionId);
+
+    const firstWorkspaceResponse = await request(app).get(
+      `/missions/${firstMissionResponse.body.draft.missionId}/dispatch-workspace`,
+    );
+
+    expect(firstWorkspaceResponse.status).toBe(200);
+    expect(firstWorkspaceResponse.body.workspace.evidence).toMatchObject({
+      dispatchEvidenceLinkCount: 0,
+      latestDispatchEvidenceLink: null,
+      approvalEvidenceLinkCount: 0,
+      latestApprovalEvidenceLink: null,
+    });
+  });
+
+  it("returns 404 for missing dispatch workspace missions", async () => {
+    const response = await request(app).get(
+      `/missions/${randomUUID()}/dispatch-workspace`,
     );
 
     expect(response.status).toBe(404);


### PR DESCRIPTION
## Summary

Implements GitHub issue #119 by adding a mission dispatch workspace endpoint so operators can evaluate live go/no-go state, dispatch evidence, and launch blockers from a single mission view.

## What changed

- Added `GET /missions/:missionId/dispatch-workspace`.
- Built a dispatch-focused mission workspace from existing mission, readiness, approval handoff, approval evidence, dispatch evidence, and lifecycle transition state.
- Included:
  - mission core details and lifecycle state
  - linked platform and pilot summaries
  - mission risk and airspace compliance status
  - current readiness result and gate state
  - readiness snapshot and decision evidence summary
  - approval handoff / approval evidence status
  - launch transition preflight result
  - dispatch blocking reasons
  - missing dispatch requirements
  - next allowed live-operation actions
- Kept the endpoint read-only and mission-isolated.
- Added integration coverage for:
  - submitted mission dispatch workspace with launch blockers
  - approved mission without dispatch evidence
  - approved mission with dispatch evidence
  - mission isolation
  - missing mission handling
  - no mutation of source records
- Updated the save point to the next operational build step.

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/mission-planning.test.ts` passed: 27 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 310 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

Closes #119.
