### PR TITLE
Add operator mission lifecycle actions UI

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add operator mission workspace UI so planning, dispatch, and operations timeline state can be reviewed from a single mission screen.",
+ "nextBuildStep": "Add operator live operations map view so replay and future live telemetry can be reviewed separately from planning and dispatch workspace controls.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -84,6 +84,7 @@ if (process.env.NODE_ENV !== "test") {
 
 const app = express();
 app.use(express.json());
+app.use("/static", express.static(path.resolve(process.cwd(), "static")));
 
 const pool = new Pool({
   host: process.env.PGHOST,
@@ -211,6 +212,16 @@ app.use("/missions", createAlertRouter(alertController));
 app.use("/platforms", createPlatformRouter(platformController));
 app.use("/pilots", createPilotRouter(pilotController));
 app.use("/timeline", createTimelineRouter(timelineService));
+app.get("/operator/mission-workspace", (_req, res) => {
+  res.sendFile(
+    path.resolve(process.cwd(), "static", "operator-mission-workspace.html"),
+  );
+});
+app.get("/operator/missions/:missionId", (_req, res) => {
+  res.sendFile(
+    path.resolve(process.cwd(), "static", "operator-mission-workspace.html"),
+  );
+});
 app.get("/", (_req, res) => {
   res.status(200).send("FSMS backend is running");
 });

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -1826,4 +1826,29 @@ describe("mission planning drafts", () => {
       },
     });
   });
+
+  it("serves the operator mission workspace screen", async () => {
+    const response = await request(app).get("/operator/mission-workspace");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.text).toContain("Operator Mission Workspace");
+    expect(response.text).toContain("Mission Lifecycle Actions");
+    expect(response.text).toContain("/static/operator-mission-workspace.js");
+  });
+
+  it("serves the operator mission workspace javascript bundle", async () => {
+    const response = await request(app).get(
+      "/static/operator-mission-workspace.js",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("javascript");
+    expect(response.text).toContain("/planning-workspace");
+    expect(response.text).toContain("/dispatch-workspace");
+    expect(response.text).toContain("/operations-timeline");
+    expect(response.text).toContain("/transitions/${action}/check");
+    expect(response.text).toContain('["submit", "approve", "launch", "complete", "abort"]');
+    expect(response.text).toContain("/missions/${missionId}/${action}");
+  });
 });

--- a/static/operator-mission-workspace.html
+++ b/static/operator-mission-workspace.html
@@ -1,0 +1,587 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FSMS Operator Mission Workspace</title>
+  <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #09111b;
+      --bg-band: #0f1b2b;
+      --bg-soft: #142337;
+      --bg-accent: #1b2e46;
+      --border: rgba(255, 255, 255, 0.1);
+      --text: #edf3fb;
+      --muted: #9eb0c6;
+      --ok: #22c55e;
+      --warn: #f59e0b;
+      --bad: #ef4444;
+      --info: #38bdf8;
+      --shadow: 0 20px 45px rgba(0, 0, 0, 0.3);
+      --radius: 8px;
+      font-family: Inter, "Segoe UI", Arial, sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background:
+        radial-gradient(circle at top right, rgba(56, 189, 248, 0.12), transparent 28%),
+        linear-gradient(180deg, #08101a 0%, #0b1521 100%);
+      color: var(--text);
+    }
+
+    .page-shell {
+      min-height: 100vh;
+    }
+
+    .hero {
+      padding: 24px;
+      border-bottom: 1px solid var(--border);
+      background: linear-gradient(180deg, rgba(11, 21, 33, 0.94), rgba(11, 21, 33, 0.82));
+    }
+
+    .hero-inner,
+    .band-inner {
+      width: min(1380px, calc(100vw - 32px));
+      margin: 0 auto;
+    }
+
+    .hero-top {
+      display: flex;
+      align-items: start;
+      justify-content: space-between;
+      gap: 20px;
+      margin-bottom: 18px;
+    }
+
+    .hero h1 {
+      margin: 0 0 8px;
+      font-size: clamp(28px, 4vw, 44px);
+      line-height: 1.05;
+      font-weight: 800;
+    }
+
+    .hero p {
+      margin: 0;
+      max-width: 760px;
+      color: var(--muted);
+      font-size: 15px;
+      line-height: 1.55;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 40px;
+      padding: 0 14px;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.03);
+      font-size: 13px;
+      color: var(--muted);
+      white-space: nowrap;
+    }
+
+    .controls-band {
+      padding: 16px 0 28px;
+    }
+
+    .controls-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.5fr) repeat(4, minmax(150px, 1fr));
+      gap: 12px;
+      align-items: end;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .field label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      font-weight: 700;
+    }
+
+    .field input,
+    .field button {
+      min-height: 48px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font: inherit;
+    }
+
+    .field input {
+      padding: 0 14px;
+      background: rgba(255, 255, 255, 0.04);
+      color: var(--text);
+    }
+
+    .field button {
+      padding: 0 16px;
+      cursor: pointer;
+      color: var(--text);
+      background: var(--bg-accent);
+      font-weight: 700;
+    }
+
+    .field button.secondary {
+      background: rgba(255, 255, 255, 0.04);
+      color: var(--muted);
+    }
+
+    .band {
+      padding: 18px 0;
+    }
+
+    .band-title-row {
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
+      gap: 20px;
+      margin-bottom: 14px;
+    }
+
+    .band-title-row h2 {
+      margin: 0;
+      font-size: 20px;
+      font-weight: 800;
+    }
+
+    .band-title-row p {
+      margin: 6px 0 0;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .metric-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .metric {
+      min-height: 132px;
+      padding: 18px;
+      border: 1px solid var(--border);
+      background: var(--bg-band);
+      box-shadow: var(--shadow);
+    }
+
+    .metric .label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      font-weight: 700;
+    }
+
+    .metric .value {
+      margin-top: 12px;
+      font-size: 28px;
+      font-weight: 800;
+      line-height: 1.05;
+    }
+
+    .metric .meta {
+      margin-top: 10px;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.45;
+    }
+
+    .workspace-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.8fr);
+      gap: 16px;
+    }
+
+    .panel {
+      border: 1px solid var(--border);
+      background: var(--bg-band);
+      box-shadow: var(--shadow);
+    }
+
+    .panel-header {
+      padding: 16px 18px;
+      border-bottom: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.02);
+    }
+
+    .panel-header h3 {
+      margin: 0;
+      font-size: 15px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .panel-header p {
+      margin: 8px 0 0;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.45;
+    }
+
+    .panel-body {
+      padding: 18px;
+    }
+
+    .summary-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .action-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .summary-block {
+      min-height: 138px;
+      padding: 16px;
+      border: 1px solid var(--border);
+      background: var(--bg-soft);
+    }
+
+    .summary-block h4 {
+      margin: 0 0 10px;
+      font-size: 13px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .kv {
+      display: grid;
+      grid-template-columns: 150px 1fr;
+      gap: 8px 12px;
+      font-size: 13px;
+      line-height: 1.45;
+    }
+
+    .kv .k {
+      color: var(--muted);
+    }
+
+    .stack {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .action-card {
+      padding: 16px;
+      border: 1px solid var(--border);
+      background: var(--bg-soft);
+    }
+
+    .action-card h4 {
+      margin: 0 0 10px;
+      font-size: 13px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .action-meta {
+      margin: 10px 0 14px;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.5;
+    }
+
+    .action-form {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .action-form-row {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .action-field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .action-field label {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      font-weight: 700;
+    }
+
+    .action-field input,
+    .action-field textarea {
+      width: 100%;
+      min-height: 42px;
+      padding: 10px 12px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.04);
+      color: var(--text);
+      font: inherit;
+    }
+
+    .action-field textarea {
+      min-height: 96px;
+      resize: vertical;
+    }
+
+    .action-footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      margin-top: 4px;
+    }
+
+    .action-button {
+      min-height: 42px;
+      padding: 0 14px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--bg-accent);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .action-button[disabled] {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
+    .action-status {
+      font-size: 12px;
+      color: var(--muted);
+      line-height: 1.45;
+    }
+
+    .list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .list-item {
+      padding: 12px 14px;
+      border: 1px solid var(--border);
+      background: var(--bg-soft);
+      font-size: 13px;
+      line-height: 1.45;
+    }
+
+    .list-item strong {
+      display: block;
+      margin-bottom: 4px;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      min-height: 28px;
+      padding: 0 10px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .tone-ok { color: var(--ok); }
+    .tone-warn { color: var(--warn); }
+    .tone-bad { color: var(--bad); }
+    .tone-info { color: var(--info); }
+    .tone-muted { color: var(--muted); }
+
+    .timeline {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .timeline-item {
+      display: grid;
+      grid-template-columns: 170px 120px 1fr;
+      gap: 12px;
+      padding: 14px 16px;
+      border: 1px solid var(--border);
+      background: var(--bg-band);
+    }
+
+    .timeline-time {
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .timeline-phase {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-weight: 800;
+    }
+
+    .timeline-summary {
+      font-size: 14px;
+      font-weight: 700;
+      margin-bottom: 4px;
+    }
+
+    .timeline-meta {
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.45;
+    }
+
+    .empty-state {
+      padding: 26px 18px;
+      border: 1px dashed var(--border);
+      color: var(--muted);
+      font-size: 14px;
+      line-height: 1.6;
+      background: rgba(255, 255, 255, 0.02);
+    }
+
+    @media (max-width: 1100px) {
+      .controls-grid,
+      .metric-grid,
+      .workspace-grid,
+      .summary-grid,
+      .timeline-item {
+        grid-template-columns: 1fr;
+      }
+
+      .kv {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="page-shell">
+    <header class="hero">
+      <div class="hero-inner">
+        <div class="hero-top">
+          <div>
+            <h1>Operator Mission Workspace</h1>
+            <p>
+              One mission screen for planning status, dispatch readiness, and the full operational timeline.
+              This UI reads the existing mission workspace endpoints directly and does not maintain a second operator model.
+            </p>
+          </div>
+          <div id="connection-status" class="status-pill">No mission loaded</div>
+        </div>
+        <div class="controls-band">
+          <div class="controls-grid">
+            <div class="field">
+              <label for="mission-id-input">Mission ID</label>
+              <input id="mission-id-input" type="text" placeholder="Enter mission UUID" />
+            </div>
+            <div class="field">
+              <label>&nbsp;</label>
+              <button id="load-workspace-btn" type="button">Load mission workspace</button>
+            </div>
+            <div class="field">
+              <label>&nbsp;</label>
+              <button id="copy-link-btn" class="secondary" type="button">Copy direct link</button>
+            </div>
+            <div class="field">
+              <label>&nbsp;</label>
+              <button id="open-api-btn" class="secondary" type="button">Open API JSON</button>
+            </div>
+            <div class="field">
+              <label>Loaded mission</label>
+              <div id="loaded-mission-pill" class="status-pill">None</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <section class="band">
+      <div class="band-inner">
+        <div class="band-title-row">
+          <div>
+            <h2>Operational Overview</h2>
+            <p>Mission state, readiness state, and current live go/no-go posture.</p>
+          </div>
+        </div>
+        <div id="overview-metrics" class="metric-grid"></div>
+      </div>
+    </section>
+
+    <section class="band">
+      <div class="band-inner">
+        <div class="panel">
+          <div class="panel-header">
+            <h3>Mission Lifecycle Actions</h3>
+            <p>Execute mission transitions from the operator workspace using backend transition checks and evidence-aware safeguards.</p>
+          </div>
+          <div id="actions-panel" class="panel-body"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="band">
+      <div class="band-inner workspace-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h3>Planning Workspace</h3>
+            <p>Planning checklist, assigned resources, evidence chain, blockers, and allowed actions.</p>
+          </div>
+          <div id="planning-panel" class="panel-body"></div>
+        </div>
+        <div class="panel">
+          <div class="panel-header">
+            <h3>Dispatch Workspace</h3>
+            <p>Launch preflight, dispatch evidence, and live blockers preventing launch.</p>
+          </div>
+          <div id="dispatch-panel" class="panel-body"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="band">
+      <div class="band-inner">
+        <div class="panel">
+          <div class="panel-header">
+            <h3>Operations Timeline</h3>
+            <p>Ordered mission narrative across planning, approval, dispatch, flight, and post-operation phases.</p>
+          </div>
+          <div id="timeline-panel" class="panel-body"></div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <script type="module" src="/static/operator-mission-workspace.js"></script>
+</body>
+</html>

--- a/static/operator-mission-workspace.js
+++ b/static/operator-mission-workspace.js
@@ -1,0 +1,798 @@
+const missionIdInput = document.getElementById("mission-id-input");
+const loadWorkspaceButton = document.getElementById("load-workspace-btn");
+const copyLinkButton = document.getElementById("copy-link-btn");
+const openApiButton = document.getElementById("open-api-btn");
+const connectionStatus = document.getElementById("connection-status");
+const loadedMissionPill = document.getElementById("loaded-mission-pill");
+const overviewMetrics = document.getElementById("overview-metrics");
+const actionsPanel = document.getElementById("actions-panel");
+const planningPanel = document.getElementById("planning-panel");
+const dispatchPanel = document.getElementById("dispatch-panel");
+const timelinePanel = document.getElementById("timeline-panel");
+
+const ACTION_ORDER = ["submit", "approve", "launch", "complete", "abort"];
+const ACTION_DEFINITIONS = {
+  submit: {
+    title: "Submit",
+    description: "Move the mission from draft into submitted planning review.",
+    fields: [
+      { key: "userId", label: "User ID", type: "text", required: true },
+    ],
+  },
+  approve: {
+    title: "Approve",
+    description: "Record approval once readiness and approval evidence safeguards are satisfied.",
+    fields: [
+      { key: "reviewerId", label: "Reviewer ID", type: "text", required: true },
+      {
+        key: "decisionEvidenceLinkId",
+        label: "Approval evidence link ID",
+        type: "text",
+        required: false,
+      },
+      { key: "notes", label: "Notes", type: "textarea", required: false },
+    ],
+  },
+  launch: {
+    title: "Launch",
+    description: "Execute launch only after approval, dispatch evidence, and launch preflight are clear.",
+    fields: [
+      { key: "operatorId", label: "Operator ID", type: "text", required: true },
+      { key: "vehicleId", label: "Vehicle ID", type: "text", required: true },
+      { key: "lat", label: "Launch latitude", type: "number", required: true },
+      { key: "lng", label: "Launch longitude", type: "number", required: true },
+      {
+        key: "decisionEvidenceLinkId",
+        label: "Dispatch evidence link ID",
+        type: "text",
+        required: false,
+      },
+    ],
+  },
+  complete: {
+    title: "Complete",
+    description: "Close the mission and preserve the post-operation evidence chain.",
+    fields: [
+      { key: "operatorId", label: "Operator ID", type: "text", required: false },
+    ],
+  },
+  abort: {
+    title: "Abort",
+    description: "Terminate the mission with a recorded operational reason.",
+    fields: [
+      { key: "actorId", label: "Actor ID", type: "text", required: false },
+      { key: "reason", label: "Reason", type: "textarea", required: true },
+    ],
+  },
+};
+
+const uiState = {
+  missionId: "",
+  planningWorkspace: null,
+  dispatchWorkspace: null,
+  timeline: null,
+  transitionChecks: {},
+  actionStatus: {},
+  busyAction: null,
+};
+
+const toneClass = (value) => {
+  const text = String(value ?? "").toLowerCase();
+
+  if (
+    text.includes("approved") ||
+    text.includes("present") ||
+    text.includes("ready") ||
+    text.includes("clear") ||
+    text.includes("pass") ||
+    text.includes("assigned") ||
+    text.includes("allowed") ||
+    text.includes("active")
+  ) {
+    return "tone-ok";
+  }
+
+  if (
+    text.includes("review") ||
+    text.includes("pending") ||
+    text.includes("missing") ||
+    text.includes("draft") ||
+    text.includes("submitted")
+  ) {
+    return "tone-warn";
+  }
+
+  if (
+    text.includes("blocked") ||
+    text.includes("not_found") ||
+    text.includes("rejected") ||
+    text.includes("fail") ||
+    text.includes("abort")
+  ) {
+    return "tone-bad";
+  }
+
+  return "tone-info";
+};
+
+const escapeHtml = (value) =>
+  String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+
+const formatDateTime = (value) => {
+  if (!value) {
+    return "Not recorded";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+
+  return date.toLocaleString("en-GB", {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+};
+
+const renderList = (items, title) => {
+  if (!items || items.length === 0) {
+    return `<div class="empty-state">No ${escapeHtml(title).toLowerCase()} recorded.</div>`;
+  }
+
+  return `
+    <ul class="list">
+      ${items
+        .map(
+          (item) => `
+            <li class="list-item">
+              <strong>${escapeHtml(item.label ?? title)}</strong>
+              <div>${escapeHtml(item.value ?? item)}</div>
+            </li>
+          `,
+        )
+        .join("")}
+    </ul>
+  `;
+};
+
+const renderBadge = (value) =>
+  `<span class="badge ${toneClass(value)}">${escapeHtml(value ?? "Unknown")}</span>`;
+
+const setConnectionState = (message, tone = "tone-muted") => {
+  connectionStatus.className = `status-pill ${tone}`;
+  connectionStatus.textContent = message;
+};
+
+const setLoadedMission = (missionId) => {
+  loadedMissionPill.textContent = missionId || "None";
+};
+
+const updateUrl = (missionId) => {
+  const next = new URL(window.location.href);
+  if (missionId) {
+    next.searchParams.set("missionId", missionId);
+  } else {
+    next.searchParams.delete("missionId");
+  }
+  window.history.replaceState({}, "", next);
+};
+
+const getMissionIdFromLocation = () => {
+  const pathMatch = window.location.pathname.match(/^\/operator\/missions\/([^/]+)$/);
+  if (pathMatch?.[1]) {
+    return decodeURIComponent(pathMatch[1]);
+  }
+
+  const queryMissionId = new URL(window.location.href).searchParams.get("missionId");
+  return queryMissionId?.trim() || "";
+};
+
+const fetchJson = async (url, options = {}) => {
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+      ...(options.body ? { "Content-Type": "application/json" } : {}),
+      ...(options.headers ?? {}),
+    },
+    ...options,
+  });
+
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message = payload?.error?.message || `Request failed with ${response.status}`;
+    throw new Error(message);
+  }
+
+  return payload;
+};
+
+const collectActionPayload = (action) => {
+  const definition = ACTION_DEFINITIONS[action];
+  const payload = {};
+
+  for (const field of definition.fields) {
+    const input = document.getElementById(`action-${action}-${field.key}`);
+    const rawValue = input?.value ?? "";
+    const trimmed = typeof rawValue === "string" ? rawValue.trim() : rawValue;
+
+    if (field.required && !trimmed) {
+      throw new Error(`${field.label} is required`);
+    }
+
+    if (!trimmed) {
+      continue;
+    }
+
+    payload[field.key] =
+      field.type === "number" ? Number(trimmed) : trimmed;
+  }
+
+  return payload;
+};
+
+const applyActionDefaults = () => {
+  const planningWorkspace = uiState.planningWorkspace;
+  const dispatchWorkspace = uiState.dispatchWorkspace;
+
+  const defaultMap = {
+    approve: {
+      reviewerId: "planning-reviewer-1",
+      decisionEvidenceLinkId:
+        planningWorkspace?.evidence?.latestApprovalEvidenceLink?.id ?? "",
+      notes: "",
+    },
+    submit: {
+      userId: "planning-user-1",
+    },
+    launch: {
+      operatorId: "dispatch-operator-1",
+      vehicleId:
+        dispatchWorkspace?.platform?.summary?.id ??
+        dispatchWorkspace?.mission?.platformId ??
+        "",
+      lat: "",
+      lng: "",
+      decisionEvidenceLinkId:
+        dispatchWorkspace?.dispatch?.latestDispatchEvidenceLink?.id ?? "",
+    },
+    complete: {
+      operatorId: "ops-closer-1",
+    },
+    abort: {
+      actorId: "ops-controller-1",
+      reason: "",
+    },
+  };
+
+  for (const action of ACTION_ORDER) {
+    const defaults = defaultMap[action] ?? {};
+
+    for (const [key, value] of Object.entries(defaults)) {
+      const input = document.getElementById(`action-${action}-${key}`);
+      if (!input) {
+        continue;
+      }
+
+      if (!input.value || key === "decisionEvidenceLinkId" || key === "vehicleId") {
+        input.value = value;
+      }
+    }
+  }
+};
+
+const renderOverview = () => {
+  const planningWorkspace = uiState.planningWorkspace;
+  const dispatchWorkspace = uiState.dispatchWorkspace;
+  const timeline = uiState.timeline;
+  const mission = planningWorkspace?.mission ?? dispatchWorkspace?.mission;
+  const readinessGate = planningWorkspace?.readiness?.gate;
+  const dispatchReady = dispatchWorkspace?.dispatch?.ready ? "Ready" : "Blocked";
+  const approvalReady = planningWorkspace?.approval?.ready ? "Ready" : "Blocked";
+  const timelineCount = timeline?.items?.length ?? 0;
+  const missionStatus = mission?.status ?? "Unknown";
+
+  overviewMetrics.innerHTML = `
+    <article class="metric">
+      <div class="label">Mission status</div>
+      <div class="value ${toneClass(missionStatus)}">${escapeHtml(missionStatus)}</div>
+      <div class="meta">Mission ID: ${escapeHtml(mission?.id ?? "Not loaded")}</div>
+    </article>
+    <article class="metric">
+      <div class="label">Readiness gate</div>
+      <div class="value ${toneClass(readinessGate?.status ?? "Unknown")}">${escapeHtml(
+        readinessGate?.status ?? "Unknown",
+      )}</div>
+      <div class="meta">Dispatch block: ${escapeHtml(
+        readinessGate?.blocksDispatch ? "Yes" : "No",
+      )}</div>
+    </article>
+    <article class="metric">
+      <div class="label">Approval / Dispatch</div>
+      <div class="value">${renderBadge(approvalReady)} ${renderBadge(dispatchReady)}</div>
+      <div class="meta">Approval handoff: ${escapeHtml(
+        planningWorkspace?.approval?.handoffCreated ? "Recorded" : "Missing",
+      )}</div>
+    </article>
+    <article class="metric">
+      <div class="label">Timeline coverage</div>
+      <div class="value">${escapeHtml(String(timelineCount))}</div>
+      <div class="meta">Phases present: ${escapeHtml(
+        String((timeline?.phases ?? []).filter((phase) => phase.status === "present").length),
+      )} / ${escapeHtml(String((timeline?.phases ?? []).length ?? 0))}</div>
+    </article>
+  `;
+};
+
+const renderPlanning = () => {
+  const workspace = uiState.planningWorkspace;
+
+  if (!workspace) {
+    planningPanel.innerHTML = `<div class="empty-state">Planning workspace is not available.</div>`;
+    return;
+  }
+
+  const checklist = (workspace.planning?.checklist ?? []).map((item) => ({
+    label: `${item.key} - ${item.status}`,
+    value: item.message,
+  }));
+  const blockers = (workspace.blockingReasons ?? []).map((reason) => ({
+    label: "Blocking reason",
+    value: reason,
+  }));
+  const missing = (workspace.missingRequirements ?? []).map((reason) => ({
+    label: "Missing requirement",
+    value: reason,
+  }));
+  const actions = (workspace.nextAllowedActions ?? []).map((action) => ({
+    label: `${action.action} -> ${action.targetStatus}`,
+    value: action.allowed
+      ? `Allowed from ${action.currentStatus}`
+      : action.error?.message ?? `Blocked from ${action.currentStatus}`,
+  }));
+
+  planningPanel.innerHTML = `
+    <div class="summary-grid">
+      <section class="summary-block">
+        <h4>Mission Core</h4>
+        <div class="kv">
+          <div class="k">Mission plan</div>
+          <div>${escapeHtml(workspace.mission.missionPlanId ?? "Not assigned")}</div>
+          <div class="k">Platform</div>
+          <div>${escapeHtml(workspace.platform.summary?.name ?? workspace.platform.assignedPlatformId ?? "Missing")}</div>
+          <div class="k">Pilot</div>
+          <div>${escapeHtml(workspace.pilot.summary?.displayName ?? workspace.pilot.assignedPilotId ?? "Missing")}</div>
+          <div class="k">Risk input</div>
+          <div>${renderBadge(workspace.missionRisk ? "Present" : "Missing")}</div>
+          <div class="k">Airspace input</div>
+          <div>${renderBadge(workspace.airspaceCompliance ? "Present" : "Missing")}</div>
+        </div>
+      </section>
+      <section class="summary-block">
+        <h4>Evidence Chain</h4>
+        <div class="kv">
+          <div class="k">Readiness snapshots</div>
+          <div>${escapeHtml(String(workspace.evidence.readinessSnapshotCount))}</div>
+          <div class="k">Approval evidence</div>
+          <div>${escapeHtml(String(workspace.evidence.approvalEvidenceLinkCount))}</div>
+          <div class="k">Dispatch evidence</div>
+          <div>${escapeHtml(String(workspace.evidence.dispatchEvidenceLinkCount))}</div>
+          <div class="k">Latest handoff</div>
+          <div>${escapeHtml(
+            workspace.approval.latestApprovalHandoff?.createdAt
+              ? formatDateTime(workspace.approval.latestApprovalHandoff.createdAt)
+              : "Not recorded",
+          )}</div>
+        </div>
+      </section>
+      <section class="summary-block">
+        <h4>Checklist</h4>
+        ${renderList(checklist, "checklist items")}
+      </section>
+      <section class="summary-block">
+        <h4>Next Allowed Actions</h4>
+        ${renderList(actions, "next allowed actions")}
+      </section>
+    </div>
+    <div class="stack" style="margin-top: 14px;">
+      <section>
+        <h4 style="margin: 0 0 10px;">Blocking Reasons</h4>
+        ${renderList(blockers, "blocking reasons")}
+      </section>
+      <section>
+        <h4 style="margin: 0 0 10px;">Missing Requirements</h4>
+        ${renderList(missing, "missing requirements")}
+      </section>
+    </div>
+  `;
+};
+
+const renderDispatch = () => {
+  const workspace = uiState.dispatchWorkspace;
+
+  if (!workspace) {
+    dispatchPanel.innerHTML = `<div class="empty-state">Dispatch workspace is not available.</div>`;
+    return;
+  }
+
+  const blockers = (workspace.dispatch?.blockingReasons ?? []).map((reason) => ({
+    label: "Launch blocker",
+    value: reason,
+  }));
+  const missing = (workspace.dispatch?.missingRequirements ?? []).map((reason) => ({
+    label: "Dispatch requirement",
+    value: reason,
+  }));
+  const actions = (workspace.nextAllowedActions ?? []).map((action) => ({
+    label: `${action.action} -> ${action.targetStatus}`,
+    value: action.allowed
+      ? `Allowed from ${action.currentStatus}`
+      : action.error?.message ?? `Blocked from ${action.currentStatus}`,
+  }));
+
+  dispatchPanel.innerHTML = `
+    <div class="stack">
+      <section class="summary-block">
+        <h4>Dispatch Status</h4>
+        <div class="kv">
+          <div class="k">Mission lifecycle</div>
+          <div>${renderBadge(workspace.mission.status)}</div>
+          <div class="k">Approved for dispatch</div>
+          <div>${renderBadge(workspace.approval.approvedForDispatch ? "Approved" : "Not approved")}</div>
+          <div class="k">Dispatch ready</div>
+          <div>${renderBadge(workspace.dispatch.ready ? "Ready" : "Blocked")}</div>
+          <div class="k">Launch preflight</div>
+          <div>${renderBadge(workspace.dispatch.launchPreflight.allowed ? "Allowed" : "Blocked")}</div>
+        </div>
+      </section>
+      <section class="summary-block">
+        <h4>Approval and Evidence</h4>
+        <div class="kv">
+          <div class="k">Approval handoff</div>
+          <div>${escapeHtml(workspace.approval.handoffCreated ? "Recorded" : "Missing")}</div>
+          <div class="k">Approval evidence link</div>
+          <div>${escapeHtml(workspace.approval.latestApprovalEvidenceLink?.id ?? "Missing")}</div>
+          <div class="k">Dispatch evidence link</div>
+          <div>${escapeHtml(workspace.dispatch.latestDispatchEvidenceLink?.id ?? "Missing")}</div>
+        </div>
+      </section>
+      <section>
+        <h4 style="margin: 0 0 10px;">Launch Blockers</h4>
+        ${renderList(blockers, "launch blockers")}
+      </section>
+      <section>
+        <h4 style="margin: 0 0 10px;">Missing Dispatch Requirements</h4>
+        ${renderList(missing, "dispatch requirements")}
+      </section>
+      <section>
+        <h4 style="margin: 0 0 10px;">Relevant Lifecycle Actions</h4>
+        ${renderList(actions, "dispatch actions")}
+      </section>
+    </div>
+  `;
+};
+
+const renderTimeline = () => {
+  const timeline = uiState.timeline;
+
+  if (!timeline) {
+    timelinePanel.innerHTML = `<div class="empty-state">Operations timeline is not available.</div>`;
+    return;
+  }
+
+  const phaseSummary = `
+    <div class="summary-grid" style="margin-bottom: 14px;">
+      ${(timeline.phases ?? [])
+        .map(
+          (phase) => `
+            <section class="summary-block">
+              <h4>${escapeHtml(phase.phase.replaceAll("_", " "))}</h4>
+              <div class="kv">
+                <div class="k">Status</div>
+                <div>${renderBadge(phase.status)}</div>
+                <div class="k">Latest record</div>
+                <div>${escapeHtml(formatDateTime(phase.latestAt))}</div>
+                <div class="k">Summary</div>
+                <div>${escapeHtml(phase.summary)}</div>
+              </div>
+            </section>
+          `,
+        )
+        .join("")}
+    </div>
+  `;
+
+  const items = timeline.items ?? [];
+  const renderedItems =
+    items.length === 0
+      ? `<div class="empty-state">No mission timeline items recorded yet.</div>`
+      : `<div class="timeline">
+          ${items
+            .map(
+              (item) => `
+                <article class="timeline-item">
+                  <div class="timeline-time">${escapeHtml(formatDateTime(item.occurredAt))}</div>
+                  <div class="timeline-phase ${toneClass(item.phase)}">${escapeHtml(
+                    item.phase.replaceAll("_", " "),
+                  )}</div>
+                  <div>
+                    <div class="timeline-summary">${escapeHtml(item.summary)}</div>
+                    <div class="timeline-meta">
+                      Type: ${escapeHtml(item.type)}<br />
+                      Source: ${escapeHtml(item.source)}
+                    </div>
+                  </div>
+                </article>
+              `,
+            )
+            .join("")}
+        </div>`;
+
+  timelinePanel.innerHTML = `${phaseSummary}${renderedItems}`;
+};
+
+const renderActions = () => {
+  if (!uiState.missionId) {
+    actionsPanel.innerHTML = `<div class="empty-state">Load a mission before lifecycle actions can be evaluated.</div>`;
+    return;
+  }
+
+  actionsPanel.innerHTML = `
+    <div class="action-grid">
+      ${ACTION_ORDER.map((action) => renderActionCard(action)).join("")}
+    </div>
+  `;
+
+  applyActionDefaults();
+  bindActionForms();
+};
+
+const renderActionCard = (action) => {
+  const definition = ACTION_DEFINITIONS[action];
+  const check = uiState.transitionChecks[action];
+  const actionStatus = uiState.actionStatus[action];
+  const allowed = Boolean(check?.allowed);
+  const actionBusy = uiState.busyAction === action;
+  const footerMessage =
+    actionStatus?.message ??
+    (check?.allowed
+      ? `Allowed from ${check.currentStatus} to ${check.targetStatus}`
+      : check?.error?.message ?? "Transition check unavailable");
+
+  const fieldMarkup = definition.fields
+    .map((field) => {
+      const inputId = `action-${action}-${field.key}`;
+      const inputMarkup =
+        field.type === "textarea"
+          ? `<textarea id="${inputId}" ${field.required ? "required" : ""}></textarea>`
+          : `<input id="${inputId}" type="${field.type}" ${field.required ? "required" : ""} />`;
+
+      return `
+        <div class="action-field">
+          <label for="${inputId}">${escapeHtml(field.label)}</label>
+          ${inputMarkup}
+        </div>
+      `;
+    })
+    .join("");
+
+  return `
+    <section class="action-card">
+      <h4>${escapeHtml(definition.title)}</h4>
+      <div>${renderBadge(check?.allowed ? "Allowed" : "Blocked")}</div>
+      <div class="action-meta">
+        ${escapeHtml(definition.description)}<br />
+        Current status: ${escapeHtml(check?.currentStatus ?? "Unknown")}<br />
+        Target status: ${escapeHtml(check?.targetStatus ?? "Unknown")}
+      </div>
+      <form class="action-form" data-action="${action}">
+        <div class="action-form-row">
+          ${fieldMarkup}
+        </div>
+        <div class="action-footer">
+          <button class="action-button" type="submit" ${!allowed || actionBusy ? "disabled" : ""}>
+            ${actionBusy ? "Running..." : `Run ${escapeHtml(definition.title)}`}
+          </button>
+          <div class="action-status ${toneClass(footerMessage)}">${escapeHtml(footerMessage)}</div>
+        </div>
+      </form>
+    </section>
+  `;
+};
+
+const bindActionForms = () => {
+  document.querySelectorAll(".action-form").forEach((form) => {
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+
+      const action = form.getAttribute("data-action");
+      if (!action) {
+        return;
+      }
+
+      await executeAction(action);
+    });
+  });
+};
+
+const refreshTransitionChecks = async (missionId) => {
+  const checks = await Promise.all(
+    ACTION_ORDER.map(async (action) => {
+      const result = await fetchJson(
+        `/missions/${missionId}/transitions/${action}/check`,
+      );
+      return [action, result];
+    }),
+  );
+
+  uiState.transitionChecks = Object.fromEntries(checks);
+};
+
+const loadMissionWorkspace = async (missionId, options = {}) => {
+  const preserveActionStatus = Boolean(options.preserveActionStatus);
+
+  if (!missionId) {
+    uiState.missionId = "";
+    uiState.planningWorkspace = null;
+    uiState.dispatchWorkspace = null;
+    uiState.timeline = null;
+    uiState.transitionChecks = {};
+    uiState.actionStatus = {};
+    uiState.busyAction = null;
+    setConnectionState("Enter a mission UUID", "tone-warn");
+    setLoadedMission("");
+    overviewMetrics.innerHTML = "";
+    actionsPanel.innerHTML = `<div class="empty-state">Load a mission before lifecycle actions can be evaluated.</div>`;
+    planningPanel.innerHTML = `<div class="empty-state">Enter a mission UUID to load the planning workspace.</div>`;
+    dispatchPanel.innerHTML = `<div class="empty-state">Dispatch state will appear after a mission is loaded.</div>`;
+    timelinePanel.innerHTML = `<div class="empty-state">Timeline data will appear after a mission is loaded.</div>`;
+    return;
+  }
+
+  uiState.missionId = missionId;
+  if (!preserveActionStatus) {
+    uiState.actionStatus = {};
+  }
+
+  setConnectionState("Loading mission workspace...", "tone-info");
+  setLoadedMission(missionId);
+  updateUrl(missionId);
+
+  try {
+    const [
+      planningResponse,
+      dispatchResponse,
+      timelineResponse,
+    ] = await Promise.all([
+      fetchJson(`/missions/${missionId}/planning-workspace`),
+      fetchJson(`/missions/${missionId}/dispatch-workspace`),
+      fetchJson(`/missions/${missionId}/operations-timeline`),
+    ]);
+
+    uiState.planningWorkspace = planningResponse.workspace;
+    uiState.dispatchWorkspace = dispatchResponse.workspace;
+    uiState.timeline = timelineResponse.timeline;
+    await refreshTransitionChecks(missionId);
+
+    renderOverview();
+    renderActions();
+    renderPlanning();
+    renderDispatch();
+    renderTimeline();
+    setConnectionState("Mission workspace loaded", "tone-ok");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to load mission workspace";
+    uiState.planningWorkspace = null;
+    uiState.dispatchWorkspace = null;
+    uiState.timeline = null;
+    uiState.transitionChecks = {};
+    setConnectionState(message, "tone-bad");
+    actionsPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
+    planningPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
+    dispatchPanel.innerHTML = `<div class="empty-state">Dispatch view unavailable because the mission workspace did not load.</div>`;
+    timelinePanel.innerHTML = `<div class="empty-state">Timeline view unavailable because the mission workspace did not load.</div>`;
+    overviewMetrics.innerHTML = "";
+  }
+};
+
+const executeAction = async (action) => {
+  const missionId = uiState.missionId;
+  const check = uiState.transitionChecks[action];
+
+  if (!missionId || !check?.allowed) {
+    uiState.actionStatus[action] = {
+      message: check?.error?.message ?? "Action is currently blocked",
+    };
+    renderActions();
+    return;
+  }
+
+  let payload;
+  try {
+    payload = collectActionPayload(action);
+  } catch (error) {
+    uiState.actionStatus[action] = {
+      message: error instanceof Error ? error.message : "Invalid action payload",
+    };
+    renderActions();
+    return;
+  }
+
+  uiState.busyAction = action;
+  uiState.actionStatus[action] = { message: "Submitting lifecycle action..." };
+  renderActions();
+
+  try {
+    await fetchJson(`/missions/${missionId}/${action}`, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+
+    uiState.actionStatus = {
+      [action]: { message: `${ACTION_DEFINITIONS[action].title} completed` },
+    };
+    uiState.busyAction = null;
+    await loadMissionWorkspace(missionId, { preserveActionStatus: true });
+    setConnectionState(`${ACTION_DEFINITIONS[action].title} completed`, "tone-ok");
+  } catch (error) {
+    uiState.busyAction = null;
+    uiState.actionStatus[action] = {
+      message: error instanceof Error ? error.message : "Lifecycle action failed",
+    };
+    renderActions();
+    setConnectionState(
+      error instanceof Error ? error.message : "Lifecycle action failed",
+      "tone-bad",
+    );
+  }
+};
+
+loadWorkspaceButton.addEventListener("click", () => {
+  loadMissionWorkspace(missionIdInput.value.trim());
+});
+
+missionIdInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    loadMissionWorkspace(missionIdInput.value.trim());
+  }
+});
+
+copyLinkButton.addEventListener("click", async () => {
+  const missionId = missionIdInput.value.trim();
+  const url = new URL(window.location.href);
+  if (missionId) {
+    url.searchParams.set("missionId", missionId);
+  }
+
+  try {
+    await navigator.clipboard.writeText(url.toString());
+    setConnectionState("Direct link copied", "tone-ok");
+  } catch {
+    setConnectionState("Clipboard write failed", "tone-warn");
+  }
+});
+
+openApiButton.addEventListener("click", () => {
+  const missionId = missionIdInput.value.trim();
+  if (!missionId) {
+    setConnectionState("Enter a mission UUID before opening API JSON", "tone-warn");
+    return;
+  }
+
+  window.open(`/missions/${missionId}/planning-workspace`, "_blank", "noopener");
+});
+
+const initialMissionId = getMissionIdFromLocation();
+if (initialMissionId) {
+  missionIdInput.value = initialMissionId;
+}
+
+loadMissionWorkspace(initialMissionId);


### PR DESCRIPTION
## Summary

Implements GitHub issue #123 by extending the operator mission workspace UI with mission lifecycle action controls for submit, approve, launch, complete, and abort.

## What changed

- Extended the existing operator mission workspace UI with a dedicated `Mission Lifecycle Actions` panel.
- Added client-side action cards for:
  - `submit`
  - `approve`
  - `launch`
  - `complete`
  - `abort`
- Added transition preflight loading from the existing backend source of truth:
  - `GET /missions/:missionId/transitions/:action/check`
- Added action execution through the existing lifecycle endpoints:
  - `POST /missions/:missionId/submit`
  - `POST /missions/:missionId/approve`
  - `POST /missions/:missionId/launch`
  - `POST /missions/:missionId/complete`
  - `POST /missions/:missionId/abort`
- Collected the minimum required payload fields for each lifecycle action:
  - submit: `userId`
  - approve: `reviewerId`, optional `decisionEvidenceLinkId`, optional `notes`
  - launch: `operatorId`, `vehicleId`, `lat`, `lng`, optional `decisionEvidenceLinkId`
  - complete: optional `operatorId`
  - abort: optional `actorId`, required `reason`
- Prevented obviously invalid action attempts in the client by disabling action buttons when the backend transition preflight reports the action as blocked.
- Kept backend validation as the source of truth for lifecycle transitions and surfaced backend failures back into the workspace UI.
- Refreshed the planning workspace, dispatch workspace, and operations timeline after successful action execution so the screen remains consistent with mission state.
- Updated operator workspace route smoke tests to verify the lifecycle action UI is served and the JavaScript bundle references lifecycle transition checks and mission action endpoints.
- Updated the save point to the next operational build step.

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/mission-planning.test.ts` passed: 33 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 316 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

## Notes

- The operator lifecycle action UI remains frontend-only for this issue and uses the existing mission lifecycle backend endpoints and transition checks.
- Local dev server startup in this worktree still depends on valid PostgreSQL runtime credentials in `.env`; this change was verified through build and integration tests rather than a persistent local browser session.

Closes #123.
