### PR TITLE
Add live operations alert timeline correlation

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission-linked alert timeline correlation so replay controls and map-native cues can be reviewed against explicit alert periods and operational events.",
+ "nextBuildStep": "Add operator live operations replay speed controls and segment stepping so alert-correlated mission review can move faster than one fixed playback pace.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -1927,8 +1927,10 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("Operator Live Operations View");
     expect(response.text).toContain("Map and Replay Surface");
     expect(response.text).toContain("Telemetry and Risk Status");
+    expect(response.text).toContain("Alert Timeline Correlation");
     expect(response.text).toContain("live-ops-replay-play-btn");
     expect(response.text).toContain("live-ops-replay-slider");
+    expect(response.text).toContain("live-ops-replay-markers");
     expect(response.text).toContain("live-ops-replay-progress");
     expect(response.text).toContain("map-alert-stack");
     expect(response.text).toContain("map-terrain");
@@ -1979,6 +1981,9 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("renderReplayControls");
     expect(response.text).toContain("replayPlayButton");
     expect(response.text).toContain("replaySlider");
+    expect(response.text).toContain("replayMarkers");
+    expect(response.text).toContain("correlatedAlertWindows");
+    expect(response.text).toContain("renderAlertCorrelation");
     expect(response.text).toContain("setInterval");
     expect(response.text).toContain("map-terrain");
   });

--- a/static/operator-live-operations-map.html
+++ b/static/operator-live-operations-map.html
@@ -266,6 +266,11 @@
       align-items: center;
       margin-bottom: 14px;
     }
+    .replay-slider-stack {
+      display: grid;
+      gap: 6px;
+      min-width: 0;
+    }
     .control-button {
       min-height: 40px;
       padding: 0 14px;
@@ -294,6 +299,26 @@
       width: 100%;
       accent-color: var(--info);
     }
+    .replay-markers {
+      position: relative;
+      height: 14px;
+      border-radius: 999px;
+      background: rgba(255,255,255,0.04);
+      overflow: hidden;
+    }
+    .replay-marker {
+      position: absolute;
+      top: 2px;
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      transform: translateX(-50%);
+      border: 1px solid rgba(9,17,27,0.92);
+      box-shadow: 0 0 0 2px rgba(9,17,27,0.38);
+    }
+    .replay-marker.info { background: var(--info); }
+    .replay-marker.warning { background: var(--warn); }
+    .replay-marker.critical { background: var(--bad); }
     .replay-progress {
       min-width: 126px;
       text-align: right;
@@ -421,6 +446,39 @@
       border: 1px solid var(--border);
       background: var(--bg-band);
     }
+    .correlation-card {
+      padding: 14px 16px;
+      border: 1px solid var(--border);
+      background: var(--bg-soft);
+    }
+    .correlation-card h4 {
+      margin: 0 0 10px;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+    }
+    .alert-window-list {
+      display: grid;
+      gap: 10px;
+    }
+    .alert-window {
+      padding: 12px 14px;
+      border: 1px solid var(--border);
+      background: rgba(255,255,255,0.03);
+    }
+    .alert-window strong {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .alert-window-meta {
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.45;
+    }
     .timeline-time { color: var(--muted); font-size: 13px; }
     .timeline-phase {
       font-size: 12px;
@@ -506,7 +564,10 @@
             <div class="replay-controls">
               <button id="live-ops-replay-play-btn" class="control-button" type="button">Play</button>
               <button id="live-ops-replay-pause-btn" class="control-button" type="button" disabled>Pause</button>
-              <input id="live-ops-replay-slider" class="replay-slider" type="range" min="0" max="0" step="1" value="0" />
+              <div class="replay-slider-stack">
+                <input id="live-ops-replay-slider" class="replay-slider" type="range" min="0" max="0" step="1" value="0" />
+                <div id="live-ops-replay-markers" class="replay-markers"></div>
+              </div>
               <div id="live-ops-replay-time" class="replay-readout">Replay time: not loaded</div>
               <div id="live-ops-replay-progress" class="replay-progress">0 / 0</div>
             </div>
@@ -520,6 +581,13 @@
               <p>Current telemetry context, readiness posture, and operator-relevant launch risk signals.</p>
             </div>
             <div id="live-ops-status" class="panel-body"></div>
+          </div>
+          <div class="panel">
+            <div class="panel-header">
+              <h3>Alert Timeline Correlation</h3>
+              <p>Current replay-point alert state, alert windows, and nearby mission events.</p>
+            </div>
+            <div id="live-ops-alert-correlation" class="panel-body"></div>
           </div>
           <div class="panel">
             <div class="panel-header">

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -8,11 +8,13 @@ const overviewPanel = document.getElementById("live-ops-overview");
 const mapPanel = document.getElementById("live-ops-map");
 const statusPanel = document.getElementById("live-ops-status");
 const timelinePanel = document.getElementById("live-ops-timeline");
+const alertCorrelationPanel = document.getElementById("live-ops-alert-correlation");
 const replayPlayButton = document.getElementById("live-ops-replay-play-btn");
 const replayPauseButton = document.getElementById("live-ops-replay-pause-btn");
 const replaySlider = document.getElementById("live-ops-replay-slider");
 const replayTimeReadout = document.getElementById("live-ops-replay-time");
 const replayProgress = document.getElementById("live-ops-replay-progress");
+const replayMarkers = document.getElementById("live-ops-replay-markers");
 
 const uiState = {
   missionId: "",
@@ -128,6 +130,12 @@ const renderReplayControls = () => {
   const pointCount = points.length;
   const activePoint = activeReplayPoint();
   const sliderMax = Math.max(pointCount - 1, 0);
+  const replayStart = points[0]?.timestamp ? Date.parse(points[0].timestamp) : null;
+  const replayEnd = points[pointCount - 1]?.timestamp
+    ? Date.parse(points[pointCount - 1].timestamp)
+    : replayStart;
+  const replaySpan =
+    replayStart != null && replayEnd != null ? Math.max(replayEnd - replayStart, 1) : 1;
 
   replaySlider.max = String(sliderMax);
   replaySlider.disabled = pointCount <= 1;
@@ -140,6 +148,22 @@ const renderReplayControls = () => {
     pointCount === 0
       ? "0 / 0"
       : `${uiState.replayPlayback.index + 1} / ${pointCount}`;
+  replayMarkers.innerHTML =
+    pointCount === 0 || replayStart == null || replayEnd == null
+      ? ""
+      : (uiState.alerts ?? [])
+          .map((alert) => {
+            const markerTime = Date.parse(alert.triggeredAt);
+            if (!Number.isFinite(markerTime)) {
+              return "";
+            }
+
+            const left = ((markerTime - replayStart) / replaySpan) * 100;
+            return `<span class="replay-marker ${escapeHtml(
+              alert.severity,
+            )}" style="left:${Math.max(0, Math.min(left, 100))}%"></span>`;
+          })
+          .join("");
 };
 
 const missionDisplayName = (mission) =>
@@ -364,6 +388,64 @@ const buildOverlayCards = () => {
       `,
     )
     .join("");
+};
+
+const correlatedAlertWindows = () => {
+  const replayPoints = replayTrack();
+  const activePoint = activeReplayPoint();
+  const activeTime = activePoint?.timestamp ? Date.parse(activePoint.timestamp) : null;
+  const lastReplayTimestamp =
+    replayPoints[replayPoints.length - 1]?.timestamp
+      ? Date.parse(replayPoints[replayPoints.length - 1].timestamp)
+      : activeTime;
+
+  return (uiState.alerts ?? [])
+    .map((alert) => {
+      const start = Date.parse(alert.triggeredAt);
+      const end = alert.resolvedAt
+        ? Date.parse(alert.resolvedAt)
+        : lastReplayTimestamp ?? start;
+      const activeAtReplay =
+        activeTime != null &&
+        Number.isFinite(start) &&
+        Number.isFinite(end) &&
+        activeTime >= start &&
+        activeTime <= end;
+      const relativeMs =
+        activeTime == null || !Number.isFinite(start) ? Number.POSITIVE_INFINITY : Math.abs(activeTime - start);
+
+      return {
+        ...alert,
+        activeAtReplay,
+        relativeMs,
+      };
+    })
+    .sort((left, right) => {
+      if (left.activeAtReplay !== right.activeAtReplay) {
+        return left.activeAtReplay ? -1 : 1;
+      }
+      return left.relativeMs - right.relativeMs;
+    });
+};
+
+const correlatedTimelineEvents = () => {
+  const activePoint = activeReplayPoint();
+  const activeTime = activePoint?.timestamp ? Date.parse(activePoint.timestamp) : null;
+
+  return (uiState.timeline?.items ?? [])
+    .map((item) => {
+      const itemTime = item?.occurredAt ? Date.parse(item.occurredAt) : NaN;
+      const relativeMs =
+        activeTime == null || !Number.isFinite(itemTime) ? Number.POSITIVE_INFINITY : Math.abs(itemTime - activeTime);
+
+      return {
+        ...item,
+        relativeMs,
+      };
+    })
+    .filter((item) => Number.isFinite(item.relativeMs))
+    .sort((left, right) => left.relativeMs - right.relativeMs)
+    .slice(0, 4);
 };
 
 const renderOverview = () => {
@@ -707,6 +789,80 @@ const renderStatus = () => {
   `;
 };
 
+const renderAlertCorrelation = () => {
+  const replayPoint = activeReplayPoint();
+  const alertWindows = correlatedAlertWindows();
+  const nearbyEvents = correlatedTimelineEvents();
+
+  if (!replayPoint) {
+    alertCorrelationPanel.innerHTML =
+      '<div class="empty-state">Load a mission replay before alert windows and event correlation can be reviewed.</div>';
+    return;
+  }
+
+  const currentAlerts = alertWindows.filter((alert) => alert.activeAtReplay).slice(0, 3);
+  const recentWindows = (currentAlerts.length > 0 ? currentAlerts : alertWindows.slice(0, 3))
+    .map(
+      (alert) => `
+        <article class="alert-window ${toneClass(alert.severity)}">
+          <strong>${escapeHtml(alert.alertType.replaceAll("_", " "))} ${escapeHtml(alert.status)}</strong>
+          <div>${escapeHtml(alert.message)}</div>
+          <div class="alert-window-meta">
+            Triggered: ${escapeHtml(formatDateTime(alert.triggeredAt))}<br />
+            Resolved: ${escapeHtml(formatDateTime(alert.resolvedAt))}<br />
+            Severity: ${escapeHtml(alert.severity)}
+          </div>
+        </article>
+      `,
+    )
+    .join("");
+
+  alertCorrelationPanel.innerHTML = `
+    <div class="stack">
+      <section class="correlation-card">
+        <h4>Current Replay-Point Alert Context</h4>
+        <div class="kv">
+          <div class="k">Replay timestamp</div>
+          <div>${escapeHtml(formatDateTime(replayPoint.timestamp))}</div>
+          <div class="k">Active alerts</div>
+          <div>${escapeHtml(
+            currentAlerts.length === 0 ? "None at current replay position" : `${currentAlerts.length}`,
+          )}</div>
+          <div class="k">Window state</div>
+          <div>${escapeHtml(
+            currentAlerts[0]
+              ? `${currentAlerts[0].alertType} ${currentAlerts[0].status}`
+              : "No alert window intersects the current replay point",
+          )}</div>
+        </div>
+      </section>
+      <section class="correlation-card">
+        <h4>Alert Windows</h4>
+        <div class="alert-window-list">
+          ${
+            recentWindows ||
+            '<div class="empty-state">No alert windows are available for this mission.</div>'
+          }
+        </div>
+      </section>
+      <section class="correlation-card">
+        <h4>Nearby Operational Events</h4>
+        ${
+          nearbyEvents.length === 0
+            ? '<div class="empty-state">No nearby mission events were found around the current replay position.</div>'
+            : renderList(
+                nearbyEvents.map((item) => ({
+                  label: `${item.phase.replaceAll("_", " ")} · ${item.type}`,
+                  value: `${formatDateTime(item.occurredAt)} · ${item.summary}`,
+                })),
+                "nearby operational events",
+              )
+        }
+      </section>
+    </div>
+  `;
+};
+
 const renderTimeline = () => {
   const items = uiState.timeline?.items ?? [];
   const relevant = items.slice(-8).reverse();
@@ -747,6 +903,7 @@ const renderLiveOperations = () => {
   renderOverview();
   renderMap();
   renderStatus();
+  renderAlertCorrelation();
   renderTimeline();
 };
 
@@ -754,6 +911,7 @@ const clearPanels = (message) => {
   overviewPanel.innerHTML = "";
   mapPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
   statusPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
+  alertCorrelationPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
   timelinePanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
   renderReplayControls();
 };


### PR DESCRIPTION
## Summary

Implements GitHub issue #139 by adding mission-linked alert timeline correlation in the live operations view so replay controls and map-native cues can be reviewed against explicit alert periods and operational events.

## What changed

- Extended the operator live operations view with explicit alert timeline correlation.
- Kept the implementation read-only and client-side.
- Added alert markers on the replay scrubber using existing mission alert timing data.
- Added current replay-point alert context so the live ops view shows which alerts intersect the selected replay position.
- Added alert window display using existing alert timing fields:
  - `triggeredAt`
  - `resolvedAt`
  - `status`
  - `severity`
- Added nearby mission-event correlation so the current replay position can be reviewed against the closest operational timeline items.
- Reused the existing mission-linked backend data already consumed by the live ops screen:
  - `GET /missions/:missionId/replay`
  - `GET /missions/:missionId/telemetry/latest`
  - `GET /missions/:missionId/alerts`
  - `GET /missions/:missionId/planning-workspace`
  - `GET /missions/:missionId/dispatch-workspace`
  - `GET /missions/:missionId/operations-timeline`
- Kept the existing operator live ops routes unchanged:
  - `GET /operator/live-operations-map`
  - `GET /operator/missions/:missionId/live-operations`
- Updated the save point to the next live-ops replay refinement step.

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 320 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

Closes #139.
