### PR TITLE
Add mission search and list UI

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add operator evidence creation helpers so approval and dispatch evidence links can be created from the workspace instead of outside it.",
+ "nextBuildStep": "Add mission-linked operator evidence creation helpers so approval and dispatch evidence links can be created from the workspace instead of outside it.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add operator live operations map view so replay and future live telemetry can be reviewed separately from planning and dispatch workspace controls.",
+ "nextBuildStep": "Add operator evidence creation helpers so approval and dispatch evidence links can be created from the workspace instead of outside it.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/missions/mission.controller.ts
+++ b/src/missions/mission.controller.ts
@@ -34,6 +34,22 @@ export class MissionController {
     }
   };
 
+  listMissions = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const query = this.optionalString(req.query.q);
+      const limit = this.optionalPositiveInteger(req.query.limit);
+      const result = await this.missionService.listMissions({ query, limit });
+
+      res.status(200).json(result);
+    } catch (error) {
+      next(error);
+    }
+  };
+
   getDispatchWorkspace = async (
     req: Request,
     res: Response,
@@ -359,6 +375,22 @@ export class MissionController {
 
     if (!Number.isFinite(num)) {
       throw new Error(`${fieldName} must be a valid number`);
+    }
+
+    return num;
+  }
+
+  private optionalPositiveInteger(value: unknown): number | undefined {
+    const normalized = this.optionalString(value);
+
+    if (!normalized) {
+      return undefined;
+    }
+
+    const num = Number(normalized);
+
+    if (!Number.isInteger(num) || num <= 0) {
+      throw new Error("limit must be a positive integer");
     }
 
     return num;

--- a/src/missions/mission.repository.ts
+++ b/src/missions/mission.repository.ts
@@ -13,6 +13,20 @@ export interface MissionRow {
   last_event_sequence_no: number;
 }
 
+export interface MissionListRow {
+  id: string;
+  status: MissionStatus;
+  mission_plan_id: string | null;
+  platform_id: string | null;
+  pilot_id: string | null;
+  last_event_sequence_no: number;
+  platform_name: string | null;
+  pilot_display_name: string | null;
+  latest_event_type: string | null;
+  latest_event_summary: string | null;
+  latest_event_time: string | null;
+}
+
 type AppError = Error & {
   statusCode: number;
   code: string;
@@ -30,6 +44,65 @@ const makeAppError = (
 };
 
 export class MissionRepository implements MissionSequenceAllocator {
+  async list(
+    tx: DbTx,
+    params: { query?: string; limit: number },
+  ): Promise<MissionListRow[]> {
+    const search = params.query?.trim() ?? "";
+    const searchPattern = search ? `%${search.toLowerCase()}%` : null;
+
+    const result = await tx.query<MissionListRow>(
+      `
+      select
+        missions.id,
+        missions.status,
+        missions.mission_plan_id,
+        missions.platform_id,
+        missions.pilot_id,
+        missions.last_event_sequence_no,
+        platforms.name as platform_name,
+        pilots.display_name as pilot_display_name,
+        latest_event.event_type as latest_event_type,
+        latest_event.summary as latest_event_summary,
+        latest_event.event_ts::text as latest_event_time
+      from missions
+      left join platforms
+        on platforms.id = missions.platform_id
+      left join pilots
+        on pilots.id = missions.pilot_id
+      left join lateral (
+        select
+          mission_events.event_type,
+          mission_events.summary,
+          mission_events.event_ts
+        from mission_events
+        where mission_events.mission_id = missions.id
+        order by mission_events.event_ts desc, mission_events.id desc
+        limit 1
+      ) as latest_event on true
+      where (
+        $1::text is null
+        or lower(missions.id::text) like $1
+        or lower(coalesce(missions.mission_plan_id, '')) like $1
+        or lower(missions.status) like $1
+        or lower(coalesce(platforms.name, '')) like $1
+        or lower(coalesce(pilots.display_name, '')) like $1
+      )
+      order by
+        coalesce(latest_event.event_ts, 'epoch'::timestamptz) desc,
+        missions.last_event_sequence_no desc,
+        missions.id desc
+      limit $2
+      `,
+      [searchPattern, params.limit],
+    );
+
+    return result.rows.map((row) => ({
+      ...row,
+      last_event_sequence_no: Number(row.last_event_sequence_no),
+    }));
+  }
+
   async getForUpdate(tx: DbTx, missionId: string): Promise<MissionRow> {
     const result = await tx.query<MissionRow>(
       `

--- a/src/missions/mission.routes.ts
+++ b/src/missions/mission.routes.ts
@@ -6,6 +6,7 @@ export function createMissionRouter(
 ): Router {
   const router = Router();
 
+  router.get("/", missionController.listMissions);
   router.post("/:missionId/submit", missionController.submitMission);
   router.post("/:missionId/approve", missionController.approveMission);
   router.post("/:missionId/launch", missionController.launchMission);

--- a/src/missions/mission.service.ts
+++ b/src/missions/mission.service.ts
@@ -27,12 +27,33 @@ import {
   MissionApprovalEvidenceRequiredError,
   MissionDispatchEvidenceRequiredError,
 } from "./errors";
+import type { MissionListRow } from "./mission.repository";
+import type { MissionStatus } from "./mission-telemetry.types";
 
 export interface GetMissionEventsFilters {
   safety?: boolean;
   compliance?: boolean;
   severity?: "info" | "warning" | "critical";
   type?: string;
+}
+
+export interface ListMissionsFilters {
+  query?: string;
+  limit?: number;
+}
+
+export interface MissionListItem {
+  id: string;
+  status: MissionStatus;
+  missionPlanId: string | null;
+  platformId: string | null;
+  pilotId: string | null;
+  lastEventSequenceNo: number;
+  platformName: string | null;
+  pilotDisplayName: string | null;
+  latestEventType: string | null;
+  latestEventSummary: string | null;
+  latestEventTime: string | null;
 }
 
 
@@ -547,6 +568,25 @@ export class MissionService {
     });
   }
 
+  async listMissions(filters: ListMissionsFilters = {}): Promise<{
+    missions: MissionListItem[];
+    query: string | null;
+    limit: number;
+  }> {
+    const limit = Math.min(Math.max(filters.limit ?? 20, 1), 100);
+    const query = filters.query?.trim() || null;
+
+    const missions = await this.db.transaction(async (tx) =>
+      this.missionRepo.list(tx, { query: query ?? undefined, limit }),
+    );
+
+    return {
+      missions: missions.map((row) => this.toMissionListItem(row)),
+      query,
+      limit,
+    };
+  }
+
   async getMissionEvents(
     missionId: string,
     filters: GetMissionEventsFilters = {},
@@ -764,5 +804,21 @@ export class MissionService {
     }
 
     return "pass";
+  }
+
+  private toMissionListItem(row: MissionListRow): MissionListItem {
+    return {
+      id: row.id,
+      status: row.status,
+      missionPlanId: row.mission_plan_id,
+      platformId: row.platform_id,
+      pilotId: row.pilot_id,
+      lastEventSequenceNo: Number(row.last_event_sequence_no),
+      platformName: row.platform_name,
+      pilotDisplayName: row.pilot_display_name,
+      latestEventType: row.latest_event_type,
+      latestEventSummary: row.latest_event_summary,
+      latestEventTime: row.latest_event_time,
+    };
   }
 }

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -1827,6 +1827,83 @@ describe("mission planning drafts", () => {
     });
   });
 
+  it("lists recent missions for operator search and selection", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+
+    const firstDraftResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "search-alpha",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+    const secondDraftResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "search-bravo",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(firstDraftResponse.status).toBe(201);
+    expect(secondDraftResponse.status).toBe(201);
+
+    const response = await request(app).get("/missions");
+
+    expect(response.status).toBe(200);
+    expect(response.body.missions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          missionPlanId: "search-alpha",
+          status: "draft",
+          platformId: platform.id,
+          platformName: "Planning UAV",
+          pilotId: pilot.id,
+          pilotDisplayName: "Planning Pilot",
+        }),
+        expect.objectContaining({
+          missionPlanId: "search-bravo",
+          status: "draft",
+        }),
+      ]),
+    );
+    expect(response.body.limit).toBe(20);
+  });
+
+  it("filters listed missions by operator search query", async () => {
+    const platform = await createPlatform();
+    const pilot = await createPilot();
+
+    const alphaResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "ops-alpha",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+    const bravoResponse = await request(app).post("/mission-plans/drafts").send({
+      missionPlanId: "ops-bravo",
+      platformId: platform.id,
+      pilotId: pilot.id,
+      riskInput: lowRiskInput,
+      airspaceInput: clearAirspaceInput,
+    });
+
+    expect(alphaResponse.status).toBe(201);
+    expect(bravoResponse.status).toBe(201);
+
+    const response = await request(app).get("/missions").query({ q: "bravo" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.query).toBe("bravo");
+    expect(response.body.missions).toHaveLength(1);
+    expect(response.body.missions[0]).toMatchObject({
+      missionPlanId: "ops-bravo",
+      status: "draft",
+    });
+  });
+
   it("serves the operator mission workspace screen", async () => {
     const response = await request(app).get("/operator/mission-workspace");
 
@@ -1834,6 +1911,9 @@ describe("mission planning drafts", () => {
     expect(response.headers["content-type"]).toContain("text/html");
     expect(response.text).toContain("Operator Mission Workspace");
     expect(response.text).toContain("Mission Lifecycle Actions");
+    expect(response.text).toContain("Mission Search and Selection");
+    expect(response.text).toContain("mission-search-input");
+    expect(response.text).toContain("mission-browser-list");
     expect(response.text).toContain("/static/operator-mission-workspace.js");
   });
 
@@ -1850,5 +1930,8 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("/transitions/${action}/check");
     expect(response.text).toContain('["submit", "approve", "launch", "complete", "abort"]');
     expect(response.text).toContain("/missions/${missionId}/${action}");
+    expect(response.text).toContain('getElementById("mission-search-input")');
+    expect(response.text).toContain('fetchJson(`/missions?${params.toString()}`)');
+    expect(response.text).toContain('data-open-mission');
   });
 });

--- a/static/operator-mission-workspace.html
+++ b/static/operator-mission-workspace.html
@@ -171,6 +171,12 @@
       gap: 12px;
     }
 
+    .mission-browser-grid {
+      display: grid;
+      grid-template-columns: minmax(320px, 0.7fr) minmax(0, 1.3fr);
+      gap: 16px;
+    }
+
     .metric {
       min-height: 132px;
       padding: 18px;
@@ -428,6 +434,69 @@
       gap: 10px;
     }
 
+    .mission-browser-toolbar {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 160px;
+      gap: 10px;
+      margin-bottom: 14px;
+    }
+
+    .mission-browser-toolbar input,
+    .mission-browser-toolbar button {
+      min-height: 42px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.04);
+      color: var(--text);
+      font: inherit;
+      padding: 0 12px;
+    }
+
+    .mission-browser-toolbar button {
+      background: var(--bg-accent);
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    .mission-browser-list {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .mission-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 130px;
+      gap: 10px;
+      padding: 14px;
+      border: 1px solid var(--border);
+      background: var(--bg-soft);
+      align-items: center;
+    }
+
+    .mission-row-title {
+      font-size: 14px;
+      font-weight: 800;
+      margin-bottom: 6px;
+    }
+
+    .mission-row-meta {
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .mission-row button {
+      min-height: 38px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--bg-accent);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
     .timeline-item {
       display: grid;
       grid-template-columns: 170px 120px 1fr;
@@ -525,6 +594,31 @@
         </div>
       </div>
     </header>
+
+    <section class="band">
+      <div class="band-inner">
+        <div class="panel">
+          <div class="panel-header">
+            <h3>Mission Search and Selection</h3>
+            <p>Browse recent missions, filter by mission plan, status, platform, pilot, or ID, then open a mission into the operator workspace.</p>
+          </div>
+          <div class="panel-body mission-browser-grid">
+            <section>
+              <div class="mission-browser-toolbar">
+                <input id="mission-search-input" type="text" placeholder="Search mission ID, plan, status, platform, or pilot" />
+                <button id="mission-search-btn" type="button">Search</button>
+              </div>
+              <div id="mission-browser-list" class="mission-browser-list"></div>
+            </section>
+            <section>
+              <div id="mission-browser-detail" class="empty-state">
+                Select a mission from the list to load its planning workspace, dispatch state, and operations timeline.
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </section>
 
     <section class="band">
       <div class="band-inner">

--- a/static/operator-mission-workspace.js
+++ b/static/operator-mission-workspace.js
@@ -5,6 +5,10 @@ const openApiButton = document.getElementById("open-api-btn");
 const connectionStatus = document.getElementById("connection-status");
 const loadedMissionPill = document.getElementById("loaded-mission-pill");
 const overviewMetrics = document.getElementById("overview-metrics");
+const missionSearchInput = document.getElementById("mission-search-input");
+const missionSearchButton = document.getElementById("mission-search-btn");
+const missionBrowserList = document.getElementById("mission-browser-list");
+const missionBrowserDetail = document.getElementById("mission-browser-detail");
 const actionsPanel = document.getElementById("actions-panel");
 const planningPanel = document.getElementById("planning-panel");
 const dispatchPanel = document.getElementById("dispatch-panel");
@@ -71,6 +75,8 @@ const uiState = {
   planningWorkspace: null,
   dispatchWorkspace: null,
   timeline: null,
+  missionList: [],
+  missionQuery: "",
   transitionChecks: {},
   actionStatus: {},
   busyAction: null,
@@ -166,6 +172,9 @@ const renderList = (items, title) => {
 
 const renderBadge = (value) =>
   `<span class="badge ${toneClass(value)}">${escapeHtml(value ?? "Unknown")}</span>`;
+
+const missionDisplayName = (mission) =>
+  mission?.missionPlanId || mission?.id || "Unknown mission";
 
 const setConnectionState = (message, tone = "tone-muted") => {
   connectionStatus.className = `status-pill ${tone}`;
@@ -286,6 +295,136 @@ const applyActionDefaults = () => {
         input.value = value;
       }
     }
+  }
+};
+
+const renderMissionBrowser = () => {
+  const missions = uiState.missionList ?? [];
+
+  if (!missionBrowserList || !missionBrowserDetail) {
+    return;
+  }
+
+  if (missions.length === 0) {
+    missionBrowserList.innerHTML =
+      '<div class="empty-state">No missions match the current filter.</div>';
+    missionBrowserDetail.innerHTML = `
+      <div class="empty-state">
+        Search recent missions or clear the filter to load a mission into the operator workspace.
+      </div>
+    `;
+    return;
+  }
+
+  missionBrowserList.innerHTML = missions
+    .map((mission) => {
+      const loaded = mission.id === uiState.missionId;
+      const lastEvent = mission.latestEventSummary ?? "No lifecycle events yet";
+      const platform =
+        mission.platform?.name ?? mission.platform?.id ?? "Platform not assigned";
+      const pilot =
+        mission.pilot?.displayName ?? mission.pilot?.id ?? "Pilot not assigned";
+
+      return `
+        <article class="mission-row" data-mission-id="${escapeHtml(mission.id)}">
+          <div class="mission-row-title">
+            <div>
+              <strong>${escapeHtml(missionDisplayName(mission))}</strong>
+              <div class="timeline-meta">Mission ID: ${escapeHtml(mission.id)}</div>
+            </div>
+            <div>${renderBadge(mission.status ?? "Unknown")}</div>
+          </div>
+          <div class="mission-row-meta">
+            Platform: ${escapeHtml(platform)}<br />
+            Pilot: ${escapeHtml(pilot)}<br />
+            Last event: ${escapeHtml(lastEvent)}<br />
+            Updated: ${escapeHtml(formatDateTime(mission.latestEventAt ?? mission.updatedAt))}
+          </div>
+          <div style="margin-top: 10px;">
+            <button class="action-button" type="button" data-open-mission="${escapeHtml(
+              mission.id,
+            )}">
+              ${loaded ? "Loaded" : "Open mission"}
+            </button>
+          </div>
+        </article>
+      `;
+    })
+    .join("");
+
+  missionBrowserList.querySelectorAll("[data-open-mission]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const missionId = button.getAttribute("data-open-mission");
+      if (!missionId) {
+        return;
+      }
+
+      missionIdInput.value = missionId;
+      loadMissionWorkspace(missionId);
+    });
+  });
+
+  const selectedMission =
+    missions.find((mission) => mission.id === uiState.missionId) ?? missions[0];
+
+  missionBrowserDetail.innerHTML = `
+    <section class="summary-block">
+      <h4>Selected Mission</h4>
+      <div class="kv">
+        <div class="k">Mission</div>
+        <div>${escapeHtml(missionDisplayName(selectedMission))}</div>
+        <div class="k">Mission ID</div>
+        <div>${escapeHtml(selectedMission.id)}</div>
+        <div class="k">Status</div>
+        <div>${renderBadge(selectedMission.status ?? "Unknown")}</div>
+        <div class="k">Platform</div>
+        <div>${escapeHtml(
+          selectedMission.platform?.name ??
+            selectedMission.platform?.id ??
+            "Platform not assigned",
+        )}</div>
+        <div class="k">Pilot</div>
+        <div>${escapeHtml(
+          selectedMission.pilot?.displayName ??
+            selectedMission.pilot?.id ??
+            "Pilot not assigned",
+        )}</div>
+        <div class="k">Last event</div>
+        <div>${escapeHtml(selectedMission.latestEventSummary ?? "No lifecycle events yet")}</div>
+        <div class="k">Updated</div>
+        <div>${escapeHtml(formatDateTime(selectedMission.latestEventAt ?? selectedMission.updatedAt))}</div>
+      </div>
+    </section>
+  `;
+};
+
+const loadMissionList = async (query = "") => {
+  uiState.missionQuery = query;
+
+  if (!missionBrowserList || !missionBrowserDetail) {
+    return;
+  }
+
+  missionBrowserList.innerHTML =
+    '<div class="empty-state">Loading mission list...</div>';
+
+  const params = new URLSearchParams();
+  if (query) {
+    params.set("q", query);
+  }
+  params.set("limit", "12");
+
+  try {
+    const response = await fetchJson(`/missions?${params.toString()}`);
+    uiState.missionList = response.missions ?? [];
+    renderMissionBrowser();
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to load mission list";
+    uiState.missionList = [];
+    missionBrowserList.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
+    missionBrowserDetail.innerHTML =
+      '<div class="empty-state">Mission detail is unavailable because the mission list did not load.</div>';
   }
 };
 
@@ -644,6 +783,7 @@ const loadMissionWorkspace = async (missionId, options = {}) => {
     uiState.planningWorkspace = null;
     uiState.dispatchWorkspace = null;
     uiState.timeline = null;
+    renderMissionBrowser();
     uiState.transitionChecks = {};
     uiState.actionStatus = {};
     uiState.busyAction = null;
@@ -682,6 +822,7 @@ const loadMissionWorkspace = async (missionId, options = {}) => {
     uiState.timeline = timelineResponse.timeline;
     await refreshTransitionChecks(missionId);
 
+    renderMissionBrowser();
     renderOverview();
     renderActions();
     renderPlanning();
@@ -694,6 +835,7 @@ const loadMissionWorkspace = async (missionId, options = {}) => {
     uiState.dispatchWorkspace = null;
     uiState.timeline = null;
     uiState.transitionChecks = {};
+    renderMissionBrowser();
     setConnectionState(message, "tone-bad");
     actionsPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
     planningPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
@@ -740,6 +882,7 @@ const executeAction = async (action) => {
       [action]: { message: `${ACTION_DEFINITIONS[action].title} completed` },
     };
     uiState.busyAction = null;
+    await loadMissionList(uiState.missionQuery);
     await loadMissionWorkspace(missionId, { preserveActionStatus: true });
     setConnectionState(`${ACTION_DEFINITIONS[action].title} completed`, "tone-ok");
   } catch (error) {
@@ -762,6 +905,16 @@ loadWorkspaceButton.addEventListener("click", () => {
 missionIdInput.addEventListener("keydown", (event) => {
   if (event.key === "Enter") {
     loadMissionWorkspace(missionIdInput.value.trim());
+  }
+});
+
+missionSearchButton?.addEventListener("click", () => {
+  loadMissionList(missionSearchInput?.value.trim() ?? "");
+});
+
+missionSearchInput?.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    loadMissionList(missionSearchInput.value.trim());
   }
 });
 
@@ -795,4 +948,5 @@ if (initialMissionId) {
   missionIdInput.value = initialMissionId;
 }
 
+loadMissionList("");
 loadMissionWorkspace(initialMissionId);


### PR DESCRIPTION
## Summary

Implements GitHub issue #125 by adding mission search and list UI so operators can select missions without pasting UUIDs into the operator workspace.

## What changed

- Added a read-only mission list/search endpoint:
  - `GET /missions`
  - supports `q` and `limit` query parameters
- Built the endpoint from existing mission, platform, pilot, and latest-event state rather than introducing a second mission model.
- Extended the operator mission workspace UI with a new `Mission Search and Selection` section.
- Added client-side mission browsing that:
  - loads recent missions
  - filters missions by search text
  - shows operator-facing mission context
  - opens a selected mission into the existing workspace
- Mission list rows now surface:
  - mission ID
  - mission plan ID
  - mission status
  - platform assignment summary
  - pilot assignment summary
  - latest event summary
  - latest event time
- Kept the implementation read-only.
- Preserved the existing workspace flow so selecting a mission refreshes:
  - planning workspace
  - dispatch workspace
  - operations timeline
- Added integration coverage for:
  - recent mission listing
  - mission list filtering
  - operator workspace shell exposing search/list affordances
  - operator JavaScript bundle referencing mission list loading

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/mission-planning.test.ts` passed: 35 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 318 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

Closes #125.
