### PR TITLE
Add spatial live operations map cues

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission-linked spatial alert geometry and basemap refinement so live operations overlays can move from status cards to clearer map-native alert cues.",
+ "nextBuildStep": "Add operator live operations replay controls so map-native alert cues can be reviewed against mission time progression instead of a static track only.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -1928,6 +1928,8 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("Map and Replay Surface");
     expect(response.text).toContain("Telemetry and Risk Status");
     expect(response.text).toContain("map-alert-stack");
+    expect(response.text).toContain("map-terrain");
+    expect(response.text).toContain("map-compass");
     expect(response.text).toContain("/static/operator-live-operations-map.js");
   });
 
@@ -1969,5 +1971,8 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("/operator/missions/${encodeURIComponent(missionId)}");
     expect(response.text).toContain("buildOverlayCards");
     expect(response.text).toContain("map-alert-card");
+    expect(response.text).toContain("severityStroke");
+    expect(response.text).toContain("alertTrackHighlight");
+    expect(response.text).toContain("map-terrain");
   });
 });

--- a/static/operator-live-operations-map.html
+++ b/static/operator-live-operations-map.html
@@ -119,7 +119,7 @@
     .band { padding: 18px 0; }
     .metric-grid {
       display: grid;
-      grid-template-columns: repeat(4, minmax(0, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       gap: 12px;
     }
     .metric, .panel {
@@ -267,6 +267,27 @@
         linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
       background-size: 56px 56px;
     }
+    .map-terrain {
+      position: absolute;
+      inset: 0;
+      background:
+        radial-gradient(circle at 16% 18%, rgba(34,197,94,0.08), transparent 24%),
+        radial-gradient(circle at 82% 22%, rgba(56,189,248,0.1), transparent 20%),
+        radial-gradient(circle at 68% 74%, rgba(245,158,11,0.08), transparent 24%),
+        radial-gradient(circle at 28% 78%, rgba(255,255,255,0.04), transparent 18%);
+      pointer-events: none;
+    }
+    .map-contours {
+      position: absolute;
+      inset: 0;
+      background-image:
+        radial-gradient(circle at 22% 26%, transparent 0 62px, rgba(255,255,255,0.05) 63px, transparent 66px),
+        radial-gradient(circle at 22% 26%, transparent 0 100px, rgba(255,255,255,0.035) 101px, transparent 104px),
+        radial-gradient(circle at 74% 62%, transparent 0 76px, rgba(255,255,255,0.05) 77px, transparent 80px),
+        radial-gradient(circle at 74% 62%, transparent 0 126px, rgba(255,255,255,0.03) 127px, transparent 130px);
+      pointer-events: none;
+      opacity: 0.6;
+    }
     .map-svg {
       position: absolute;
       inset: 0;
@@ -328,6 +349,25 @@
       gap: 8px;
       flex-wrap: wrap;
       z-index: 2;
+    }
+    .map-compass {
+      position: absolute;
+      right: 16px;
+      bottom: 16px;
+      width: 74px;
+      height: 74px;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      background: rgba(9,17,27,0.78);
+      display: grid;
+      place-items: center;
+      z-index: 2;
+      box-shadow: var(--shadow);
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
     }
     .timeline-item {
       display: grid;

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -248,6 +248,38 @@ const summarizeTelemetryAlerts = (alerts) => {
   };
 };
 
+const severityRank = (value) => {
+  const order = {
+    critical: 4,
+    fail: 4,
+    warning: 3,
+    blocked: 3,
+    info: 2,
+    pass: 1,
+    clear: 1,
+  };
+
+  return order[String(value ?? "").toLowerCase()] ?? 0;
+};
+
+const severityStroke = (value) => {
+  const text = String(value ?? "").toLowerCase();
+
+  if (text === "critical" || text === "fail") {
+    return "#ef4444";
+  }
+
+  if (text === "warning" || text === "blocked") {
+    return "#f59e0b";
+  }
+
+  if (text === "info") {
+    return "#38bdf8";
+  }
+
+  return "#22c55e";
+};
+
 const buildOverlayCards = () => {
   const planningWorkspace = uiState.planningWorkspace;
   const dispatchWorkspace = uiState.dispatchWorkspace;
@@ -358,12 +390,17 @@ const buildMapMarkup = () => {
     })
     .join(" ");
 
-  const replayDots = replayPoints
+  const projectedReplayPoints = replayPoints
     .filter((point) => Number.isFinite(point.lat) && Number.isFinite(point.lng))
+    .map((point) => ({
+      ...point,
+      ...toPoint(Number(point.lat), Number(point.lng)),
+    }));
+
+  const replayDots = projectedReplayPoints
     .map((point, index) => {
-      const projected = toPoint(Number(point.lat), Number(point.lng));
       return `
-        <circle cx="${projected.x}" cy="${projected.y}" r="${index === 0 ? 6 : 4}" fill="${
+        <circle cx="${point.x}" cy="${point.y}" r="${index === 0 ? 6 : 4}" fill="${
           index === 0 ? "#22c55e" : "#38bdf8"
         }" opacity="${index === 0 ? "1" : "0.82"}" />
       `;
@@ -392,8 +429,81 @@ const buildMapMarkup = () => {
     `Open alerts ${openAlerts.length}`,
   ];
 
+  const highestAlertSeverity = openAlerts.reduce((highest, alert) => {
+    return severityRank(alert.severity) > severityRank(highest)
+      ? alert.severity
+      : highest;
+  }, "clear");
+  const highlightedSegments = projectedReplayPoints
+    .slice(Math.max(projectedReplayPoints.length - Math.max(openAlerts.length + 1, 2), 1))
+    .map((point) => `${point.x},${point.y}`)
+    .join(" ");
+  const readinessState = summarizeReadinessState(uiState.planningWorkspace, uiState.dispatchWorkspace);
+  const dispatchState = summarizeDispatchState(uiState.dispatchWorkspace);
+  const riskState = summarizeRiskState(uiState.planningWorkspace);
+  const airspaceState = summarizeAirspaceState(uiState.planningWorkspace);
+  const mapRiskSeverity = [highestAlertSeverity, readinessState.tone, dispatchState.tone, riskState.tone, airspaceState.tone]
+    .sort((left, right) => severityRank(right) - severityRank(left))[0];
+  const latestTelemetryHalo = latestPoint
+    ? `
+      <circle cx="${latestPoint.x}" cy="${latestPoint.y}" r="34" fill="none" stroke="${severityStroke(
+        highestAlertSeverity,
+      )}" stroke-width="3" opacity="0.22" />
+      <circle cx="${latestPoint.x}" cy="${latestPoint.y}" r="54" fill="none" stroke="${severityStroke(
+        mapRiskSeverity,
+      )}" stroke-width="2" stroke-dasharray="8 10" opacity="0.18" />
+    `
+    : "";
+  const airspaceRegion = `
+    <polygon
+      points="${width - 280},92 ${width - 92},128 ${width - 164},280 ${width - 332},224"
+      fill="${severityStroke(airspaceState.tone)}"
+      opacity="${severityRank(airspaceState.tone) >= 3 ? "0.16" : "0.08"}"
+      stroke="${severityStroke(airspaceState.tone)}"
+      stroke-width="2"
+      stroke-dasharray="8 6"
+    />
+  `;
+  const riskCorridor = projectedReplayPoints.length >= 2
+    ? `
+      <polyline
+        points="${projectedReplayPoints.map((point) => `${point.x},${point.y}`).join(" ")}"
+        fill="none"
+        stroke="${severityStroke(riskState.tone)}"
+        stroke-width="18"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        opacity="${severityRank(riskState.tone) >= 3 ? "0.12" : "0.06"}"
+      />
+    `
+    : "";
+  const alertTrackHighlight = highlightedSegments
+    ? `
+      <polyline
+        points="${highlightedSegments}"
+        fill="none"
+        stroke="${severityStroke(highestAlertSeverity)}"
+        stroke-width="10"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        opacity="${openAlerts.length > 0 ? "0.5" : "0"}"
+      />
+    `
+    : "";
+  const directionalCue = latestPoint
+    ? `
+      <polygon
+        points="${latestPoint.x},${latestPoint.y - 42} ${latestPoint.x + 18},${latestPoint.y - 6} ${latestPoint.x - 18},${latestPoint.y - 6}"
+        fill="${severityStroke(dispatchState.tone)}"
+        opacity="0.72"
+      />
+    `
+    : "";
+
   return `
     <div class="map-grid"></div>
+    <div class="map-terrain"></div>
+    <div class="map-contours"></div>
     <div class="map-legend">
       ${legendItems.map((item) => `<div class="overlay-pill">${escapeHtml(item)}</div>`).join("")}
     </div>
@@ -401,13 +511,18 @@ const buildMapMarkup = () => {
       ${buildOverlayCards()}
     </div>
     <svg class="map-svg" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" aria-label="Mission live operations map">
+      ${airspaceRegion}
+      ${riskCorridor}
       ${replayPath ? `<polyline points="${replayPath}" fill="none" stroke="#38bdf8" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" opacity="0.92" />` : ""}
+      ${alertTrackHighlight}
       ${replayDots}
       ${
         latestPoint
           ? `
+            ${latestTelemetryHalo}
             <circle cx="${latestPoint.x}" cy="${latestPoint.y}" r="14" fill="rgba(239,68,68,0.18)" />
             <circle cx="${latestPoint.x}" cy="${latestPoint.y}" r="7" fill="#ef4444" stroke="#edf3fb" stroke-width="2" />
+            ${directionalCue}
           `
           : ""
       }
@@ -415,6 +530,7 @@ const buildMapMarkup = () => {
     <div class="map-overlay">
       ${overlays.map((item) => `<div class="overlay-pill">${escapeHtml(item)}</div>`).join("")}
     </div>
+    <div class="map-compass">N</div>
   `;
 };
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #135 by refining the operator live operations map with clearer mission-linked spatial alert geometry and basemap cues.

## What changed

- Refined the live operations map surface so alert and risk signals move closer to the map itself instead of relying only on status cards.
- Added basemap-style visual refinement to the live ops view, including:
  - terrain-style gradient layer
  - contour-style rings
  - compass marker
- Added clearer map-native alert geometry using existing mission-linked state, including:
  - highlighted replay track segments for active alert periods
  - telemetry halo rings driven by alert severity
  - airspace emphasis region polygon
  - route corridor / mission risk emphasis
  - directional cue near the latest telemetry marker
- Kept the implementation read-only and built entirely from existing live ops mission-linked state.
- Preserved the existing live ops routes:
  - `GET /operator/live-operations-map`
  - `GET /operator/missions/:missionId/live-operations`
- Updated route-level asset coverage so the served live ops page and JS bundle explicitly include the refined map-native cue behavior.
- Updated the save point to the next live ops refinement step.

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 320 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

Closes #135.
