### PR TITLE
Add weather external overlay support

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add crewed traffic external overlay ingestion and live operations display using the mission-linked external overlay model.",
+ "nextBuildStep": "Add migration-backed crewed traffic external overlay ingestion and live operations display using the mission-linked external overlay model.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add weather external overlay ingestion and live operations display using the mission-linked external overlay model.",
+ "nextBuildStep": "Add crewed traffic external overlay ingestion and live operations display using the mission-linked external overlay model.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -62,6 +62,10 @@ import { SafetyEventRepository } from "./safety-events/safety-event.repository";
 import { SafetyEventService } from "./safety-events/safety-event.service";
 import { SafetyEventController } from "./safety-events/safety-event.controller";
 import { createSafetyEventRouter } from "./safety-events/safety-event.routes";
+import { ExternalOverlayRepository } from "./external-overlays/external-overlay.repository";
+import { ExternalOverlayService } from "./external-overlays/external-overlay.service";
+import { ExternalOverlayController } from "./external-overlays/external-overlay.controller";
+import { createExternalOverlayRouter } from "./external-overlays/external-overlay.routes";
 
 dotenv.config({
   path: path.resolve(process.cwd(), ".env"),
@@ -194,6 +198,14 @@ const airSafetyMeetingController = new AirSafetyMeetingController(
 const safetyEventRepository = new SafetyEventRepository();
 const safetyEventService = new SafetyEventService(pool, safetyEventRepository);
 const safetyEventController = new SafetyEventController(safetyEventService);
+const externalOverlayRepository = new ExternalOverlayRepository();
+const externalOverlayService = new ExternalOverlayService(
+  pool,
+  externalOverlayRepository,
+);
+const externalOverlayController = new ExternalOverlayController(
+  externalOverlayService,
+);
 
 app.use("/mission-plans", createMissionPlanningRouter(missionPlanningController));
 app.use("/sms", createSmsFrameworkRouter(smsFrameworkController));
@@ -203,6 +215,7 @@ app.use(
 );
 app.use("/safety-events", createSafetyEventRouter(safetyEventController));
 app.use("/missions", createMissionRouter(missionController));
+app.use("/missions", createExternalOverlayRouter(externalOverlayController));
 app.use("/missions", createMissionRiskRouter(missionRiskController));
 app.use("/missions", createAirspaceComplianceRouter(airspaceComplianceController));
 app.use("/missions", createAuditEvidenceRouter(auditEvidenceController));

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -1,0 +1,56 @@
+import type { NextFunction, Request, Response } from "express";
+import { ExternalOverlayService } from "./external-overlay.service";
+import type { ExternalOverlayKind } from "./external-overlay.types";
+
+type MissionIdParams = {
+  missionId: string;
+};
+
+export class ExternalOverlayController {
+  constructor(
+    private readonly externalOverlayService: ExternalOverlayService,
+  ) {}
+
+  createExternalOverlay = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      if (req.body?.kind !== "weather") {
+        throw new Error("Only weather overlays are supported in the first implementation slice");
+      }
+
+      const overlay = await this.externalOverlayService.createWeatherOverlay(
+        req.params.missionId,
+        req.body,
+      );
+
+      res.status(201).json({ overlay });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listExternalOverlays = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const kind =
+        typeof req.query.kind === "string"
+          ? (req.query.kind as ExternalOverlayKind)
+          : undefined;
+
+      const result = await this.externalOverlayService.listExternalOverlays(
+        req.params.missionId,
+        { kind },
+      );
+
+      res.status(200).json(result);
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/external-overlays/external-overlay.errors.ts
+++ b/src/external-overlays/external-overlay.errors.ts
@@ -1,0 +1,8 @@
+export class MissionExternalOverlayMissionNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly type = "mission_not_found";
+
+  constructor(missionId: string) {
+    super(`Mission ${missionId} not found`);
+  }
+}

--- a/src/external-overlays/external-overlay.repository.ts
+++ b/src/external-overlays/external-overlay.repository.ts
@@ -1,0 +1,152 @@
+import { randomUUID } from "crypto";
+import type { PoolClient, QueryResultRow } from "pg";
+import type {
+  CreateWeatherExternalOverlayInput,
+  ExternalOverlay,
+  ExternalOverlayKind,
+  ListExternalOverlaysFilters,
+} from "./external-overlay.types";
+
+interface ExternalOverlayRow extends QueryResultRow {
+  id: string;
+  mission_id: string;
+  overlay_kind: ExternalOverlayKind;
+  source_provider: string;
+  source_type: string;
+  source_record_id: string | null;
+  observed_at: Date;
+  valid_from: Date | null;
+  valid_to: Date | null;
+  geometry_type: "point";
+  latitude: number | null;
+  longitude: number | null;
+  altitude_msl_ft: number | null;
+  heading_degrees: number | null;
+  speed_knots: number | null;
+  severity: ExternalOverlay["severity"];
+  confidence: number | null;
+  freshness_seconds: number | null;
+  metadata: Record<string, unknown>;
+  created_at: Date;
+  updated_at: Date;
+}
+
+const toExternalOverlay = (row: ExternalOverlayRow): ExternalOverlay => ({
+  id: row.id,
+  missionId: row.mission_id,
+  kind: row.overlay_kind,
+  source: {
+    provider: row.source_provider,
+    sourceType: row.source_type,
+    sourceRecordId: row.source_record_id,
+  },
+  observedAt: row.observed_at.toISOString(),
+  validFrom: row.valid_from ? row.valid_from.toISOString() : null,
+  validTo: row.valid_to ? row.valid_to.toISOString() : null,
+  geometry: {
+    type: "point",
+    lat: Number(row.latitude),
+    lng: Number(row.longitude),
+    altitudeMslFt:
+      row.altitude_msl_ft == null ? null : Number(row.altitude_msl_ft),
+  },
+  headingDegrees:
+    row.heading_degrees == null ? null : Number(row.heading_degrees),
+  speedKnots: row.speed_knots == null ? null : Number(row.speed_knots),
+  severity: row.severity,
+  confidence: row.confidence == null ? null : Number(row.confidence),
+  freshnessSeconds:
+    row.freshness_seconds == null ? null : Number(row.freshness_seconds),
+  metadata: row.metadata ?? {},
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
+});
+
+export class ExternalOverlayRepository {
+  async missionExists(tx: PoolClient, missionId: string): Promise<boolean> {
+    const result = await tx.query(
+      `
+      select 1
+      from missions
+      where id = $1
+      `,
+      [missionId],
+    );
+
+    return result.rowCount === 1;
+  }
+
+  async insertWeatherOverlay(
+    tx: PoolClient,
+    missionId: string,
+    input: CreateWeatherExternalOverlayInput,
+  ): Promise<ExternalOverlay> {
+    const result = await tx.query<ExternalOverlayRow>(
+      `
+      insert into mission_external_overlays (
+        id,
+        mission_id,
+        overlay_kind,
+        source_provider,
+        source_type,
+        source_record_id,
+        observed_at,
+        valid_from,
+        valid_to,
+        geometry_type,
+        latitude,
+        longitude,
+        altitude_msl_ft,
+        heading_degrees,
+        speed_knots,
+        severity,
+        confidence,
+        freshness_seconds,
+        metadata
+      )
+      values (
+        $1, $2, 'weather', $3, $4, $5, $6, $7, $8, 'point', $9, $10, $11, null, null, $12, $13, $14, $15::jsonb
+      )
+      returning *
+      `,
+      [
+        randomUUID(),
+        missionId,
+        input.source.provider,
+        input.source.sourceType,
+        input.source.sourceRecordId,
+        input.observedAt,
+        input.validFrom,
+        input.validTo,
+        input.geometry.lat,
+        input.geometry.lng,
+        input.geometry.altitudeMslFt,
+        input.severity,
+        input.confidence,
+        input.freshnessSeconds,
+        JSON.stringify(input.metadata),
+      ],
+    );
+
+    return toExternalOverlay(result.rows[0]);
+  }
+
+  async listForMission(
+    tx: PoolClient,
+    missionId: string,
+    filters: ListExternalOverlaysFilters = {},
+  ): Promise<ExternalOverlay[]> {
+    const result = await tx.query<ExternalOverlayRow>(
+      `
+      select *
+      from mission_external_overlays
+      where mission_id = $1
+        and ($2::text is null or overlay_kind = $2)
+      order by observed_at desc, id desc
+      `,
+      [missionId, filters.kind ?? null],
+    );
+
+    return result.rows.map(toExternalOverlay);
+  }
+}

--- a/src/external-overlays/external-overlay.routes.ts
+++ b/src/external-overlays/external-overlay.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { ExternalOverlayController } from "./external-overlay.controller";
+
+export function createExternalOverlayRouter(
+  controller: ExternalOverlayController,
+): Router {
+  const router = Router();
+
+  router.post("/:missionId/external-overlays", controller.createExternalOverlay);
+  router.get("/:missionId/external-overlays", controller.listExternalOverlays);
+
+  return router;
+}

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -1,0 +1,74 @@
+import type { Pool } from "pg";
+import { ExternalOverlayRepository } from "./external-overlay.repository";
+import { MissionExternalOverlayMissionNotFoundError } from "./external-overlay.errors";
+import type {
+  CreateWeatherExternalOverlayInput,
+  ExternalOverlay,
+  ExternalOverlayKind,
+} from "./external-overlay.types";
+import { validateCreateWeatherExternalOverlayInput } from "./external-overlay.validators";
+
+export class ExternalOverlayService {
+  constructor(
+    private readonly pool: Pool,
+    private readonly externalOverlayRepository: ExternalOverlayRepository,
+  ) {}
+
+  async createWeatherOverlay(
+    missionId: string,
+    input: unknown,
+  ): Promise<ExternalOverlay> {
+    const validated = validateCreateWeatherExternalOverlayInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.externalOverlayRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new MissionExternalOverlayMissionNotFoundError(missionId);
+      }
+
+      return await this.externalOverlayRepository.insertWeatherOverlay(
+        client,
+        missionId,
+        validated,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  async listExternalOverlays(
+    missionId: string,
+    filters: { kind?: ExternalOverlayKind } = {},
+  ): Promise<{ missionId: string; overlays: ExternalOverlay[] }> {
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.externalOverlayRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new MissionExternalOverlayMissionNotFoundError(missionId);
+      }
+
+      const overlays = await this.externalOverlayRepository.listForMission(
+        client,
+        missionId,
+        filters,
+      );
+
+      return {
+        missionId,
+        overlays,
+      };
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/src/external-overlays/external-overlay.types.ts
+++ b/src/external-overlays/external-overlay.types.ts
@@ -1,0 +1,79 @@
+export type ExternalOverlayKind =
+  | "weather"
+  | "crewed_traffic"
+  | "drone_traffic";
+
+export type ExternalOverlaySeverity = "info" | "caution" | "critical";
+
+export interface ExternalOverlaySource {
+  provider: string;
+  sourceType: string;
+  sourceRecordId: string | null;
+}
+
+export interface ExternalOverlayPointGeometry {
+  type: "point";
+  lat: number;
+  lng: number;
+  altitudeMslFt: number | null;
+}
+
+export type ExternalOverlayGeometry = ExternalOverlayPointGeometry;
+
+export interface WeatherOverlayMetadata {
+  windSpeedKnots: number;
+  windDirectionDegrees: number;
+  temperatureC: number;
+  precipitation:
+    | "none"
+    | "drizzle"
+    | "rain"
+    | "snow"
+    | "hail"
+    | "mixed";
+}
+
+export interface ExternalOverlay {
+  id: string;
+  missionId: string;
+  kind: ExternalOverlayKind;
+  source: ExternalOverlaySource;
+  observedAt: string;
+  validFrom: string | null;
+  validTo: string | null;
+  geometry: ExternalOverlayGeometry;
+  headingDegrees: number | null;
+  speedKnots: number | null;
+  severity: ExternalOverlaySeverity | null;
+  confidence: number | null;
+  freshnessSeconds: number | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateWeatherExternalOverlayInput {
+  kind: "weather";
+  source: {
+    provider: string;
+    sourceType: string;
+    sourceRecordId?: string | null;
+  };
+  observedAt: string;
+  validFrom?: string | null;
+  validTo?: string | null;
+  geometry: {
+    type: "point";
+    lat: number;
+    lng: number;
+    altitudeMslFt?: number | null;
+  };
+  severity?: ExternalOverlaySeverity | null;
+  confidence?: number | null;
+  freshnessSeconds?: number | null;
+  metadata: WeatherOverlayMetadata;
+}
+
+export interface ListExternalOverlaysFilters {
+  kind?: ExternalOverlayKind;
+}

--- a/src/external-overlays/external-overlay.validators.ts
+++ b/src/external-overlays/external-overlay.validators.ts
@@ -1,0 +1,166 @@
+import type {
+  CreateWeatherExternalOverlayInput,
+  ExternalOverlaySeverity,
+} from "./external-overlay.types";
+
+const SEVERITIES: ExternalOverlaySeverity[] = ["info", "caution", "critical"];
+const PRECIPITATION = ["none", "drizzle", "rain", "snow", "hail", "mixed"];
+
+const requiredString = (value: unknown, fieldName: string): string => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${fieldName} is required`);
+  }
+
+  return value.trim();
+};
+
+const optionalString = (value: unknown): string | null => {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    throw new Error("Optional string fields must be strings when provided");
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const requiredNumber = (value: unknown, fieldName: string): number => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${fieldName} must be a valid number`);
+  }
+
+  return value;
+};
+
+const optionalNumber = (value: unknown, fieldName: string): number | null => {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${fieldName} must be a valid number when provided`);
+  }
+
+  return value;
+};
+
+const requiredTimestamp = (value: unknown, fieldName: string): string => {
+  const normalized = requiredString(value, fieldName);
+
+  if (Number.isNaN(Date.parse(normalized))) {
+    throw new Error(`${fieldName} must be a valid ISO timestamp`);
+  }
+
+  return normalized;
+};
+
+const optionalTimestamp = (value: unknown, fieldName: string): string | null => {
+  if (value == null) {
+    return null;
+  }
+
+  const normalized = requiredString(value, fieldName);
+
+  if (Number.isNaN(Date.parse(normalized))) {
+    throw new Error(`${fieldName} must be a valid ISO timestamp`);
+  }
+
+  return normalized;
+};
+
+const optionalSeverity = (value: unknown): ExternalOverlaySeverity | null => {
+  if (value == null) {
+    return null;
+  }
+
+  const normalized = requiredString(value, "severity").toLowerCase();
+  if (!SEVERITIES.includes(normalized as ExternalOverlaySeverity)) {
+    throw new Error("severity must be one of: info, caution, critical");
+  }
+
+  return normalized as ExternalOverlaySeverity;
+};
+
+export const validateCreateWeatherExternalOverlayInput = (
+  input: unknown,
+): CreateWeatherExternalOverlayInput => {
+  if (!input || typeof input !== "object") {
+    throw new Error("request body is required");
+  }
+
+  const candidate = input as Record<string, any>;
+  if (candidate.kind !== "weather") {
+    throw new Error("kind must be 'weather'");
+  }
+
+  if (!candidate.source || typeof candidate.source !== "object") {
+    throw new Error("source is required");
+  }
+
+  if (!candidate.geometry || typeof candidate.geometry !== "object") {
+    throw new Error("geometry is required");
+  }
+
+  if (!candidate.metadata || typeof candidate.metadata !== "object") {
+    throw new Error("metadata is required");
+  }
+
+  const precipitation = requiredString(
+    candidate.metadata.precipitation,
+    "metadata.precipitation",
+  ).toLowerCase();
+  if (!PRECIPITATION.includes(precipitation)) {
+    throw new Error(
+      "metadata.precipitation must be one of: none, drizzle, rain, snow, hail, mixed",
+    );
+  }
+
+  if (candidate.geometry.type !== "point") {
+    throw new Error("geometry.type must be 'point'");
+  }
+
+  return {
+    kind: "weather",
+    source: {
+      provider: requiredString(candidate.source.provider, "source.provider"),
+      sourceType: requiredString(candidate.source.sourceType, "source.sourceType"),
+      sourceRecordId: optionalString(candidate.source.sourceRecordId),
+    },
+    observedAt: requiredTimestamp(candidate.observedAt, "observedAt"),
+    validFrom: optionalTimestamp(candidate.validFrom, "validFrom"),
+    validTo: optionalTimestamp(candidate.validTo, "validTo"),
+    geometry: {
+      type: "point",
+      lat: requiredNumber(candidate.geometry.lat, "geometry.lat"),
+      lng: requiredNumber(candidate.geometry.lng, "geometry.lng"),
+      altitudeMslFt: optionalNumber(
+        candidate.geometry.altitudeMslFt,
+        "geometry.altitudeMslFt",
+      ),
+    },
+    severity: optionalSeverity(candidate.severity),
+    confidence: optionalNumber(candidate.confidence, "confidence"),
+    freshnessSeconds:
+      candidate.freshnessSeconds == null
+        ? null
+        : requiredNumber(candidate.freshnessSeconds, "freshnessSeconds"),
+    metadata: {
+      windSpeedKnots: requiredNumber(
+        candidate.metadata.windSpeedKnots,
+        "metadata.windSpeedKnots",
+      ),
+      windDirectionDegrees: requiredNumber(
+        candidate.metadata.windDirectionDegrees,
+        "metadata.windDirectionDegrees",
+      ),
+      temperatureC: requiredNumber(
+        candidate.metadata.temperatureC,
+        "metadata.temperatureC",
+      ),
+      precipitation: precipitation as CreateWeatherExternalOverlayInput["metadata"]["precipitation"],
+    },
+  };
+};

--- a/src/migrations/029_create_mission_external_overlays.sql
+++ b/src/migrations/029_create_mission_external_overlays.sql
@@ -1,0 +1,35 @@
+create table if not exists mission_external_overlays (
+  id uuid primary key,
+  mission_id uuid not null references missions(id) on delete cascade,
+  overlay_kind text not null,
+  source_provider text not null,
+  source_type text not null,
+  source_record_id text null,
+  observed_at timestamptz not null,
+  valid_from timestamptz null,
+  valid_to timestamptz null,
+  geometry_type text not null,
+  latitude double precision null,
+  longitude double precision null,
+  altitude_msl_ft double precision null,
+  heading_degrees double precision null,
+  speed_knots double precision null,
+  severity text null,
+  confidence double precision null,
+  freshness_seconds integer null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint mission_external_overlays_kind_chk
+    check (overlay_kind in ('weather', 'crewed_traffic', 'drone_traffic')),
+  constraint mission_external_overlays_geometry_chk
+    check (geometry_type in ('point', 'polyline', 'polygon', 'circle')),
+  constraint mission_external_overlays_severity_chk
+    check (severity in ('info', 'caution', 'critical') or severity is null)
+);
+
+create index if not exists idx_mission_external_overlays_mission_observed_at
+  on mission_external_overlays (mission_id, observed_at desc);
+
+create index if not exists idx_mission_external_overlays_kind
+  on mission_external_overlays (overlay_kind);

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -1,0 +1,164 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import { randomUUID } from "crypto";
+import app, { pool } from "../app";
+import { runMigrations } from "../migrations/runMigrations";
+
+const clearTables = async () => {
+  await pool.query("delete from mission_external_overlays");
+  await pool.query("delete from mission_planning_approval_handoffs");
+  await pool.query("delete from mission_decision_evidence_links");
+  await pool.query("delete from audit_evidence_snapshots");
+  await pool.query("delete from airspace_compliance_inputs");
+  await pool.query("delete from mission_risk_inputs");
+  await pool.query("delete from mission_events");
+  await pool.query("delete from missions");
+};
+
+const createMission = async () => {
+  const response = await request(app).post("/mission-plans/drafts").send({});
+  expect(response.status).toBe(201);
+  return response.body.draft.missionId as string;
+};
+
+describe("mission external overlays integration", () => {
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  beforeEach(async () => {
+    await clearTables();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("creates and lists weather overlays through the mission-linked external overlay boundary", async () => {
+    const missionId = await createMission();
+
+    const createResponse = await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "weather",
+        source: {
+          provider: "met-office",
+          sourceType: "surface_observation",
+          sourceRecordId: "obs-1001",
+        },
+        observedAt: "2026-04-21T10:00:00.000Z",
+        validFrom: "2026-04-21T10:00:00.000Z",
+        validTo: "2026-04-21T10:30:00.000Z",
+        geometry: {
+          type: "point",
+          lat: 51.5074,
+          lng: -0.1278,
+          altitudeMslFt: 220,
+        },
+        severity: "caution",
+        confidence: 0.92,
+        freshnessSeconds: 300,
+        metadata: {
+          windSpeedKnots: 18,
+          windDirectionDegrees: 240,
+          temperatureC: 11,
+          precipitation: "rain",
+        },
+      });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.overlay).toMatchObject({
+      missionId,
+      kind: "weather",
+      source: {
+        provider: "met-office",
+        sourceType: "surface_observation",
+        sourceRecordId: "obs-1001",
+      },
+      geometry: {
+        type: "point",
+        lat: 51.5074,
+        lng: -0.1278,
+        altitudeMslFt: 220,
+      },
+      severity: "caution",
+      freshnessSeconds: 300,
+      metadata: {
+        windSpeedKnots: 18,
+        windDirectionDegrees: 240,
+        temperatureC: 11,
+        precipitation: "rain",
+      },
+    });
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays?kind=weather`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body).toMatchObject({
+      missionId,
+      overlays: [
+        expect.objectContaining({
+          kind: "weather",
+          severity: "caution",
+          metadata: expect.objectContaining({
+            windSpeedKnots: 18,
+            windDirectionDegrees: 240,
+            temperatureC: 11,
+            precipitation: "rain",
+          }),
+        }),
+      ],
+    });
+  });
+
+  it("preserves mission isolation for external overlays", async () => {
+    const firstMissionId = await createMission();
+    const secondMissionId = await createMission();
+
+    const createResponse = await request(app)
+      .post(`/missions/${secondMissionId}/external-overlays`)
+      .send({
+        kind: "weather",
+        source: {
+          provider: "met-office",
+          sourceType: "surface_observation",
+        },
+        observedAt: "2026-04-21T10:00:00.000Z",
+        geometry: {
+          type: "point",
+          lat: 51.5074,
+          lng: -0.1278,
+        },
+        metadata: {
+          windSpeedKnots: 15,
+          windDirectionDegrees: 180,
+          temperatureC: 12,
+          precipitation: "none",
+        },
+      });
+
+    expect(createResponse.status).toBe(201);
+
+    const listResponse = await request(app).get(
+      `/missions/${firstMissionId}/external-overlays?kind=weather`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.overlays).toEqual([]);
+  });
+
+  it("returns 404 for missing missions on external overlay reads", async () => {
+    const response = await request(app).get(
+      `/missions/${randomUUID()}/external-overlays?kind=weather`,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "mission_not_found",
+      },
+    });
+  });
+});

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -7,6 +7,7 @@ import { runMigrations } from "../migrations/runMigrations";
 const clearTables = async () => {
   await pool.query("delete from mission_planning_approval_handoffs");
   await pool.query("delete from mission_decision_evidence_links");
+  await pool.query("delete from mission_external_overlays");
   await pool.query("delete from audit_evidence_snapshots");
   await pool.query("delete from airspace_compliance_inputs");
   await pool.query("delete from mission_risk_inputs");
@@ -1975,6 +1976,7 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("/missions/${missionId}/replay");
     expect(response.text).toContain("/missions/${missionId}/telemetry/latest");
     expect(response.text).toContain("/missions/${missionId}/alerts");
+    expect(response.text).toContain("/missions/${missionId}/external-overlays?kind=weather");
     expect(response.text).toContain("/missions/${missionId}/planning-workspace");
     expect(response.text).toContain("/missions/${missionId}/dispatch-workspace");
     expect(response.text).toContain("/missions/${missionId}/operations-timeline");
@@ -1999,5 +2001,8 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("data-jump-timestamp");
     expect(response.text).toContain("setInterval");
     expect(response.text).toContain("map-terrain");
+    expect(response.text).toContain("weatherOverlays");
+    expect(response.text).toContain("activeWeatherOverlay");
+    expect(response.text).toContain("weatherSummary");
   });
 });

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -28,6 +28,7 @@ const uiState = {
   replay: null,
   latestTelemetry: null,
   alerts: [],
+  externalOverlays: [],
   replayPlayback: {
     index: 0,
     playing: false,
@@ -83,6 +84,9 @@ const escapeHtml = (value) =>
 
 const renderBadge = (value) =>
   `<span class="badge ${toneClass(value)}">${escapeHtml(value ?? "Unknown")}</span>`;
+
+const weatherOverlays = () =>
+  (uiState.externalOverlays ?? []).filter((overlay) => overlay.kind === "weather");
 
 const formatDateTime = (value) => {
   if (!value) {
@@ -180,6 +184,65 @@ const renderReplayControls = () => {
 
 const missionDisplayName = (mission) =>
   mission?.missionPlanId || mission?.id || "Unknown mission";
+
+const activeWeatherOverlay = () => {
+  const replayPoint = activeReplayPoint();
+  const replayTime = replayPoint?.timestamp ? Date.parse(replayPoint.timestamp) : null;
+  const overlays = weatherOverlays();
+
+  if (overlays.length === 0) {
+    return null;
+  }
+
+  const relevant = overlays
+    .map((overlay) => {
+      const observedAt = Date.parse(overlay.observedAt ?? "");
+      const validFrom = overlay.validFrom ? Date.parse(overlay.validFrom) : observedAt;
+      const validTo = overlay.validTo ? Date.parse(overlay.validTo) : null;
+      const activeAtReplay =
+        replayTime != null &&
+        Number.isFinite(validFrom) &&
+        replayTime >= validFrom &&
+        (validTo == null || replayTime <= validTo);
+      const relativeMs =
+        replayTime == null || !Number.isFinite(observedAt)
+          ? Number.POSITIVE_INFINITY
+          : Math.abs(replayTime - observedAt);
+
+      return {
+        ...overlay,
+        activeAtReplay,
+        relativeMs,
+      };
+    })
+    .sort((left, right) => {
+      if (left.activeAtReplay !== right.activeAtReplay) {
+        return left.activeAtReplay ? -1 : 1;
+      }
+
+      return left.relativeMs - right.relativeMs;
+    });
+
+  return relevant[0] ?? null;
+};
+
+const weatherSummary = () => {
+  const overlay = activeWeatherOverlay();
+  if (!overlay) {
+    return {
+      label: "Weather overlay missing",
+      tone: "warning",
+      detail: "No mission-linked weather overlay is available for the current replay position.",
+    };
+  }
+
+  const metadata = overlay.metadata ?? {};
+  return {
+    label: `Weather ${metadata.precipitation ?? "unknown"}`,
+    tone: overlay.severity ?? "info",
+    detail: `${metadata.windSpeedKnots ?? "?"} kt @ ${metadata.windDirectionDegrees ?? "?"}° · ${metadata.temperatureC ?? "?"}°C · observed ${formatDateTime(overlay.observedAt)}`,
+  };
+};
 
 const replayTrack = () =>
   (uiState.replay?.replay ?? []).filter(
@@ -482,6 +545,7 @@ const buildOverlayCards = () => {
     summarizeAirspaceState(planningWorkspace),
     summarizeReadinessState(planningWorkspace, dispatchWorkspace),
     summarizeDispatchState(dispatchWorkspace),
+    weatherSummary(),
     summarizeTelemetryAlerts(uiState.alerts),
   ];
 
@@ -563,6 +627,8 @@ const renderOverview = () => {
   const currentReplayPoint = activeReplayPoint();
   const timelineCount = uiState.timeline?.items?.length ?? 0;
   const openAlertCount = (uiState.alerts ?? []).filter((alert) => alert.status !== "resolved").length;
+  const activeWeather = activeWeatherOverlay();
+  const weatherMeta = activeWeather?.metadata ?? null;
 
   overviewPanel.innerHTML = `
     <article class="metric">
@@ -604,6 +670,19 @@ const renderOverview = () => {
       <div class="label">Active alerts</div>
       <div class="value ${toneClass(openAlertCount > 0 ? "warning" : "clear")}">${escapeHtml(String(openAlertCount))}</div>
       <div class="meta">Open telemetry-linked alerts currently associated with the selected mission.</div>
+    </article>
+    <article class="metric">
+      <div class="label">Weather</div>
+      <div class="value ${toneClass(activeWeather?.severity ?? "missing")}">${escapeHtml(
+        weatherMeta
+          ? `${weatherMeta.windSpeedKnots} kt ${weatherMeta.precipitation}`
+          : "Missing",
+      )}</div>
+      <div class="meta">${escapeHtml(
+        weatherMeta
+          ? `${weatherMeta.temperatureC}°C at ${formatDateTime(activeWeather.observedAt)}`
+          : "No weather overlay loaded for this mission.",
+      )}</div>
     </article>
   `;
 };
@@ -685,6 +764,7 @@ const buildMapMarkup = () => {
     uiState.dispatchWorkspace?.dispatch?.ready ? "Dispatch ready" : "Dispatch blocked",
     summarizeRiskState(uiState.planningWorkspace).label,
     summarizeAirspaceState(uiState.planningWorkspace).label,
+    weatherOverlays().length > 0 ? `Weather overlays ${weatherOverlays().length}` : "Weather overlays 0",
   ];
 
   const openAlerts = (uiState.alerts ?? []).filter((alert) => alert.status !== "resolved");
@@ -707,8 +787,19 @@ const buildMapMarkup = () => {
   const dispatchState = summarizeDispatchState(uiState.dispatchWorkspace);
   const riskState = summarizeRiskState(uiState.planningWorkspace);
   const airspaceState = summarizeAirspaceState(uiState.planningWorkspace);
+  const weatherState = weatherSummary();
   const mapRiskSeverity = [highestAlertSeverity, readinessState.tone, dispatchState.tone, riskState.tone, airspaceState.tone]
     .sort((left, right) => severityRank(right) - severityRank(left))[0];
+  const weatherOverlay = activeWeatherOverlay();
+  const weatherPoint =
+    weatherOverlay &&
+    Number.isFinite(weatherOverlay.geometry?.lat) &&
+    Number.isFinite(weatherOverlay.geometry?.lng)
+      ? toPoint(
+          Number(weatherOverlay.geometry.lat),
+          Number(weatherOverlay.geometry.lng),
+        )
+      : null;
   const latestTelemetryHalo = currentMapPoint
     ? `
       <circle cx="${currentMapPoint.x}" cy="${currentMapPoint.y}" r="34" fill="none" stroke="${severityStroke(
@@ -764,6 +855,15 @@ const buildMapMarkup = () => {
       />
     `
     : "";
+  const weatherMarker = weatherPoint
+    ? `
+      <circle cx="${weatherPoint.x}" cy="${weatherPoint.y}" r="18" fill="rgba(56,189,248,0.14)" stroke="#7dd3fc" stroke-width="2" />
+      <path d="M ${weatherPoint.x - 10} ${weatherPoint.y} L ${weatherPoint.x + 8} ${weatherPoint.y - 8} L ${weatherPoint.x + 8} ${weatherPoint.y + 8} Z" fill="#7dd3fc" opacity="0.88" />
+      <text x="${weatherPoint.x + 22}" y="${weatherPoint.y + 5}" fill="#d8ecff" font-size="12" font-weight="700">${escapeHtml(
+        `${weatherOverlay?.metadata?.windSpeedKnots ?? "?"}kt`,
+      )}</text>
+    `
+    : "";
 
   return `
     <div class="map-grid"></div>
@@ -782,6 +882,7 @@ const buildMapMarkup = () => {
       ${completedReplayPath ? `<polyline points="${completedReplayPath}" fill="none" stroke="#38bdf8" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.98" />` : ""}
       ${alertTrackHighlight}
       ${replayDots}
+      ${weatherMarker}
       ${
         currentMapPoint
           ? `
@@ -886,6 +987,24 @@ const renderStatus = () => {
           <div class="k">Open alerts</div>
           <div>${escapeHtml(
             String((uiState.alerts ?? []).filter((alert) => alert.status !== "resolved").length),
+          )}</div>
+          <div class="k">Weather overlay</div>
+          <div>${renderBadge(weatherState.label)}</div>
+          <div class="k">Wind / temp</div>
+          <div>${escapeHtml(
+            activeWeatherOverlay()
+              ? `${activeWeatherOverlay().metadata?.windSpeedKnots ?? "?"} kt @ ${activeWeatherOverlay().metadata?.windDirectionDegrees ?? "?"}° · ${activeWeatherOverlay().metadata?.temperatureC ?? "?"}°C`
+              : "Missing",
+          )}</div>
+          <div class="k">Precipitation</div>
+          <div>${escapeHtml(
+            activeWeatherOverlay()?.metadata?.precipitation ?? "Missing",
+          )}</div>
+          <div class="k">Observed</div>
+          <div>${escapeHtml(
+            activeWeatherOverlay()
+              ? formatDateTime(activeWeatherOverlay().observedAt)
+              : "Not recorded",
           )}</div>
         </div>
       </section>
@@ -1064,6 +1183,7 @@ const loadLiveOperationsView = async (missionId) => {
     uiState.replay = null;
     uiState.latestTelemetry = null;
     uiState.alerts = [];
+    uiState.externalOverlays = [];
     uiState.replayPlayback.index = 0;
     setLoadedMission("");
     setConnectionState("Enter a mission UUID", "tone-warn");
@@ -1084,6 +1204,7 @@ const loadLiveOperationsView = async (missionId) => {
       replayResponse,
       latestTelemetryResponse,
       alertsResponse,
+      externalOverlayResponse,
     ] = await Promise.all([
       fetchJson(`/missions/${missionId}/planning-workspace`),
       fetchJson(`/missions/${missionId}/dispatch-workspace`),
@@ -1091,6 +1212,7 @@ const loadLiveOperationsView = async (missionId) => {
       fetchJson(`/missions/${missionId}/replay`),
       fetchJson(`/missions/${missionId}/telemetry/latest`),
       fetchJson(`/missions/${missionId}/alerts`),
+      fetchJson(`/missions/${missionId}/external-overlays?kind=weather`),
     ]);
 
     uiState.planningWorkspace = planningResponse.workspace;
@@ -1099,6 +1221,7 @@ const loadLiveOperationsView = async (missionId) => {
     uiState.replay = replayResponse;
     uiState.latestTelemetry = latestTelemetryResponse;
     uiState.alerts = alertsResponse.alerts ?? [];
+    uiState.externalOverlays = externalOverlayResponse.overlays ?? [];
     uiState.replayPlayback.index = 0;
     renderLiveOperations();
     setConnectionState("Live operations view loaded", "tone-ok");
@@ -1111,6 +1234,7 @@ const loadLiveOperationsView = async (missionId) => {
     uiState.replay = null;
     uiState.latestTelemetry = null;
     uiState.alerts = [];
+    uiState.externalOverlays = [];
     uiState.replayPlayback.index = 0;
     clearPanels(message);
     setConnectionState(message, "tone-bad");


### PR DESCRIPTION
## Summary

Implements GitHub issue #147 by adding the first mission-linked external overlay slice for weather and wiring it into the live operations view.

## What changed

- Added a dedicated mission-linked external overlay boundary:
  - `POST /missions/:missionId/external-overlays`
  - `GET /missions/:missionId/external-overlays`
- Implemented the first supported overlay kind:
  - `weather`
- Added vendor-neutral weather overlay validation and storage for:
  - wind speed
  - wind direction
  - temperature
  - precipitation
  - observed time
  - optional validity window
  - freshness / confidence
- Added migration-backed storage in `mission_external_overlays`.
- Kept the overlay boundary aligned with the design in:
  - `docs/live-operations-external-overlay-model.md`
- Extended the operator live operations view to consume weather overlays from:
  - `GET /missions/:missionId/external-overlays?kind=weather`
- Live operations display now surfaces weather context including:
  - wind speed/direction
  - temperature
  - precipitation
  - observation time/freshness
- Kept the operator UI read-only.
- Added integration coverage for:
  - weather overlay creation
  - weather overlay listing
  - mission isolation
  - missing mission handling
  - live ops bundle wiring to the new overlay path
- Updated the save point to the next implementation slice:
  - crewed traffic overlays

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 3 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 22 files, 323 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

## Notes

This issue implements weather only. It does not implement:
- crewed traffic overlays
- drone traffic overlays
- conflict detection
- advisory or avoidance logic

Closes #147.
