### PR TITLE
Add mission operations timeline endpoint

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission operations timeline endpoint combining planning, approval, dispatch, telemetry, and post-operation evidence.",
+ "nextBuildStep": "Add operator mission workspace UI so planning, dispatch, and operations timeline state can be reviewed from a single mission screen.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -167,6 +167,7 @@ const missionPlanningService = new MissionPlanningService(
   airspaceComplianceRepository,
   auditEvidenceService,
   missionService,
+  missionTelemetryRepo,
 );
 const missionController = new MissionController(
   missionService,

--- a/src/mission-planning/mission-planning.repository.ts
+++ b/src/mission-planning/mission-planning.repository.ts
@@ -33,6 +33,31 @@ interface MissionPlanningApprovalHandoffTraceRow extends QueryResultRow {
   created_at: string;
 }
 
+interface MissionPlanningRiskInputTimelineRow extends QueryResultRow {
+  id: string;
+  created_at: string;
+  operating_category: string;
+  mission_complexity: string;
+  population_exposure: string;
+  airspace_complexity: string;
+  weather_risk: string;
+  payload_risk: string;
+  mitigation_summary: string | null;
+}
+
+interface MissionPlanningAirspaceInputTimelineRow extends QueryResultRow {
+  id: string;
+  created_at: string;
+  airspace_class: string;
+  max_altitude_ft: number;
+  restriction_status: string;
+  permission_status: string;
+  controlled_airspace: boolean;
+  nearby_aerodrome: boolean;
+  evidence_ref: string | null;
+  notes: string | null;
+}
+
 export class MissionPlanningRepository {
   async platformExists(tx: PoolClient, platformId: string): Promise<boolean> {
     const result = await tx.query(
@@ -193,6 +218,83 @@ export class MissionPlanningRepository {
     );
 
     return result.rows[0] ?? null;
+  }
+
+  async listMissionRiskInputTimelineRows(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<MissionPlanningRiskInputTimelineRow[]> {
+    const result = await tx.query<MissionPlanningRiskInputTimelineRow>(
+      `
+      select
+        id,
+        created_at,
+        operating_category,
+        mission_complexity,
+        population_exposure,
+        airspace_complexity,
+        weather_risk,
+        payload_risk,
+        mitigation_summary
+      from mission_risk_inputs
+      where mission_id = $1
+      order by created_at asc, id asc
+      `,
+      [missionId],
+    );
+
+    return result.rows;
+  }
+
+  async listAirspaceInputTimelineRows(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<MissionPlanningAirspaceInputTimelineRow[]> {
+    const result = await tx.query<MissionPlanningAirspaceInputTimelineRow>(
+      `
+      select
+        id,
+        created_at,
+        airspace_class,
+        max_altitude_ft,
+        restriction_status,
+        permission_status,
+        controlled_airspace,
+        nearby_aerodrome,
+        evidence_ref,
+        notes
+      from airspace_compliance_inputs
+      where mission_id = $1
+      order by created_at asc, id asc
+      `,
+      [missionId],
+    );
+
+    return result.rows;
+  }
+
+  async listApprovalHandoffTraces(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<MissionPlanningApprovalHandoffTraceRow[]> {
+    const result = await tx.query<MissionPlanningApprovalHandoffTraceRow>(
+      `
+      select
+        id,
+        mission_id,
+        audit_evidence_snapshot_id,
+        mission_decision_evidence_link_id,
+        planning_review,
+        created_by,
+        created_at
+      from mission_planning_approval_handoffs
+      where mission_id = $1
+      order by created_at asc, id asc
+      `,
+      [missionId],
+    );
+
+    return result.rows;
   }
 
   async insertApprovalHandoffTrace(

--- a/src/mission-planning/mission-planning.service.ts
+++ b/src/mission-planning/mission-planning.service.ts
@@ -6,6 +6,7 @@ import type { AuditReportSmsControlMapping } from "../audit-evidence/audit-evide
 import { MissionRiskRepository } from "../mission-risk/mission-risk.repository";
 import { validateCreateMissionRiskInput } from "../mission-risk/mission-risk.validators";
 import { MissionService } from "../missions/mission.service";
+import { MissionTelemetryRepository } from "../missions/mission-telemetry.repository";
 import {
   MissionPlanningDraftNotFoundError,
   MissionPlanningMissionNotFoundError,
@@ -17,6 +18,11 @@ import type {
   CreateMissionPlanningApprovalHandoffInput,
   CreateMissionPlanningDraftInput,
   MissionDispatchWorkspace,
+  MissionOperationsTelemetrySummary,
+  MissionOperationsTimeline,
+  MissionOperationsTimelineItem,
+  MissionOperationsTimelinePhase,
+  MissionOperationsTimelinePhaseStatus,
   MissionPlanningApprovalHandoff,
   MissionPlanningApprovalHandoffTrace,
   MissionPlanningDraft,
@@ -81,6 +87,7 @@ export class MissionPlanningService {
     private readonly airspaceComplianceRepository: AirspaceComplianceRepository,
     private readonly auditEvidenceService: AuditEvidenceService,
     private readonly missionService: MissionService,
+    private readonly missionTelemetryRepository: MissionTelemetryRepository,
   ) {}
 
   async createDraft(
@@ -551,6 +558,199 @@ export class MissionPlanningService {
     };
   }
 
+  async getOperationsTimeline(
+    missionId: string,
+  ): Promise<MissionOperationsTimeline> {
+    const context = await this.getMissionWorkspaceContext(missionId);
+    const {
+      mission,
+      decisionEvidenceLinks,
+    } = context;
+    const client = await this.pool.connect();
+
+    try {
+      const lifecycleEvents = await this.missionService.getMissionEvents(
+        missionId,
+        {},
+      );
+      const planningHandoffs =
+        await this.missionPlanningRepository.listApprovalHandoffTraces(
+          client,
+          missionId,
+        );
+      const riskInputs =
+        await this.missionPlanningRepository.listMissionRiskInputTimelineRows(
+          client,
+          missionId,
+        );
+      const airspaceInputs =
+        await this.missionPlanningRepository.listAirspaceInputTimelineRows(
+          client,
+          missionId,
+        );
+      const telemetrySummary =
+        await this.missionTelemetryRepository.getTimelineSummaryByMissionId(
+          missionId,
+          client,
+        );
+      const postOperationSnapshots =
+        await this.auditEvidenceService.listPostOperationEvidenceSnapshots(
+          missionId,
+        );
+
+      const items: MissionOperationsTimelineItem[] = [
+        ...riskInputs.map((input) => ({
+          id: `planning-risk-${input.id}`,
+          phase: "planning" as const,
+          type: "planning_risk_input" as const,
+          occurredAt: input.created_at,
+          source: "mission-risk-service",
+          summary: `Mission risk input recorded (${input.operating_category}/${input.mission_complexity})`,
+          details: {
+            id: input.id,
+            operatingCategory: input.operating_category,
+            missionComplexity: input.mission_complexity,
+            populationExposure: input.population_exposure,
+            airspaceComplexity: input.airspace_complexity,
+            weatherRisk: input.weather_risk,
+            payloadRisk: input.payload_risk,
+            mitigationSummary: input.mitigation_summary,
+          },
+        })),
+        ...airspaceInputs.map((input) => ({
+          id: `planning-airspace-${input.id}`,
+          phase: "planning" as const,
+          type: "planning_airspace_input" as const,
+          occurredAt: input.created_at,
+          source: "airspace-compliance-service",
+          summary: `Airspace input recorded (${input.airspace_class.toUpperCase()} / ${input.permission_status})`,
+          details: {
+            id: input.id,
+            airspaceClass: input.airspace_class,
+            maxAltitudeFt: Number(input.max_altitude_ft),
+            restrictionStatus: input.restriction_status,
+            permissionStatus: input.permission_status,
+            controlledAirspace: input.controlled_airspace,
+            nearbyAerodrome: input.nearby_aerodrome,
+            evidenceRef: input.evidence_ref,
+            notes: input.notes,
+          },
+        })),
+        ...planningHandoffs.map((handoff) => ({
+          id: `planning-handoff-${handoff.id}`,
+          phase: "planning" as const,
+          type: "planning_approval_handoff" as const,
+          occurredAt: handoff.created_at,
+          source: "mission-planning-service",
+          summary: "Planning approval handoff recorded",
+          details: {
+            id: handoff.id,
+            auditEvidenceSnapshotId: handoff.audit_evidence_snapshot_id,
+            missionDecisionEvidenceLinkId: handoff.mission_decision_evidence_link_id,
+            planningReview: handoff.planning_review,
+            createdBy: handoff.created_by,
+          },
+        })),
+        ...decisionEvidenceLinks.map((link) => ({
+          id: `decision-evidence-${link.id}`,
+          phase: link.decisionType === "approval" ? ("approval" as const) : ("dispatch" as const),
+          type: "decision_evidence_link" as const,
+          occurredAt: link.createdAt,
+          source: "audit-evidence-service",
+          summary:
+            link.decisionType === "approval"
+              ? "Approval evidence linked"
+              : "Dispatch evidence linked",
+          details: {
+            id: link.id,
+            decisionType: link.decisionType,
+            auditEvidenceSnapshotId: link.auditEvidenceSnapshotId,
+            createdBy: link.createdBy,
+          },
+        })),
+        ...lifecycleEvents.map((event) => ({
+          id: `mission-event-${event.id}`,
+          phase: this.getLifecyclePhase(event.type),
+          type: "mission_event" as const,
+          occurredAt: event.time,
+          source: event.type,
+          summary: event.summary,
+          details: {
+            id: event.id,
+            sequence: event.sequence,
+            eventType: event.type,
+            actorType: event.actorType,
+            actorId: event.actorId,
+            fromState: event.fromState,
+            toState: event.toState,
+            details: event.details,
+          },
+        })),
+        ...(telemetrySummary.recordCount > 0 && telemetrySummary.lastRecordedAt
+          ? [
+              {
+                id: `telemetry-summary-${mission.id}`,
+                phase: "flight" as const,
+                type: "telemetry_summary" as const,
+                occurredAt: telemetrySummary.lastRecordedAt.toISOString(),
+                source: "mission-telemetry-service",
+                summary: `Telemetry recorded (${telemetrySummary.recordCount} records)`,
+                details: {
+                  recordCount: telemetrySummary.recordCount,
+                  firstRecordedAt:
+                    telemetrySummary.firstRecordedAt?.toISOString() ?? null,
+                  lastRecordedAt:
+                    telemetrySummary.lastRecordedAt?.toISOString() ?? null,
+                  latestRecord: telemetrySummary.latestRecord
+                    ? {
+                        timestamp: telemetrySummary.latestRecord.recordedAt.toISOString(),
+                        lat: telemetrySummary.latestRecord.lat,
+                        lng: telemetrySummary.latestRecord.lng,
+                        altitudeM: telemetrySummary.latestRecord.altitudeM,
+                        speedMps: telemetrySummary.latestRecord.speedMps,
+                        headingDeg: telemetrySummary.latestRecord.headingDeg,
+                        progressPct: telemetrySummary.latestRecord.progressPct,
+                        payload: telemetrySummary.latestRecord.payload,
+                      }
+                    : null,
+                },
+              },
+            ]
+          : []),
+        ...postOperationSnapshots.map((snapshot) => ({
+          id: `post-operation-${snapshot.id}`,
+          phase: "post_operation" as const,
+          type: "post_operation_snapshot" as const,
+          occurredAt: snapshot.createdAt,
+          source: "audit-evidence-service",
+          summary: "Post-operation evidence snapshot recorded",
+          details: {
+            id: snapshot.id,
+            evidenceType: snapshot.evidenceType,
+            lifecycleState: snapshot.lifecycleState,
+            createdBy: snapshot.createdBy,
+            completionSnapshot: snapshot.completionSnapshot,
+          },
+        })),
+      ].sort((left, right) => this.compareTimelineItems(left, right));
+
+      return {
+        mission: {
+          id: mission.id,
+          missionPlanId: mission.mission_plan_id,
+          status: mission.status,
+          platformId: mission.platform_id,
+          pilotId: mission.pilot_id,
+          lastEventSequenceNo: Number(mission.last_event_sequence_no),
+        },
+        phases: this.buildTimelinePhaseStatuses(items, telemetrySummary),
+        items,
+      };
+    } finally {
+      client.release();
+    }
+  }
+
   private async getMissionWorkspaceContext(
     missionId: string,
   ): Promise<MissionWorkspaceContext> {
@@ -719,6 +919,102 @@ export class MissionPlanningService {
       createdBy: row.created_by,
       createdAt: row.created_at,
     };
+  }
+
+  private getLifecyclePhase(eventType: string): MissionOperationsTimelinePhase {
+    if (eventType === "mission.approved") {
+      return "approval";
+    }
+
+    if (eventType === "mission.launched" || eventType === "mission.aborted") {
+      return "dispatch";
+    }
+
+    if (eventType === "mission.completed") {
+      return "post_operation";
+    }
+
+    return "approval";
+  }
+
+  private compareTimelineItems(
+    left: MissionOperationsTimelineItem,
+    right: MissionOperationsTimelineItem,
+  ): number {
+    const byTime =
+      new Date(left.occurredAt).getTime() - new Date(right.occurredAt).getTime();
+
+    if (byTime !== 0) {
+      return byTime;
+    }
+
+    const phaseRank = this.getPhaseRank(left.phase) - this.getPhaseRank(right.phase);
+
+    if (phaseRank !== 0) {
+      return phaseRank;
+    }
+
+    return left.id.localeCompare(right.id);
+  }
+
+  private getPhaseRank(phase: MissionOperationsTimelinePhase): number {
+    switch (phase) {
+      case "planning":
+        return 0;
+      case "approval":
+        return 1;
+      case "dispatch":
+        return 2;
+      case "flight":
+        return 3;
+      case "post_operation":
+        return 4;
+      default:
+        return 99;
+    }
+  }
+
+  private buildTimelinePhaseStatuses(
+    items: MissionOperationsTimelineItem[],
+    telemetrySummary: {
+      recordCount: number;
+      firstRecordedAt: Date | null;
+      lastRecordedAt: Date | null;
+      latestRecord: unknown;
+    },
+  ): MissionOperationsTimelinePhaseStatus[] {
+    return ([
+      "planning",
+      "approval",
+      "dispatch",
+      "flight",
+      "post_operation",
+    ] as MissionOperationsTimelinePhase[]).map((phase) => {
+      const phaseItems = items.filter((item) => item.phase === phase);
+      const latestAt =
+        phaseItems.length > 0
+          ? phaseItems[phaseItems.length - 1].occurredAt
+          : null;
+
+      if (phase === "flight" && telemetrySummary.recordCount === 0 && phaseItems.length === 0) {
+        return {
+          phase,
+          status: "missing",
+          latestAt: null,
+          summary: "No telemetry or flight-phase evidence recorded",
+        };
+      }
+
+      return {
+        phase,
+        status: phaseItems.length > 0 ? "present" : "missing",
+        latestAt,
+        summary:
+          phaseItems.length > 0
+            ? `${phaseItems.length} ${phase.replace("_", " ")} timeline item(s) recorded`
+            : `No ${phase.replace("_", " ")} timeline items recorded`,
+      };
+    });
   }
 
   private getLinkedEntityState(

--- a/src/mission-planning/mission-planning.types.ts
+++ b/src/mission-planning/mission-planning.types.ts
@@ -11,6 +11,7 @@ import type { MissionReadinessCheck } from "../missions/mission-readiness.types"
 import type { Platform } from "../platforms/platform.types";
 import type { Pilot } from "../pilots/pilot.types";
 import type { MissionLifecycleAction } from "../modules/missions/domain/missionLifecycle";
+import type { MissionTelemetryRecordDto } from "../missions/mission-telemetry.types";
 
 export interface CreateMissionPlanningDraftInput {
   missionPlanId?: string | null;
@@ -194,4 +195,55 @@ export interface MissionDispatchWorkspace {
   dispatch: MissionDispatchWorkspaceDispatchStatus;
   blockingReasons: string[];
   nextAllowedActions: MissionPlanningWorkspaceNextAction[];
+}
+
+export type MissionOperationsTimelinePhase =
+  | "planning"
+  | "approval"
+  | "dispatch"
+  | "flight"
+  | "post_operation";
+
+export interface MissionOperationsTimelineItem {
+  id: string;
+  phase: MissionOperationsTimelinePhase;
+  type:
+    | "planning_risk_input"
+    | "planning_airspace_input"
+    | "planning_approval_handoff"
+    | "mission_event"
+    | "decision_evidence_link"
+    | "telemetry_summary"
+    | "post_operation_snapshot";
+  occurredAt: string;
+  source: string;
+  summary: string;
+  details: Record<string, unknown>;
+}
+
+export interface MissionOperationsTimelinePhaseStatus {
+  phase: MissionOperationsTimelinePhase;
+  status: "present" | "missing";
+  latestAt: string | null;
+  summary: string;
+}
+
+export interface MissionOperationsTelemetrySummary {
+  recordCount: number;
+  firstRecordedAt: string;
+  lastRecordedAt: string;
+  latestRecord: MissionTelemetryRecordDto;
+}
+
+export interface MissionOperationsTimeline {
+  mission: {
+    id: string;
+    missionPlanId: string | null;
+    status: string;
+    platformId: string | null;
+    pilotId: string | null;
+    lastEventSequenceNo: number;
+  };
+  phases: MissionOperationsTimelinePhaseStatus[];
+  items: MissionOperationsTimelineItem[];
 }

--- a/src/missions/mission-telemetry.repository.ts
+++ b/src/missions/mission-telemetry.repository.ts
@@ -18,6 +18,19 @@ interface MissionTelemetryRowResult extends QueryResultRow {
   createdAt?: Date;
 }
 
+interface MissionTelemetryTimelineSummaryRow extends QueryResultRow {
+  record_count: number;
+  first_recorded_at: Date | null;
+  last_recorded_at: Date | null;
+  latest_lat: number | null;
+  latest_lng: number | null;
+  latest_altitude_m: number | null;
+  latest_speed_mps: number | null;
+  latest_heading_deg: number | null;
+  latest_progress_pct: number | null;
+  latest_payload: Record<string, unknown> | null;
+}
+
 export class MissionTelemetryRepository {
   async insertMany(
     rows: MissionTelemetryRow[],
@@ -182,5 +195,82 @@ export class MissionTelemetryRepository {
 
     const result = await tx.query<MissionTelemetryRowResult>(sql, values);
     return result.rows;
+  }
+
+  async getTimelineSummaryByMissionId(
+    missionId: string,
+    tx: PoolClient,
+  ): Promise<{
+    recordCount: number;
+    firstRecordedAt: Date | null;
+    lastRecordedAt: Date | null;
+    latestRecord: Omit<MissionTelemetryRow, "id" | "missionId" | "createdAt"> | null;
+  }> {
+    const result = await tx.query<MissionTelemetryTimelineSummaryRow>(
+      `
+      with telemetry as (
+        select
+          recorded_at,
+          lat,
+          lng,
+          altitude_m,
+          speed_mps,
+          heading_deg,
+          progress_pct,
+          payload
+        from mission_telemetry
+        where mission_id = $1
+      ),
+      latest as (
+        select
+          recorded_at,
+          lat,
+          lng,
+          altitude_m,
+          speed_mps,
+          heading_deg,
+          progress_pct,
+          payload
+        from telemetry
+        order by recorded_at desc
+        limit 1
+      )
+      select
+        count(*)::int as record_count,
+        min(recorded_at) as first_recorded_at,
+        max(recorded_at) as last_recorded_at,
+        (select lat from latest) as latest_lat,
+        (select lng from latest) as latest_lng,
+        (select altitude_m from latest) as latest_altitude_m,
+        (select speed_mps from latest) as latest_speed_mps,
+        (select heading_deg from latest) as latest_heading_deg,
+        (select progress_pct from latest) as latest_progress_pct,
+        (select payload from latest) as latest_payload
+      from telemetry
+      `,
+      [missionId],
+    );
+
+    const row = result.rows[0];
+    const recordCount = Number(row.record_count ?? 0);
+
+    return {
+      recordCount,
+      firstRecordedAt: row.first_recorded_at ?? null,
+      lastRecordedAt: row.last_recorded_at ?? null,
+      latestRecord:
+        recordCount > 0 && row.last_recorded_at
+          ? {
+              recordedAt: row.last_recorded_at,
+              lat: row.latest_lat,
+              lng: row.latest_lng,
+              altitudeM: row.latest_altitude_m,
+              speedMps: row.latest_speed_mps,
+              headingDeg: row.latest_heading_deg,
+              progressPct: row.latest_progress_pct,
+              payload: row.latest_payload ?? {},
+            }
+          : null,
+    };
   }
 }

--- a/src/missions/mission.controller.ts
+++ b/src/missions/mission.controller.ts
@@ -50,6 +50,22 @@ export class MissionController {
     }
   };
 
+  getOperationsTimeline = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const missionId = this.requireUuid(req.params.missionId, "missionId");
+      const timeline =
+        await this.missionPlanningService.getOperationsTimeline(missionId);
+
+      res.status(200).json({ timeline });
+    } catch (error) {
+      next(error);
+    }
+  };
+
   getMissionEvents = async (
     req: Request,
     res: Response,

--- a/src/missions/mission.routes.ts
+++ b/src/missions/mission.routes.ts
@@ -20,6 +20,10 @@ export function createMissionRouter(
     "/:missionId/dispatch-workspace",
     missionController.getDispatchWorkspace,
   );
+  router.get(
+    "/:missionId/operations-timeline",
+    missionController.getOperationsTimeline,
+  );
   router.get("/:missionId/events", missionController.getMissionEvents);
   router.get("/:missionId/readiness", missionController.checkReadiness);
   router.get(

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -73,6 +73,48 @@ const createDispatchEvidenceLink = async (missionId: string) => {
   return linkResponse.body.link as { id: string };
 };
 
+const recordTelemetry = async (missionId: string) => {
+  const response = await request(app)
+    .post(`/missions/${missionId}/telemetry`)
+    .send({
+      records: [
+        {
+          timestamp: "2026-04-20T10:00:00.000Z",
+          lat: 51.5074,
+          lng: -0.1278,
+          altitudeM: 55,
+          speedMps: 12,
+          headingDeg: 180,
+          progressPct: 25,
+          payload: { segment: "departure" },
+        },
+        {
+          timestamp: "2026-04-20T10:05:00.000Z",
+          lat: 51.508,
+          lng: -0.1281,
+          altitudeM: 62,
+          speedMps: 14,
+          headingDeg: 182,
+          progressPct: 90,
+          payload: { segment: "return" },
+        },
+      ],
+    });
+
+  expect(response.status).toBe(202);
+};
+
+const createPostOperationEvidenceSnapshot = async (missionId: string) => {
+  const response = await request(app)
+    .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
+    .send({
+      createdBy: "ops-reviewer-1",
+    });
+
+  expect(response.status).toBe(201);
+  return response.body.snapshot as { id: string };
+};
+
 const lowRiskInput = {
   operatingCategory: "open",
   missionComplexity: "low",
@@ -132,6 +174,32 @@ const countRows = async (missionId?: string) => {
     snapshot_count: number;
     planning_handoff_count: number;
     decision_link_count: number;
+  };
+};
+
+const countOperationsTimelineRows = async (missionId: string) => {
+  const result = await pool.query(
+    `
+    select
+      (select count(*)::int from mission_risk_inputs where mission_id = $1) as risk_input_count,
+      (select count(*)::int from airspace_compliance_inputs where mission_id = $1) as airspace_input_count,
+      (select count(*)::int from mission_planning_approval_handoffs where mission_id = $1) as planning_handoff_count,
+      (select count(*)::int from mission_events where mission_id = $1) as mission_event_count,
+      (select count(*)::int from mission_decision_evidence_links where mission_id = $1) as decision_link_count,
+      (select count(*)::int from mission_telemetry where mission_id = $1) as telemetry_count,
+      (select count(*)::int from post_operation_evidence_snapshots where mission_id = $1) as post_operation_snapshot_count
+    `,
+    [missionId],
+  );
+
+  return result.rows[0] as {
+    risk_input_count: number;
+    airspace_input_count: number;
+    planning_handoff_count: number;
+    mission_event_count: number;
+    decision_link_count: number;
+    telemetry_count: number;
+    post_operation_snapshot_count: number;
   };
 };
 
@@ -1473,6 +1541,282 @@ describe("mission planning drafts", () => {
   it("returns 404 for missing dispatch workspace missions", async () => {
     const response = await request(app).get(
       `/missions/${randomUUID()}/dispatch-workspace`,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "mission_not_found",
+      },
+    });
+  });
+
+  it("returns a minimal operations timeline with explicit missing phases", async () => {
+    const createResponse = await request(app).post("/mission-plans/drafts").send({});
+
+    expect(createResponse.status).toBe(201);
+    const missionId = createResponse.body.draft.missionId as string;
+
+    const timelineResponse = await request(app).get(
+      `/missions/${missionId}/operations-timeline`,
+    );
+
+    expect(timelineResponse.status).toBe(200);
+    expect(timelineResponse.body.timeline).toMatchObject({
+      mission: {
+        id: missionId,
+        status: "draft",
+      },
+      items: [],
+      phases: [
+        expect.objectContaining({
+          phase: "planning",
+          status: "missing",
+        }),
+        expect.objectContaining({
+          phase: "approval",
+          status: "missing",
+        }),
+        expect.objectContaining({
+          phase: "dispatch",
+          status: "missing",
+        }),
+        expect.objectContaining({
+          phase: "flight",
+          status: "missing",
+        }),
+        expect.objectContaining({
+          phase: "post_operation",
+          status: "missing",
+        }),
+      ],
+    });
+  });
+
+  it("returns a populated operations timeline across planning, approval, dispatch, flight, and post-operation", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    await createPilotReadinessEvidence(pilot.id);
+
+    const createResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "plan-ops-timeline",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(createResponse.status).toBe(201);
+    const missionId = createResponse.body.draft.missionId as string;
+
+    const handoffResponse = await request(app)
+      .post(`/mission-plans/drafts/${missionId}/approval-handoff`)
+      .send({
+        createdBy: "planning lead",
+      });
+    expect(handoffResponse.status).toBe(201);
+
+    expect(
+      (
+        await request(app).post(`/missions/${missionId}/submit`).send({
+          userId: "operator-1",
+        })
+      ).status,
+    ).toBe(204);
+    expect(
+      (
+        await request(app).post(`/missions/${missionId}/approve`).send({
+          reviewerId: "approver-1",
+          decisionEvidenceLinkId:
+            handoffResponse.body.handoff.approvalEvidenceLink.id,
+        })
+      ).status,
+    ).toBe(204);
+
+    const dispatchLink = await createDispatchEvidenceLink(missionId);
+
+    expect(
+      (
+        await request(app).post(`/missions/${missionId}/launch`).send({
+          operatorId: "operator-1",
+          vehicleId: "vehicle-1",
+          lat: 51.5074,
+          lng: -0.1278,
+          decisionEvidenceLinkId: dispatchLink.id,
+        })
+      ).status,
+    ).toBe(204);
+
+    await recordTelemetry(missionId);
+
+    expect(
+      (
+        await request(app).post(`/missions/${missionId}/complete`).send({
+          operatorId: "operator-1",
+        })
+      ).status,
+    ).toBe(204);
+
+    const postOperationSnapshot = await createPostOperationEvidenceSnapshot(
+      missionId,
+    );
+    const before = await countOperationsTimelineRows(missionId);
+
+    const timelineResponse = await request(app).get(
+      `/missions/${missionId}/operations-timeline`,
+    );
+
+    expect(timelineResponse.status).toBe(200);
+    expect(timelineResponse.body.timeline.mission).toMatchObject({
+      id: missionId,
+      missionPlanId: "plan-ops-timeline",
+      status: "completed",
+    });
+    expect(timelineResponse.body.timeline.phases).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ phase: "planning", status: "present" }),
+        expect.objectContaining({ phase: "approval", status: "present" }),
+        expect.objectContaining({ phase: "dispatch", status: "present" }),
+        expect.objectContaining({ phase: "flight", status: "present" }),
+        expect.objectContaining({ phase: "post_operation", status: "present" }),
+      ]),
+    );
+    expect(timelineResponse.body.timeline.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          phase: "planning",
+          type: "planning_risk_input",
+        }),
+        expect.objectContaining({
+          phase: "planning",
+          type: "planning_airspace_input",
+        }),
+        expect.objectContaining({
+          phase: "planning",
+          type: "planning_approval_handoff",
+        }),
+        expect.objectContaining({
+          phase: "approval",
+          type: "decision_evidence_link",
+          details: expect.objectContaining({
+            decisionType: "approval",
+          }),
+        }),
+        expect.objectContaining({
+          phase: "approval",
+          type: "mission_event",
+          details: expect.objectContaining({
+            eventType: "mission.approved",
+          }),
+        }),
+        expect.objectContaining({
+          phase: "dispatch",
+          type: "decision_evidence_link",
+          details: expect.objectContaining({
+            decisionType: "dispatch",
+          }),
+        }),
+        expect.objectContaining({
+          phase: "dispatch",
+          type: "mission_event",
+          details: expect.objectContaining({
+            eventType: "mission.launched",
+          }),
+        }),
+        expect.objectContaining({
+          phase: "flight",
+          type: "telemetry_summary",
+          details: expect.objectContaining({
+            recordCount: 2,
+          }),
+        }),
+        expect.objectContaining({
+          phase: "post_operation",
+          type: "mission_event",
+          details: expect.objectContaining({
+            eventType: "mission.completed",
+          }),
+        }),
+        expect.objectContaining({
+          phase: "post_operation",
+          type: "post_operation_snapshot",
+          details: expect.objectContaining({
+            id: postOperationSnapshot.id,
+          }),
+        }),
+      ]),
+    );
+
+    const occurredAtValues = timelineResponse.body.timeline.items.map(
+      (item: { occurredAt: string }) => item.occurredAt,
+    );
+    expect([...occurredAtValues].sort()).toEqual(occurredAtValues);
+    expect(await countOperationsTimelineRows(missionId)).toEqual(before);
+  });
+
+  it("keeps operations timeline records isolated by mission", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+    await createPilotReadinessEvidence(pilot.id);
+
+    const firstMissionResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "ops-iso-1",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+    const secondMissionResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "ops-iso-2",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(firstMissionResponse.status).toBe(201);
+    expect(secondMissionResponse.status).toBe(201);
+
+    const secondMissionId = secondMissionResponse.body.draft.missionId as string;
+    const handoffResponse = await request(app)
+      .post(`/mission-plans/drafts/${secondMissionId}/approval-handoff`)
+      .send({
+        createdBy: "planning lead",
+      });
+
+    expect(handoffResponse.status).toBe(201);
+
+    const firstTimelineResponse = await request(app).get(
+      `/missions/${firstMissionResponse.body.draft.missionId}/operations-timeline`,
+    );
+
+    expect(firstTimelineResponse.status).toBe(200);
+    expect(firstTimelineResponse.body.timeline.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "planning_risk_input",
+        }),
+        expect.objectContaining({
+          type: "planning_airspace_input",
+        }),
+      ]),
+    );
+    expect(firstTimelineResponse.body.timeline.items).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "planning_approval_handoff",
+          details: expect.objectContaining({
+            missionDecisionEvidenceLinkId:
+              handoffResponse.body.handoff.approvalEvidenceLink.id,
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("returns 404 for missing operations timeline missions", async () => {
+    const response = await request(app).get(
+      `/missions/${randomUUID()}/operations-timeline`,
     );
 
     expect(response.status).toBe(404);


### PR DESCRIPTION
## Summary

Implements GitHub issue #120 by adding a mission operations timeline endpoint combining planning, approval, dispatch, telemetry, and post-operation evidence.

## What changed

- Added `GET /missions/:missionId/operations-timeline`.
- Built a unified mission timeline from existing backend sources instead of introducing a second event model.
- Timeline items now include, where present:
  - mission risk input records
  - airspace compliance input records
  - planning approval handoff records
  - approval and dispatch evidence links
  - mission lifecycle events
  - telemetry summary markers
  - post-operation evidence snapshots
- Added phase coverage summary for:
  - planning
  - approval
  - dispatch
  - flight
  - post_operation
- Kept ordering deterministic across mixed item sources.
- Kept the endpoint read-only and mission-isolated.
- Added integration coverage for:
  - minimal mission timeline
  - populated cross-phase mission timeline
  - deterministic ordering
  - missing-phase handling
  - mission isolation
  - missing mission handling
  - no mutation of source records
- Updated the save point to the next operational build step.

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/mission-planning.test.ts` passed: 31 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 314 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

Closes #120.
