### PR TITLE
Fix local dev startup for operator UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,22 @@ fsms-backend/
 
 # Running the Backend
 
+## Current TypeScript dev startup
+
+For the current Express/TypeScript operator UI work, use:
+
+```powershell
+npm run dev
+```
+
+This dev entrypoint now:
+
+- compiles runtime server output into `dist/`
+- starts the server with plain `node`
+- skips startup migrations in local dev by default so static operator routes can still be rendered when local PostgreSQL credentials are not configured
+
+This is intended for UI rendering and route verification. API-backed mission data still requires a working local database setup.
+
 Activate the virtual environment:
 
 

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission-linked live operations alert overlay so replay and future live telemetry can surface airspace, readiness, and dispatch risk states on the operator map view.",
+ "nextBuildStep": "Document and harden local dev startup checks so operator UI routes remain renderable after runtime and environment changes.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
-    "dev": "tsx src/server.ts",
+    "dev": "node scripts/dev-server.mjs",
     "build": "tsc",
+    "build:runtime": "tsc -p tsconfig.runtime.json",
     "start": "node dist/server.js",
     "test": "vitest run",
     "validate:savepoint": "node scripts/validate-save-point.mjs",

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -1,0 +1,47 @@
+import { spawn, spawnSync } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.cwd();
+const tscCli = path.resolve(root, "node_modules", "typescript", "bin", "tsc");
+const runtimeConfig = path.resolve(root, "tsconfig.runtime.json");
+
+const compile = spawnSync(
+  process.execPath,
+  [tscCli, "-p", runtimeConfig],
+  {
+    cwd: root,
+    stdio: "inherit",
+  },
+);
+
+if (compile.status !== 0) {
+  process.exit(compile.status ?? 1);
+}
+
+const child = spawn(process.execPath, [path.resolve(root, "dist", "server.js")], {
+  cwd: root,
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    SKIP_STARTUP_MIGRATIONS: process.env.SKIP_STARTUP_MIGRATIONS ?? "1",
+  },
+});
+
+const forwardSignal = (signal) => {
+  if (!child.killed) {
+    child.kill(signal);
+  }
+};
+
+process.on("SIGINT", () => forwardSignal("SIGINT"));
+process.on("SIGTERM", () => forwardSignal("SIGTERM"));
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,14 +2,19 @@ import app, { pool } from "./app";
 import { runMigrations } from "./migrations/runMigrations";
 
 const port = Number(process.env.PORT ?? 3000);
+const skipStartupMigrations = process.env.SKIP_STARTUP_MIGRATIONS === "1";
 
 async function start() {
   try {
-    console.log("Running migrations...");
-    await runMigrations(pool);
+    if (skipStartupMigrations) {
+      console.log("Skipping startup migrations for local dev startup.");
+    } else {
+      console.log("Running migrations...");
+      await runMigrations(pool);
+    }
 
     app.listen(port, () => {
-      console.log(`🚀 Express server running on http://localhost:${port}`);
+      console.log(`Express server running on http://localhost:${port}`);
     });
   } catch (error) {
     console.error("Failed to start server:", error);

--- a/tsconfig.runtime.json
+++ b/tsconfig.runtime.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Implements GitHub issue #131 by fixing local dev startup so operator UI routes can be rendered and verified in-browser.

## What changed

- Replaced the `tsx`-based dev entrypoint with a deterministic local dev launcher:
  - `npm run dev` now runs `node scripts/dev-server.mjs`
- Added a runtime TypeScript build config:
  - `tsconfig.runtime.json`
- Added a dev startup script that:
  - compiles runtime server output to `dist`
  - starts the server with plain `node dist/server.js`
  - avoids the local `esbuild` child-process spawn failure path seen through `tsx`
- Updated `src/server.ts` so startup migrations are skipped only when:
  - `SKIP_STARTUP_MIGRATIONS=1`
- Set the dev launcher to use `SKIP_STARTUP_MIGRATIONS=1` by default so operator UI routes can still render locally even when PostgreSQL runtime credentials are not configured in `.env`
- Documented the current TypeScript local dev startup path in `README.md`
- Updated the save point to the next development-hardening step

## Root cause addressed

The previous `npm run dev` path used:

- `tsx src/server.ts`

In this Windows worktree that path failed with:

- `esbuild` child process spawn `EPERM`

The new dev path removes that dependency from local startup and provides a stable render path for operator UI verification.

## Verification

- `npm.cmd run build` passed.
- `npm.cmd run build:runtime` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `npm.cmd run dev` started successfully.
- Local route checks returned `200` for:
  - `http://localhost:3000/operator/mission-workspace`
  - `http://localhost:3000/operator/live-operations-map`

## Notes

- This change is development-focused and does not change the default production startup behavior unless `SKIP_STARTUP_MIGRATIONS` is explicitly set.
- API-backed mission data still requires a working local database setup. The fix here is specifically to restore reliable local rendering of operator UI routes and static assets.

Closes #131.
