### PR TITLE
Add operator live operations map view

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add operator live operations map view so replay and future live telemetry can be reviewed separately from planning and dispatch workspace controls.",
+ "nextBuildStep": "Add mission-linked live operations alert overlay so replay and future live telemetry can surface airspace, readiness, and dispatch risk states on the operator map view.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -222,6 +222,16 @@ app.get("/operator/missions/:missionId", (_req, res) => {
     path.resolve(process.cwd(), "static", "operator-mission-workspace.html"),
   );
 });
+app.get("/operator/live-operations-map", (_req, res) => {
+  res.sendFile(
+    path.resolve(process.cwd(), "static", "operator-live-operations-map.html"),
+  );
+});
+app.get("/operator/missions/:missionId/live-operations", (_req, res) => {
+  res.sendFile(
+    path.resolve(process.cwd(), "static", "operator-live-operations-map.html"),
+  );
+});
 app.get("/", (_req, res) => {
   res.status(200).send("FSMS backend is running");
 });

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -1919,6 +1919,17 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("/static/operator-mission-workspace.js");
   });
 
+  it("serves the operator live operations map screen", async () => {
+    const response = await request(app).get("/operator/live-operations-map");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.text).toContain("Operator Live Operations View");
+    expect(response.text).toContain("Map and Replay Surface");
+    expect(response.text).toContain("Telemetry and Risk Status");
+    expect(response.text).toContain("/static/operator-live-operations-map.js");
+  });
+
   it("serves the operator mission workspace javascript bundle", async () => {
     const response = await request(app).get(
       "/static/operator-mission-workspace.js",
@@ -1939,5 +1950,20 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("/readiness/audit-snapshots");
     expect(response.text).toContain("/approval-handoff");
     expect(response.text).toContain('payload.decisionType = "dispatch"');
+  });
+
+  it("serves the operator live operations javascript bundle", async () => {
+    const response = await request(app).get(
+      "/static/operator-live-operations-map.js",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("javascript");
+    expect(response.text).toContain("/missions/${missionId}/replay");
+    expect(response.text).toContain("/missions/${missionId}/telemetry/latest");
+    expect(response.text).toContain("/missions/${missionId}/planning-workspace");
+    expect(response.text).toContain("/missions/${missionId}/dispatch-workspace");
+    expect(response.text).toContain("/missions/${missionId}/operations-timeline");
+    expect(response.text).toContain("/operator/missions/${encodeURIComponent(missionId)}");
   });
 });

--- a/static/operator-live-operations-map.html
+++ b/static/operator-live-operations-map.html
@@ -1,0 +1,413 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FSMS Operator Live Operations</title>
+  <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #09111b;
+      --bg-band: #0f1b2b;
+      --bg-soft: #142337;
+      --bg-accent: #1b2e46;
+      --border: rgba(255, 255, 255, 0.1);
+      --text: #edf3fb;
+      --muted: #9eb0c6;
+      --ok: #22c55e;
+      --warn: #f59e0b;
+      --bad: #ef4444;
+      --info: #38bdf8;
+      --radius: 8px;
+      --shadow: 0 20px 45px rgba(0, 0, 0, 0.3);
+      font-family: Inter, "Segoe UI", Arial, sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background:
+        radial-gradient(circle at top right, rgba(56, 189, 248, 0.12), transparent 28%),
+        linear-gradient(180deg, #08101a 0%, #0b1521 100%);
+      color: var(--text);
+    }
+
+    .page-shell { min-height: 100vh; }
+    .hero {
+      padding: 24px;
+      border-bottom: 1px solid var(--border);
+      background: linear-gradient(180deg, rgba(11, 21, 33, 0.94), rgba(11, 21, 33, 0.82));
+    }
+    .hero-inner, .band-inner {
+      width: min(1380px, calc(100vw - 32px));
+      margin: 0 auto;
+    }
+    .hero-top {
+      display: flex;
+      align-items: start;
+      justify-content: space-between;
+      gap: 20px;
+      margin-bottom: 18px;
+    }
+    .hero h1 {
+      margin: 0 0 8px;
+      font-size: clamp(28px, 4vw, 44px);
+      line-height: 1.05;
+      font-weight: 800;
+    }
+    .hero p {
+      margin: 0;
+      max-width: 760px;
+      color: var(--muted);
+      font-size: 15px;
+      line-height: 1.55;
+    }
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 40px;
+      padding: 0 14px;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.03);
+      font-size: 13px;
+      color: var(--muted);
+      white-space: nowrap;
+    }
+    .controls-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.8fr) repeat(3, minmax(160px, 1fr)) 180px;
+      gap: 12px;
+      align-items: end;
+    }
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .field label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      font-weight: 700;
+    }
+    .field input, .field button {
+      min-height: 48px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font: inherit;
+    }
+    .field input {
+      padding: 0 14px;
+      background: rgba(255,255,255,0.04);
+      color: var(--text);
+    }
+    .field button {
+      padding: 0 16px;
+      cursor: pointer;
+      color: var(--text);
+      background: var(--bg-accent);
+      font-weight: 700;
+    }
+    .field button.secondary {
+      background: rgba(255,255,255,0.04);
+      color: var(--muted);
+    }
+    .band { padding: 18px 0; }
+    .metric-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+    }
+    .metric, .panel {
+      border: 1px solid var(--border);
+      background: var(--bg-band);
+      box-shadow: var(--shadow);
+    }
+    .metric {
+      min-height: 128px;
+      padding: 18px;
+    }
+    .metric .label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      font-weight: 700;
+    }
+    .metric .value {
+      margin-top: 12px;
+      font-size: 28px;
+      font-weight: 800;
+      line-height: 1.05;
+    }
+    .metric .meta {
+      margin-top: 10px;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.45;
+    }
+    .panel-header {
+      padding: 16px 18px;
+      border-bottom: 1px solid var(--border);
+      background: rgba(255,255,255,0.02);
+    }
+    .panel-header h3 {
+      margin: 0;
+      font-size: 15px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .panel-header p {
+      margin: 8px 0 0;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.45;
+    }
+    .panel-body { padding: 18px; }
+    .live-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.6fr) minmax(340px, 0.8fr);
+      gap: 16px;
+    }
+    .summary-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+    .summary-block {
+      min-height: 138px;
+      padding: 16px;
+      border: 1px solid var(--border);
+      background: var(--bg-soft);
+    }
+    .summary-block h4 {
+      margin: 0 0 10px;
+      font-size: 13px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+    .kv {
+      display: grid;
+      grid-template-columns: 150px 1fr;
+      gap: 8px 12px;
+      font-size: 13px;
+      line-height: 1.45;
+    }
+    .kv .k { color: var(--muted); }
+    .stack {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+    .list-item {
+      padding: 12px 14px;
+      border: 1px solid var(--border);
+      background: var(--bg-soft);
+      font-size: 13px;
+      line-height: 1.45;
+    }
+    .list-item strong {
+      display: block;
+      margin-bottom: 4px;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      min-height: 28px;
+      padding: 0 10px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .tone-ok { color: var(--ok); }
+    .tone-warn { color: var(--warn); }
+    .tone-bad { color: var(--bad); }
+    .tone-info { color: var(--info); }
+    .tone-muted { color: var(--muted); }
+    .empty-state {
+      padding: 26px 18px;
+      border: 1px dashed var(--border);
+      color: var(--muted);
+      font-size: 14px;
+      line-height: 1.6;
+      background: rgba(255,255,255,0.02);
+    }
+    .map-shell {
+      position: relative;
+      min-height: 620px;
+      border: 1px solid var(--border);
+      background: linear-gradient(180deg, rgba(18,32,50,0.94), rgba(10,18,28,0.98));
+      overflow: hidden;
+    }
+    .map-grid {
+      position: absolute;
+      inset: 0;
+      background-image:
+        linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
+      background-size: 56px 56px;
+    }
+    .map-svg {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+    }
+    .map-overlay {
+      position: absolute;
+      left: 16px;
+      bottom: 16px;
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+    .overlay-pill {
+      min-height: 34px;
+      padding: 0 12px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: rgba(9,17,27,0.72);
+      display: inline-flex;
+      align-items: center;
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .timeline-item {
+      display: grid;
+      grid-template-columns: 146px 110px 1fr;
+      gap: 12px;
+      padding: 14px 16px;
+      border: 1px solid var(--border);
+      background: var(--bg-band);
+    }
+    .timeline-time { color: var(--muted); font-size: 13px; }
+    .timeline-phase {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-weight: 800;
+    }
+    .timeline-summary {
+      font-size: 14px;
+      font-weight: 700;
+      margin-bottom: 4px;
+    }
+    .timeline-meta {
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.45;
+    }
+    @media (max-width: 1120px) {
+      .controls-grid,
+      .metric-grid,
+      .live-grid,
+      .summary-grid,
+      .timeline-item {
+        grid-template-columns: 1fr;
+      }
+      .kv { grid-template-columns: 1fr; }
+      .map-shell { min-height: 480px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="page-shell">
+    <header class="hero">
+      <div class="hero-inner">
+        <div class="hero-top">
+          <div>
+            <h1>Operator Live Operations View</h1>
+            <p>
+              Read-only mission map surface for replay and future live telemetry, separated from planning and dispatch controls.
+            </p>
+          </div>
+          <div id="live-ops-connection-status" class="status-pill">No mission loaded</div>
+        </div>
+        <div class="controls-grid">
+          <div class="field">
+            <label for="live-ops-mission-id-input">Mission ID</label>
+            <input id="live-ops-mission-id-input" type="text" placeholder="Enter mission UUID" />
+          </div>
+          <div class="field">
+            <label>&nbsp;</label>
+            <button id="load-live-ops-btn" type="button">Load live ops view</button>
+          </div>
+          <div class="field">
+            <label>&nbsp;</label>
+            <button id="open-workspace-btn" class="secondary" type="button">Open workspace</button>
+          </div>
+          <div class="field">
+            <label>&nbsp;</label>
+            <button id="open-replay-api-btn" class="secondary" type="button">Open replay JSON</button>
+          </div>
+          <div class="field">
+            <label>Loaded mission</label>
+            <div id="live-ops-loaded-mission-pill" class="status-pill">None</div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <section class="band">
+      <div class="band-inner">
+        <div id="live-ops-overview" class="metric-grid"></div>
+      </div>
+    </section>
+
+    <section class="band">
+      <div class="band-inner live-grid">
+        <div class="panel">
+          <div class="panel-header">
+            <h3>Map and Replay Surface</h3>
+            <p>Mission replay track, latest telemetry position, and current live-ops overlays.</p>
+          </div>
+          <div class="panel-body">
+            <div id="live-ops-map" class="map-shell"></div>
+          </div>
+        </div>
+        <div class="stack">
+          <div class="panel">
+            <div class="panel-header">
+              <h3>Telemetry and Risk Status</h3>
+              <p>Current telemetry context, readiness posture, and operator-relevant launch risk signals.</p>
+            </div>
+            <div id="live-ops-status" class="panel-body"></div>
+          </div>
+          <div class="panel">
+            <div class="panel-header">
+              <h3>Event Context</h3>
+              <p>Recent mission narrative items to keep flight picture and timeline context together.</p>
+            </div>
+            <div id="live-ops-timeline" class="panel-body"></div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <script type="module" src="/static/operator-live-operations-map.js"></script>
+</body>
+</html>

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -1,0 +1,492 @@
+const missionIdInput = document.getElementById("live-ops-mission-id-input");
+const loadButton = document.getElementById("load-live-ops-btn");
+const openWorkspaceButton = document.getElementById("open-workspace-btn");
+const openReplayApiButton = document.getElementById("open-replay-api-btn");
+const connectionStatus = document.getElementById("live-ops-connection-status");
+const loadedMissionPill = document.getElementById("live-ops-loaded-mission-pill");
+const overviewPanel = document.getElementById("live-ops-overview");
+const mapPanel = document.getElementById("live-ops-map");
+const statusPanel = document.getElementById("live-ops-status");
+const timelinePanel = document.getElementById("live-ops-timeline");
+
+const uiState = {
+  missionId: "",
+  planningWorkspace: null,
+  dispatchWorkspace: null,
+  timeline: null,
+  replay: null,
+  latestTelemetry: null,
+};
+
+const toneClass = (value) => {
+  const text = String(value ?? "").toLowerCase();
+
+  if (
+    text.includes("approved") ||
+    text.includes("present") ||
+    text.includes("ready") ||
+    text.includes("clear") ||
+    text.includes("pass") ||
+    text.includes("allowed") ||
+    text.includes("active")
+  ) {
+    return "tone-ok";
+  }
+
+  if (
+    text.includes("review") ||
+    text.includes("pending") ||
+    text.includes("missing") ||
+    text.includes("draft") ||
+    text.includes("submitted")
+  ) {
+    return "tone-warn";
+  }
+
+  if (
+    text.includes("blocked") ||
+    text.includes("rejected") ||
+    text.includes("fail") ||
+    text.includes("abort")
+  ) {
+    return "tone-bad";
+  }
+
+  return "tone-info";
+};
+
+const escapeHtml = (value) =>
+  String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+
+const renderBadge = (value) =>
+  `<span class="badge ${toneClass(value)}">${escapeHtml(value ?? "Unknown")}</span>`;
+
+const formatDateTime = (value) => {
+  if (!value) {
+    return "Not recorded";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+
+  return date.toLocaleString("en-GB", {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+};
+
+const fetchJson = async (url, options = {}) => {
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+      ...(options.headers ?? {}),
+    },
+    ...options,
+  });
+
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new Error(payload?.error?.message || `Request failed with ${response.status}`);
+  }
+
+  return payload;
+};
+
+const setConnectionState = (message, tone = "tone-muted") => {
+  connectionStatus.className = `status-pill ${tone}`;
+  connectionStatus.textContent = message;
+};
+
+const setLoadedMission = (missionId) => {
+  loadedMissionPill.textContent = missionId || "None";
+};
+
+const missionDisplayName = (mission) =>
+  mission?.missionPlanId || mission?.id || "Unknown mission";
+
+const updateUrl = (missionId) => {
+  const next = new URL(window.location.href);
+  if (missionId) {
+    next.searchParams.set("missionId", missionId);
+  } else {
+    next.searchParams.delete("missionId");
+  }
+  window.history.replaceState({}, "", next);
+};
+
+const getMissionIdFromLocation = () => {
+  const pathMatch = window.location.pathname.match(/^\/operator\/missions\/([^/]+)\/live-operations$/);
+  if (pathMatch?.[1]) {
+    return decodeURIComponent(pathMatch[1]);
+  }
+
+  const queryMissionId = new URL(window.location.href).searchParams.get("missionId");
+  return queryMissionId?.trim() || "";
+};
+
+const renderList = (items, title) => {
+  if (!items || items.length === 0) {
+    return `<div class="empty-state">No ${escapeHtml(title).toLowerCase()} recorded.</div>`;
+  }
+
+  return `
+    <ul class="list">
+      ${items
+        .map(
+          (item) => `
+            <li class="list-item">
+              <strong>${escapeHtml(item.label ?? title)}</strong>
+              <div>${escapeHtml(item.value ?? item)}</div>
+            </li>
+          `,
+        )
+        .join("")}
+    </ul>
+  `;
+};
+
+const renderOverview = () => {
+  const planningWorkspace = uiState.planningWorkspace;
+  const dispatchWorkspace = uiState.dispatchWorkspace;
+  const mission = planningWorkspace?.mission ?? dispatchWorkspace?.mission;
+  const replayCount = uiState.replay?.replay?.length ?? 0;
+  const latestTelemetry = uiState.latestTelemetry?.telemetry;
+  const timelineCount = uiState.timeline?.items?.length ?? 0;
+
+  overviewPanel.innerHTML = `
+    <article class="metric">
+      <div class="label">Mission</div>
+      <div class="value ${toneClass(mission?.status ?? "Unknown")}">${escapeHtml(
+        missionDisplayName(mission),
+      )}</div>
+      <div class="meta">Mission status: ${escapeHtml(mission?.status ?? "Unknown")}</div>
+    </article>
+    <article class="metric">
+      <div class="label">Replay track</div>
+      <div class="value">${escapeHtml(String(replayCount))}</div>
+      <div class="meta">Replay points available for the selected mission.</div>
+    </article>
+    <article class="metric">
+      <div class="label">Latest telemetry</div>
+      <div class="value ${toneClass(latestTelemetry ? "present" : "missing")}">${escapeHtml(
+        latestTelemetry ? formatDateTime(latestTelemetry.timestamp) : "Missing",
+      )}</div>
+      <div class="meta">Altitude: ${escapeHtml(
+        latestTelemetry?.altitudeM != null ? `${latestTelemetry.altitudeM} m` : "Not recorded",
+      )}</div>
+    </article>
+    <article class="metric">
+      <div class="label">Timeline coverage</div>
+      <div class="value">${escapeHtml(String(timelineCount))}</div>
+      <div class="meta">Mission narrative items across planning, approval, dispatch, flight, and post-operation.</div>
+    </article>
+  `;
+};
+
+const buildMapMarkup = () => {
+  const replayPoints = uiState.replay?.replay ?? [];
+  const latestTelemetry = uiState.latestTelemetry?.telemetry ?? null;
+  const points = replayPoints
+    .filter((point) => Number.isFinite(point.lat) && Number.isFinite(point.lng))
+    .concat(
+      latestTelemetry &&
+        Number.isFinite(latestTelemetry.lat) &&
+        Number.isFinite(latestTelemetry.lng)
+        ? [latestTelemetry]
+        : [],
+    );
+
+  if (points.length === 0) {
+    return `<div class="empty-state">No replay or telemetry coordinates are available for this mission yet.</div>`;
+  }
+
+  const lats = points.map((point) => Number(point.lat));
+  const lngs = points.map((point) => Number(point.lng));
+  const minLat = Math.min(...lats);
+  const maxLat = Math.max(...lats);
+  const minLng = Math.min(...lngs);
+  const maxLng = Math.max(...lngs);
+  const latSpan = Math.max(maxLat - minLat, 0.0001);
+  const lngSpan = Math.max(maxLng - minLng, 0.0001);
+  const width = 1000;
+  const height = 620;
+  const padding = 48;
+
+  const toPoint = (lat, lng) => {
+    const x = padding + ((lng - minLng) / lngSpan) * (width - padding * 2);
+    const y = height - padding - ((lat - minLat) / latSpan) * (height - padding * 2);
+    return { x, y };
+  };
+
+  const replayPath = replayPoints
+    .filter((point) => Number.isFinite(point.lat) && Number.isFinite(point.lng))
+    .map((point) => {
+      const projected = toPoint(Number(point.lat), Number(point.lng));
+      return `${projected.x},${projected.y}`;
+    })
+    .join(" ");
+
+  const replayDots = replayPoints
+    .filter((point) => Number.isFinite(point.lat) && Number.isFinite(point.lng))
+    .map((point, index) => {
+      const projected = toPoint(Number(point.lat), Number(point.lng));
+      return `
+        <circle cx="${projected.x}" cy="${projected.y}" r="${index === 0 ? 6 : 4}" fill="${
+          index === 0 ? "#22c55e" : "#38bdf8"
+        }" opacity="${index === 0 ? "1" : "0.82"}" />
+      `;
+    })
+    .join("");
+
+  const latestPoint =
+    latestTelemetry &&
+    Number.isFinite(latestTelemetry.lat) &&
+    Number.isFinite(latestTelemetry.lng)
+      ? toPoint(Number(latestTelemetry.lat), Number(latestTelemetry.lng))
+      : null;
+
+  const overlays = [
+    `Replay points ${replayPoints.length}`,
+    latestTelemetry ? `Latest telemetry ${formatDateTime(latestTelemetry.timestamp)}` : "Latest telemetry missing",
+    uiState.dispatchWorkspace?.dispatch?.ready ? "Dispatch ready" : "Dispatch blocked",
+  ];
+
+  return `
+    <div class="map-grid"></div>
+    <svg class="map-svg" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" aria-label="Mission live operations map">
+      ${replayPath ? `<polyline points="${replayPath}" fill="none" stroke="#38bdf8" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" opacity="0.92" />` : ""}
+      ${replayDots}
+      ${
+        latestPoint
+          ? `
+            <circle cx="${latestPoint.x}" cy="${latestPoint.y}" r="14" fill="rgba(239,68,68,0.18)" />
+            <circle cx="${latestPoint.x}" cy="${latestPoint.y}" r="7" fill="#ef4444" stroke="#edf3fb" stroke-width="2" />
+          `
+          : ""
+      }
+    </svg>
+    <div class="map-overlay">
+      ${overlays.map((item) => `<div class="overlay-pill">${escapeHtml(item)}</div>`).join("")}
+    </div>
+  `;
+};
+
+const renderMap = () => {
+  mapPanel.innerHTML = buildMapMarkup();
+};
+
+const renderStatus = () => {
+  if (!uiState.planningWorkspace || !uiState.dispatchWorkspace) {
+    statusPanel.innerHTML =
+      '<div class="empty-state">Load a mission before telemetry and risk status can be evaluated.</div>';
+    return;
+  }
+
+  const planningWorkspace = uiState.planningWorkspace;
+  const dispatchWorkspace = uiState.dispatchWorkspace;
+  const latestTelemetry = uiState.latestTelemetry?.telemetry;
+  const riskSignals = [
+    ...((planningWorkspace.blockingReasons ?? []).map((reason) => ({
+      label: "Planning blocker",
+      value: reason,
+    }))),
+    ...((dispatchWorkspace.dispatch?.blockingReasons ?? []).map((reason) => ({
+      label: "Dispatch blocker",
+      value: reason,
+    }))),
+    ...((dispatchWorkspace.dispatch?.missingRequirements ?? []).map((reason) => ({
+      label: "Dispatch requirement",
+      value: reason,
+    }))),
+  ];
+
+  statusPanel.innerHTML = `
+    <div class="summary-grid">
+      <section class="summary-block">
+        <h4>Telemetry State</h4>
+        <div class="kv">
+          <div class="k">Timestamp</div>
+          <div>${escapeHtml(formatDateTime(latestTelemetry?.timestamp))}</div>
+          <div class="k">Position</div>
+          <div>${escapeHtml(
+            latestTelemetry?.lat != null && latestTelemetry?.lng != null
+              ? `${latestTelemetry.lat}, ${latestTelemetry.lng}`
+              : "Not recorded",
+          )}</div>
+          <div class="k">Altitude</div>
+          <div>${escapeHtml(
+            latestTelemetry?.altitudeM != null ? `${latestTelemetry.altitudeM} m` : "Not recorded",
+          )}</div>
+          <div class="k">Speed</div>
+          <div>${escapeHtml(
+            latestTelemetry?.speedMps != null ? `${latestTelemetry.speedMps} m/s` : "Not recorded",
+          )}</div>
+        </div>
+      </section>
+      <section class="summary-block">
+        <h4>Operational Posture</h4>
+        <div class="kv">
+          <div class="k">Approval</div>
+          <div>${renderBadge(planningWorkspace.approval.ready ? "Ready" : "Blocked")}</div>
+          <div class="k">Dispatch</div>
+          <div>${renderBadge(dispatchWorkspace.dispatch.ready ? "Ready" : "Blocked")}</div>
+          <div class="k">Launch preflight</div>
+          <div>${renderBadge(dispatchWorkspace.dispatch.launchPreflight.allowed ? "Allowed" : "Blocked")}</div>
+          <div class="k">Approval evidence</div>
+          <div>${escapeHtml(planningWorkspace.evidence.latestApprovalEvidenceLink?.id ?? "Missing")}</div>
+          <div class="k">Dispatch evidence</div>
+          <div>${escapeHtml(dispatchWorkspace.dispatch.latestDispatchEvidenceLink?.id ?? "Missing")}</div>
+        </div>
+      </section>
+    </div>
+    <div style="margin-top: 14px;">
+      ${renderList(riskSignals, "live operation signals")}
+    </div>
+  `;
+};
+
+const renderTimeline = () => {
+  const items = uiState.timeline?.items ?? [];
+  const relevant = items.slice(-8).reverse();
+
+  if (relevant.length === 0) {
+    timelinePanel.innerHTML =
+      '<div class="empty-state">No mission event context is available for this live operations view yet.</div>';
+    return;
+  }
+
+  timelinePanel.innerHTML = `
+    <div class="stack">
+      ${relevant
+        .map(
+          (item) => `
+            <article class="timeline-item">
+              <div class="timeline-time">${escapeHtml(formatDateTime(item.occurredAt))}</div>
+              <div class="timeline-phase ${toneClass(item.phase)}">${escapeHtml(
+                item.phase.replaceAll("_", " "),
+              )}</div>
+              <div>
+                <div class="timeline-summary">${escapeHtml(item.summary)}</div>
+                <div class="timeline-meta">
+                  Type: ${escapeHtml(item.type)}<br />
+                  Source: ${escapeHtml(item.source)}
+                </div>
+              </div>
+            </article>
+          `,
+        )
+        .join("")}
+    </div>
+  `;
+};
+
+const clearPanels = (message) => {
+  overviewPanel.innerHTML = "";
+  mapPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
+  statusPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
+  timelinePanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
+};
+
+const loadLiveOperationsView = async (missionId) => {
+  if (!missionId) {
+    uiState.missionId = "";
+    uiState.planningWorkspace = null;
+    uiState.dispatchWorkspace = null;
+    uiState.timeline = null;
+    uiState.replay = null;
+    uiState.latestTelemetry = null;
+    setLoadedMission("");
+    setConnectionState("Enter a mission UUID", "tone-warn");
+    clearPanels("Enter a mission UUID to load the live operations view.");
+    return;
+  }
+
+  uiState.missionId = missionId;
+  setLoadedMission(missionId);
+  setConnectionState("Loading live operations view...", "tone-info");
+  updateUrl(missionId);
+
+  try {
+    const [
+      planningResponse,
+      dispatchResponse,
+      timelineResponse,
+      replayResponse,
+      latestTelemetryResponse,
+    ] = await Promise.all([
+      fetchJson(`/missions/${missionId}/planning-workspace`),
+      fetchJson(`/missions/${missionId}/dispatch-workspace`),
+      fetchJson(`/missions/${missionId}/operations-timeline`),
+      fetchJson(`/missions/${missionId}/replay`),
+      fetchJson(`/missions/${missionId}/telemetry/latest`),
+    ]);
+
+    uiState.planningWorkspace = planningResponse.workspace;
+    uiState.dispatchWorkspace = dispatchResponse.workspace;
+    uiState.timeline = timelineResponse.timeline;
+    uiState.replay = replayResponse;
+    uiState.latestTelemetry = latestTelemetryResponse;
+
+    renderOverview();
+    renderMap();
+    renderStatus();
+    renderTimeline();
+    setConnectionState("Live operations view loaded", "tone-ok");
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to load live operations view";
+    uiState.planningWorkspace = null;
+    uiState.dispatchWorkspace = null;
+    uiState.timeline = null;
+    uiState.replay = null;
+    uiState.latestTelemetry = null;
+    clearPanels(message);
+    setConnectionState(message, "tone-bad");
+  }
+};
+
+loadButton.addEventListener("click", () => {
+  loadLiveOperationsView(missionIdInput.value.trim());
+});
+
+missionIdInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    loadLiveOperationsView(missionIdInput.value.trim());
+  }
+});
+
+openWorkspaceButton.addEventListener("click", () => {
+  const missionId = missionIdInput.value.trim();
+  const target = missionId
+    ? `/operator/missions/${encodeURIComponent(missionId)}`
+    : "/operator/mission-workspace";
+  window.location.assign(target);
+});
+
+openReplayApiButton.addEventListener("click", () => {
+  const missionId = missionIdInput.value.trim();
+  if (!missionId) {
+    setConnectionState("Enter a mission UUID before opening replay JSON", "tone-warn");
+    return;
+  }
+
+  window.open(`/missions/${missionId}/replay`, "_blank", "noopener");
+});
+
+const initialMissionId = getMissionIdFromLocation();
+if (initialMissionId) {
+  missionIdInput.value = initialMissionId;
+}
+
+loadLiveOperationsView(initialMissionId);

--- a/static/operator-mission-workspace.html
+++ b/static/operator-mission-workspace.html
@@ -587,6 +587,10 @@
               <button id="open-api-btn" class="secondary" type="button">Open API JSON</button>
             </div>
             <div class="field">
+              <label>&nbsp;</label>
+              <button id="open-live-ops-btn" class="secondary" type="button">Open live ops view</button>
+            </div>
+            <div class="field">
               <label>Loaded mission</label>
               <div id="loaded-mission-pill" class="status-pill">None</div>
             </div>

--- a/static/operator-mission-workspace.js
+++ b/static/operator-mission-workspace.js
@@ -2,6 +2,7 @@ const missionIdInput = document.getElementById("mission-id-input");
 const loadWorkspaceButton = document.getElementById("load-workspace-btn");
 const copyLinkButton = document.getElementById("copy-link-btn");
 const openApiButton = document.getElementById("open-api-btn");
+const openLiveOpsButton = document.getElementById("open-live-ops-btn");
 const connectionStatus = document.getElementById("connection-status");
 const loadedMissionPill = document.getElementById("loaded-mission-pill");
 const overviewMetrics = document.getElementById("overview-metrics");
@@ -1198,6 +1199,14 @@ openApiButton.addEventListener("click", () => {
   }
 
   window.open(`/missions/${missionId}/planning-workspace`, "_blank", "noopener");
+});
+
+openLiveOpsButton?.addEventListener("click", () => {
+  const missionId = missionIdInput.value.trim();
+  const target = missionId
+    ? `/operator/missions/${encodeURIComponent(missionId)}/live-operations`
+    : "/operator/live-operations-map";
+  window.location.assign(target);
 });
 
 const initialMissionId = getMissionIdFromLocation();


### PR DESCRIPTION
## Summary

Implements GitHub issue #127 by adding a separate operator live operations map view so replay and future live telemetry can be reviewed independently from planning and dispatch workspace controls.

## What changed

- Added dedicated operator live-ops routes:
  - `GET /operator/live-operations-map`
  - `GET /operator/missions/:missionId/live-operations`
- Added a separate live operations screen instead of extending the planning/dispatch control workspace.
- Added a new static live-ops UI that loads mission data from the existing backend surfaces:
  - `GET /missions/:missionId/replay`
  - `GET /missions/:missionId/telemetry/latest`
  - `GET /missions/:missionId/planning-workspace`
  - `GET /missions/:missionId/dispatch-workspace`
  - `GET /missions/:missionId/operations-timeline`
- Rendered a read-only SVG mission track using replay telemetry data.
- Surfaced:
  - mission identity and status
  - replay point count
  - latest telemetry timestamp and position context
  - readiness / dispatch posture
  - recent mission timeline context relevant to live operations
- Added explicit navigation between:
  - operator mission workspace
  - operator live operations map view
- Kept the implementation read-only and did not add any new backend telemetry or replay APIs.
- Updated the save point to the next live-ops build step.

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 320 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

Closes #127.
