### PR TITLE
Add live operations replay speed controls

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add operator live operations replay speed controls and segment stepping so alert-correlated mission review can move faster than one fixed playback pace.",
+ "nextBuildStep": "Add operator live operations event jump controls so replay review can move directly to launch, completion, and alert-linked mission milestones.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -1932,6 +1932,9 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("live-ops-replay-slider");
     expect(response.text).toContain("live-ops-replay-markers");
     expect(response.text).toContain("live-ops-replay-progress");
+    expect(response.text).toContain("live-ops-replay-step-back-btn");
+    expect(response.text).toContain("live-ops-replay-step-forward-btn");
+    expect(response.text).toContain("live-ops-replay-speed");
     expect(response.text).toContain("map-alert-stack");
     expect(response.text).toContain("map-terrain");
     expect(response.text).toContain("map-compass");
@@ -1984,6 +1987,11 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("replayMarkers");
     expect(response.text).toContain("correlatedAlertWindows");
     expect(response.text).toContain("renderAlertCorrelation");
+    expect(response.text).toContain("replaySpeedSelect");
+    expect(response.text).toContain("replayStepBackButton");
+    expect(response.text).toContain("replayStepForwardButton");
+    expect(response.text).toContain("startReplayPlayback");
+    expect(response.text).toContain("replayPlaybackIntervalMs");
     expect(response.text).toContain("setInterval");
     expect(response.text).toContain("map-terrain");
   });

--- a/static/operator-live-operations-map.html
+++ b/static/operator-live-operations-map.html
@@ -261,7 +261,7 @@
     }
     .replay-controls {
       display: grid;
-      grid-template-columns: auto auto minmax(0, 1fr) auto auto;
+      grid-template-columns: auto auto auto auto minmax(0, 1fr) auto auto auto;
       gap: 10px;
       align-items: center;
       margin-bottom: 14px;
@@ -281,6 +281,16 @@
       font: inherit;
       font-weight: 700;
       cursor: pointer;
+    }
+    .control-select {
+      min-height: 40px;
+      padding: 0 12px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: rgba(255,255,255,0.04);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
     }
     .control-button:disabled {
       cursor: default;
@@ -564,12 +574,20 @@
             <div class="replay-controls">
               <button id="live-ops-replay-play-btn" class="control-button" type="button">Play</button>
               <button id="live-ops-replay-pause-btn" class="control-button" type="button" disabled>Pause</button>
+              <button id="live-ops-replay-step-back-btn" class="control-button" type="button">Back</button>
+              <button id="live-ops-replay-step-forward-btn" class="control-button" type="button">Forward</button>
               <div class="replay-slider-stack">
                 <input id="live-ops-replay-slider" class="replay-slider" type="range" min="0" max="0" step="1" value="0" />
                 <div id="live-ops-replay-markers" class="replay-markers"></div>
               </div>
               <div id="live-ops-replay-time" class="replay-readout">Replay time: not loaded</div>
               <div id="live-ops-replay-progress" class="replay-progress">0 / 0</div>
+              <select id="live-ops-replay-speed" class="control-select" aria-label="Replay speed">
+                <option value="0.5">0.5x</option>
+                <option value="1" selected>1x</option>
+                <option value="2">2x</option>
+                <option value="4">4x</option>
+              </select>
             </div>
             <div id="live-ops-map" class="map-shell"></div>
           </div>

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -11,10 +11,13 @@ const timelinePanel = document.getElementById("live-ops-timeline");
 const alertCorrelationPanel = document.getElementById("live-ops-alert-correlation");
 const replayPlayButton = document.getElementById("live-ops-replay-play-btn");
 const replayPauseButton = document.getElementById("live-ops-replay-pause-btn");
+const replayStepBackButton = document.getElementById("live-ops-replay-step-back-btn");
+const replayStepForwardButton = document.getElementById("live-ops-replay-step-forward-btn");
 const replaySlider = document.getElementById("live-ops-replay-slider");
 const replayTimeReadout = document.getElementById("live-ops-replay-time");
 const replayProgress = document.getElementById("live-ops-replay-progress");
 const replayMarkers = document.getElementById("live-ops-replay-markers");
+const replaySpeedSelect = document.getElementById("live-ops-replay-speed");
 
 const uiState = {
   missionId: "",
@@ -28,6 +31,7 @@ const uiState = {
     index: 0,
     playing: false,
     timerId: null,
+    speed: 1,
   },
 };
 
@@ -125,6 +129,9 @@ const setLoadedMission = (missionId) => {
   loadedMissionPill.textContent = missionId || "None";
 };
 
+const replayPlaybackIntervalMs = () =>
+  Math.max(150, Math.round(900 / (uiState.replayPlayback.speed || 1)));
+
 const renderReplayControls = () => {
   const points = replayTrack();
   const pointCount = points.length;
@@ -141,13 +148,17 @@ const renderReplayControls = () => {
   replaySlider.disabled = pointCount <= 1;
   replayPlayButton.disabled = pointCount <= 1 || uiState.replayPlayback.playing;
   replayPauseButton.disabled = !uiState.replayPlayback.playing;
+  replayStepBackButton.disabled = pointCount <= 1 || uiState.replayPlayback.index <= 0;
+  replayStepForwardButton.disabled =
+    pointCount <= 1 || uiState.replayPlayback.index >= pointCount - 1;
+  replaySpeedSelect.value = String(uiState.replayPlayback.speed);
   replayTimeReadout.textContent = activePoint?.timestamp
     ? `Replay time: ${formatDateTime(activePoint.timestamp)}`
     : "Replay time: not loaded";
   replayProgress.textContent =
     pointCount === 0
       ? "0 / 0"
-      : `${uiState.replayPlayback.index + 1} / ${pointCount}`;
+      : `${uiState.replayPlayback.index + 1} / ${pointCount} · ${uiState.replayPlayback.speed}x`;
   replayMarkers.innerHTML =
     pointCount === 0 || replayStart == null || replayEnd == null
       ? ""
@@ -193,6 +204,33 @@ const stopReplayPlayback = () => {
     uiState.replayPlayback.timerId = null;
   }
   uiState.replayPlayback.playing = false;
+};
+
+const startReplayPlayback = () => {
+  const points = replayTrack();
+  if (points.length <= 1) {
+    renderReplayControls();
+    return;
+  }
+
+  if (uiState.replayPlayback.index >= points.length - 1) {
+    setReplayIndex(0);
+  }
+
+  stopReplayPlayback();
+  uiState.replayPlayback.playing = true;
+  renderReplayControls();
+  uiState.replayPlayback.timerId = window.setInterval(() => {
+    const currentPoints = replayTrack();
+    if (uiState.replayPlayback.index >= currentPoints.length - 1) {
+      stopReplayPlayback();
+      renderLiveOperations();
+      return;
+    }
+
+    setReplayIndex(uiState.replayPlayback.index + 1);
+    renderLiveOperations();
+  }, replayPlaybackIntervalMs());
 };
 
 const setReplayIndex = (nextIndex) => {
@@ -997,34 +1035,35 @@ replaySlider.addEventListener("input", () => {
 });
 
 replayPlayButton.addEventListener("click", () => {
-  const points = replayTrack();
-  if (points.length <= 1) {
-    renderReplayControls();
-    return;
-  }
-
-  if (uiState.replayPlayback.index >= points.length - 1) {
-    setReplayIndex(0);
-  }
-
-  stopReplayPlayback();
-  uiState.replayPlayback.playing = true;
-  renderReplayControls();
-  uiState.replayPlayback.timerId = window.setInterval(() => {
-    const currentPoints = replayTrack();
-    if (uiState.replayPlayback.index >= currentPoints.length - 1) {
-      stopReplayPlayback();
-      renderLiveOperations();
-      return;
-    }
-
-    setReplayIndex(uiState.replayPlayback.index + 1);
-    renderLiveOperations();
-  }, 900);
+  startReplayPlayback();
 });
 
 replayPauseButton.addEventListener("click", () => {
   stopReplayPlayback();
+  renderReplayControls();
+});
+
+replayStepBackButton.addEventListener("click", () => {
+  stopReplayPlayback();
+  setReplayIndex(uiState.replayPlayback.index - 1);
+  renderLiveOperations();
+});
+
+replayStepForwardButton.addEventListener("click", () => {
+  stopReplayPlayback();
+  setReplayIndex(uiState.replayPlayback.index + 1);
+  renderLiveOperations();
+});
+
+replaySpeedSelect.addEventListener("change", () => {
+  const nextSpeed = Number(replaySpeedSelect.value);
+  uiState.replayPlayback.speed = Number.isFinite(nextSpeed) && nextSpeed > 0 ? nextSpeed : 1;
+
+  if (uiState.replayPlayback.playing) {
+    startReplayPlayback();
+    return;
+  }
+
   renderReplayControls();
 });
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #141 by adding operator live operations replay speed controls and segment stepping.

## What changed

- Extended the operator live operations view replay controls with:
  - selectable playback speed
  - step backward
  - step forward
- Kept the implementation read-only and client-side.
- Added replay speed options:
  - `0.5x`
  - `1x`
  - `2x`
  - `4x`
- Updated client-side playback cadence so replay speed affects only local replay timing.
- Added deterministic stepping controls so the replay cursor can move through replay points without manual slider dragging.
- Preserved the existing replay controls and correlation behavior:
  - play
  - pause
  - timeline scrubber
  - current replay timestamp
  - replay progress indicator
  - alert timeline correlation
  - map-native alert and risk cues
- Kept the implementation on the existing mission-linked backend data path:
  - `GET /missions/:missionId/replay`
  - `GET /missions/:missionId/telemetry/latest`
  - `GET /missions/:missionId/alerts`
  - `GET /missions/:missionId/planning-workspace`
  - `GET /missions/:missionId/dispatch-workspace`
  - `GET /missions/:missionId/operations-timeline`
- Kept the existing operator live ops routes unchanged:
  - `GET /operator/live-operations-map`
  - `GET /operator/missions/:missionId/live-operations`
- Updated the save point to the next replay usability step.

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 320 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

Closes #141.
