### PR TITLE
Add live operations event jump controls

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add operator live operations event jump controls so replay review can move directly to launch, completion, and alert-linked mission milestones.",
+ "nextBuildStep": "Add grouped live operations milestone navigation so replay review can jump by lifecycle phase and alert category rather than a flat milestone list.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -1935,6 +1935,8 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("live-ops-replay-step-back-btn");
     expect(response.text).toContain("live-ops-replay-step-forward-btn");
     expect(response.text).toContain("live-ops-replay-speed");
+    expect(response.text).toContain("Replay Milestones");
+    expect(response.text).toContain("live-ops-jump-controls");
     expect(response.text).toContain("map-alert-stack");
     expect(response.text).toContain("map-terrain");
     expect(response.text).toContain("map-compass");
@@ -1992,6 +1994,9 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("replayStepForwardButton");
     expect(response.text).toContain("startReplayPlayback");
     expect(response.text).toContain("replayPlaybackIntervalMs");
+    expect(response.text).toContain("findNearestReplayIndexForTime");
+    expect(response.text).toContain("renderJumpControls");
+    expect(response.text).toContain("data-jump-timestamp");
     expect(response.text).toContain("setInterval");
     expect(response.text).toContain("map-terrain");
   });

--- a/static/operator-live-operations-map.html
+++ b/static/operator-live-operations-map.html
@@ -468,6 +468,11 @@
       letter-spacing: 0.08em;
       color: var(--muted);
     }
+    .jump-control-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
     .alert-window-list {
       display: grid;
       gap: 10px;
@@ -563,7 +568,7 @@
       </div>
     </section>
 
-    <section class="band">
+      <section class="band">
       <div class="band-inner live-grid">
         <div class="panel">
           <div class="panel-header">
@@ -593,6 +598,13 @@
           </div>
         </div>
         <div class="stack">
+          <div class="panel">
+            <div class="panel-header">
+              <h3>Replay Milestones</h3>
+              <p>Jump directly to launch, completion, abort, and alert-linked moments.</p>
+            </div>
+            <div id="live-ops-jump-controls" class="panel-body"></div>
+          </div>
           <div class="panel">
             <div class="panel-header">
               <h3>Telemetry and Risk Status</h3>

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -9,6 +9,7 @@ const mapPanel = document.getElementById("live-ops-map");
 const statusPanel = document.getElementById("live-ops-status");
 const timelinePanel = document.getElementById("live-ops-timeline");
 const alertCorrelationPanel = document.getElementById("live-ops-alert-correlation");
+const jumpControlsPanel = document.getElementById("live-ops-jump-controls");
 const replayPlayButton = document.getElementById("live-ops-replay-play-btn");
 const replayPauseButton = document.getElementById("live-ops-replay-pause-btn");
 const replayStepBackButton = document.getElementById("live-ops-replay-step-back-btn");
@@ -239,6 +240,74 @@ const setReplayIndex = (nextIndex) => {
     points.length === 0 ? 0 : Math.max(0, Math.min(nextIndex, points.length - 1));
   uiState.replayPlayback.index = boundedIndex;
   replaySlider.value = String(boundedIndex);
+};
+
+const findNearestReplayIndexForTime = (timestamp) => {
+  const targetTime = Date.parse(timestamp ?? "");
+  const points = replayTrack();
+
+  if (!Number.isFinite(targetTime) || points.length === 0) {
+    return null;
+  }
+
+  let bestIndex = 0;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  points.forEach((point, index) => {
+    const pointTime = Date.parse(point.timestamp ?? "");
+    if (!Number.isFinite(pointTime)) {
+      return;
+    }
+
+    const distance = Math.abs(pointTime - targetTime);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = index;
+    }
+  });
+
+  return bestIndex;
+};
+
+const replayMilestones = () => {
+  const timelineItems = uiState.timeline?.items ?? [];
+  const eventMilestones = timelineItems
+    .filter((item) => {
+      const eventType = item?.details?.eventType;
+      return (
+        eventType === "mission.launched" ||
+        eventType === "mission.completed" ||
+        eventType === "mission.aborted"
+      );
+    })
+    .map((item) => ({
+      key: `${item.type}-${item.occurredAt}`,
+      label:
+        item?.details?.eventType === "mission.launched"
+          ? "Launch"
+          : item?.details?.eventType === "mission.completed"
+            ? "Completion"
+            : "Abort",
+      timestamp: item.occurredAt,
+      tone:
+        item?.details?.eventType === "mission.aborted"
+          ? "fail"
+          : "info",
+    }));
+
+  const alertMilestones = (uiState.alerts ?? [])
+    .slice(0, 4)
+    .map((alert) => ({
+      key: `alert-${alert.id}`,
+      label: `${alert.alertType.replaceAll("_", " ")}`,
+      timestamp: alert.triggeredAt,
+      tone: alert.severity,
+    }));
+
+  return [...eventMilestones, ...alertMilestones].filter(
+    (milestone, index, list) =>
+      index === list.findIndex((candidate) => candidate.key === milestone.key),
+  );
 };
 
 const updateUrl = (missionId) => {
@@ -827,6 +896,34 @@ const renderStatus = () => {
   `;
 };
 
+const renderJumpControls = () => {
+  const milestones = replayMilestones();
+
+  if (milestones.length === 0) {
+    jumpControlsPanel.innerHTML =
+      '<div class="empty-state">No launch, completion, abort, or alert-linked milestones are available for replay jumping yet.</div>';
+    return;
+  }
+
+  jumpControlsPanel.innerHTML = `
+    <div class="jump-control-grid">
+      ${milestones
+        .map(
+          (milestone) => `
+            <button
+              type="button"
+              class="control-button ${toneClass(milestone.tone)}"
+              data-jump-timestamp="${escapeHtml(milestone.timestamp)}"
+            >
+              ${escapeHtml(milestone.label)}
+            </button>
+          `,
+        )
+        .join("")}
+    </div>
+  `;
+};
+
 const renderAlertCorrelation = () => {
   const replayPoint = activeReplayPoint();
   const alertWindows = correlatedAlertWindows();
@@ -940,6 +1037,7 @@ const renderLiveOperations = () => {
   renderReplayControls();
   renderOverview();
   renderMap();
+  renderJumpControls();
   renderStatus();
   renderAlertCorrelation();
   renderTimeline();
@@ -948,6 +1046,7 @@ const renderLiveOperations = () => {
 const clearPanels = (message) => {
   overviewPanel.innerHTML = "";
   mapPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
+  jumpControlsPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
   statusPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
   alertCorrelationPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
   timelinePanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
@@ -1065,6 +1164,27 @@ replaySpeedSelect.addEventListener("change", () => {
   }
 
   renderReplayControls();
+});
+
+jumpControlsPanel.addEventListener("click", (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+
+  const timestamp = target.dataset.jumpTimestamp;
+  if (!timestamp) {
+    return;
+  }
+
+  const nextIndex = findNearestReplayIndexForTime(timestamp);
+  if (nextIndex == null) {
+    return;
+  }
+
+  stopReplayPlayback();
+  setReplayIndex(nextIndex);
+  renderLiveOperations();
 });
 
 openWorkspaceButton.addEventListener("click", () => {


### PR DESCRIPTION
## Summary

Implements GitHub issue #143 by adding operator live operations event jump controls so replay review can move directly to launch, completion, abort, and alert-linked mission milestones.

## What changed

- Extended the operator live operations view with replay milestone jump controls.
- Kept the implementation read-only and client-side.
- Added milestone jump buttons for:
  - launch event
  - completion event
  - abort event
  - alert-triggered moments
- Implemented jump-to-nearest-replay-point behavior using the existing replay timeline.
- Preserved the existing replay controls and navigation features:
  - play
  - pause
  - speed control
  - step backward
  - step forward
  - replay slider
  - alert timeline correlation
  - map-native alert and risk cues
- Reused the existing mission-linked backend data path:
  - `GET /missions/:missionId/replay`
  - `GET /missions/:missionId/telemetry/latest`
  - `GET /missions/:missionId/alerts`
  - `GET /missions/:missionId/planning-workspace`
  - `GET /missions/:missionId/dispatch-workspace`
  - `GET /missions/:missionId/operations-timeline`
- Kept the existing operator live ops routes unchanged:
  - `GET /operator/live-operations-map`
  - `GET /operator/missions/:missionId/live-operations`
- Updated the save point to the next replay navigation refinement step.

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src/tests/mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 21 files, 320 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

Closes #143.
