### PR TITLE
Add crewed traffic external overlay support

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add migration-backed crewed traffic external overlay ingestion and live operations display using the mission-linked external overlay model.",
+ "nextBuildStep": "Add migration-backed drone traffic external overlay ingestion and live operations display using the mission-linked external overlay model.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -17,14 +17,23 @@ export class ExternalOverlayController {
     next: NextFunction,
   ): Promise<void> => {
     try {
-      if (req.body?.kind !== "weather") {
-        throw new Error("Only weather overlays are supported in the first implementation slice");
-      }
+      let overlay;
 
-      const overlay = await this.externalOverlayService.createWeatherOverlay(
-        req.params.missionId,
-        req.body,
-      );
+      if (req.body?.kind === "weather") {
+        overlay = await this.externalOverlayService.createWeatherOverlay(
+          req.params.missionId,
+          req.body,
+        );
+      } else if (req.body?.kind === "crewed_traffic") {
+        overlay = await this.externalOverlayService.createCrewedTrafficOverlay(
+          req.params.missionId,
+          req.body,
+        );
+      } else {
+        throw new Error(
+          "Supported overlay kinds are: weather, crewed_traffic",
+        );
+      }
 
       res.status(201).json({ overlay });
     } catch (error) {

--- a/src/external-overlays/external-overlay.repository.ts
+++ b/src/external-overlays/external-overlay.repository.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import type { PoolClient, QueryResultRow } from "pg";
 import type {
+  CreateCrewedTrafficExternalOverlayInput,
   CreateWeatherExternalOverlayInput,
   ExternalOverlay,
   ExternalOverlayKind,
@@ -121,6 +122,63 @@ export class ExternalOverlayRepository {
         input.geometry.lat,
         input.geometry.lng,
         input.geometry.altitudeMslFt,
+        input.severity,
+        input.confidence,
+        input.freshnessSeconds,
+        JSON.stringify(input.metadata),
+      ],
+    );
+
+    return toExternalOverlay(result.rows[0]);
+  }
+
+  async insertCrewedTrafficOverlay(
+    tx: PoolClient,
+    missionId: string,
+    input: CreateCrewedTrafficExternalOverlayInput,
+  ): Promise<ExternalOverlay> {
+    const result = await tx.query<ExternalOverlayRow>(
+      `
+      insert into mission_external_overlays (
+        id,
+        mission_id,
+        overlay_kind,
+        source_provider,
+        source_type,
+        source_record_id,
+        observed_at,
+        valid_from,
+        valid_to,
+        geometry_type,
+        latitude,
+        longitude,
+        altitude_msl_ft,
+        heading_degrees,
+        speed_knots,
+        severity,
+        confidence,
+        freshness_seconds,
+        metadata
+      )
+      values (
+        $1, $2, 'crewed_traffic', $3, $4, $5, $6, $7, $8, 'point', $9, $10, $11, $12, $13, $14, $15, $16, $17::jsonb
+      )
+      returning *
+      `,
+      [
+        randomUUID(),
+        missionId,
+        input.source.provider,
+        input.source.sourceType,
+        input.source.sourceRecordId,
+        input.observedAt,
+        input.validFrom,
+        input.validTo,
+        input.geometry.lat,
+        input.geometry.lng,
+        input.geometry.altitudeMslFt,
+        input.headingDegrees,
+        input.speedKnots,
         input.severity,
         input.confidence,
         input.freshnessSeconds,

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -2,11 +2,15 @@ import type { Pool } from "pg";
 import { ExternalOverlayRepository } from "./external-overlay.repository";
 import { MissionExternalOverlayMissionNotFoundError } from "./external-overlay.errors";
 import type {
+  CreateCrewedTrafficExternalOverlayInput,
   CreateWeatherExternalOverlayInput,
   ExternalOverlay,
   ExternalOverlayKind,
 } from "./external-overlay.types";
-import { validateCreateWeatherExternalOverlayInput } from "./external-overlay.validators";
+import {
+  validateCreateCrewedTrafficExternalOverlayInput,
+  validateCreateWeatherExternalOverlayInput,
+} from "./external-overlay.validators";
 
 export class ExternalOverlayService {
   constructor(
@@ -32,6 +36,33 @@ export class ExternalOverlayService {
       }
 
       return await this.externalOverlayRepository.insertWeatherOverlay(
+        client,
+        missionId,
+        validated,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  async createCrewedTrafficOverlay(
+    missionId: string,
+    input: unknown,
+  ): Promise<ExternalOverlay> {
+    const validated = validateCreateCrewedTrafficExternalOverlayInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.externalOverlayRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new MissionExternalOverlayMissionNotFoundError(missionId);
+      }
+
+      return await this.externalOverlayRepository.insertCrewedTrafficOverlay(
         client,
         missionId,
         validated,

--- a/src/external-overlays/external-overlay.types.ts
+++ b/src/external-overlays/external-overlay.types.ts
@@ -33,6 +33,14 @@ export interface WeatherOverlayMetadata {
     | "mixed";
 }
 
+export interface CrewedTrafficOverlayMetadata {
+  trafficId: string;
+  callsign: string | null;
+  trackSource: string;
+  aircraftCategory: string | null;
+  verticalRateFpm: number | null;
+}
+
 export interface ExternalOverlay {
   id: string;
   missionId: string;
@@ -72,6 +80,30 @@ export interface CreateWeatherExternalOverlayInput {
   confidence?: number | null;
   freshnessSeconds?: number | null;
   metadata: WeatherOverlayMetadata;
+}
+
+export interface CreateCrewedTrafficExternalOverlayInput {
+  kind: "crewed_traffic";
+  source: {
+    provider: string;
+    sourceType: string;
+    sourceRecordId?: string | null;
+  };
+  observedAt: string;
+  validFrom?: string | null;
+  validTo?: string | null;
+  geometry: {
+    type: "point";
+    lat: number;
+    lng: number;
+    altitudeMslFt?: number | null;
+  };
+  headingDegrees?: number | null;
+  speedKnots?: number | null;
+  severity?: ExternalOverlaySeverity | null;
+  confidence?: number | null;
+  freshnessSeconds?: number | null;
+  metadata: CrewedTrafficOverlayMetadata;
 }
 
 export interface ListExternalOverlaysFilters {

--- a/src/external-overlays/external-overlay.validators.ts
+++ b/src/external-overlays/external-overlay.validators.ts
@@ -1,4 +1,5 @@
 import type {
+  CreateCrewedTrafficExternalOverlayInput,
   CreateWeatherExternalOverlayInput,
   ExternalOverlaySeverity,
 } from "./external-overlay.types";
@@ -161,6 +162,77 @@ export const validateCreateWeatherExternalOverlayInput = (
         "metadata.temperatureC",
       ),
       precipitation: precipitation as CreateWeatherExternalOverlayInput["metadata"]["precipitation"],
+    },
+  };
+};
+
+export const validateCreateCrewedTrafficExternalOverlayInput = (
+  input: unknown,
+): CreateCrewedTrafficExternalOverlayInput => {
+  if (!input || typeof input !== "object") {
+    throw new Error("request body is required");
+  }
+
+  const candidate = input as Record<string, any>;
+  if (candidate.kind !== "crewed_traffic") {
+    throw new Error("kind must be 'crewed_traffic'");
+  }
+
+  if (!candidate.source || typeof candidate.source !== "object") {
+    throw new Error("source is required");
+  }
+
+  if (!candidate.geometry || typeof candidate.geometry !== "object") {
+    throw new Error("geometry is required");
+  }
+
+  if (!candidate.metadata || typeof candidate.metadata !== "object") {
+    throw new Error("metadata is required");
+  }
+
+  if (candidate.geometry.type !== "point") {
+    throw new Error("geometry.type must be 'point'");
+  }
+
+  return {
+    kind: "crewed_traffic",
+    source: {
+      provider: requiredString(candidate.source.provider, "source.provider"),
+      sourceType: requiredString(candidate.source.sourceType, "source.sourceType"),
+      sourceRecordId: optionalString(candidate.source.sourceRecordId),
+    },
+    observedAt: requiredTimestamp(candidate.observedAt, "observedAt"),
+    validFrom: optionalTimestamp(candidate.validFrom, "validFrom"),
+    validTo: optionalTimestamp(candidate.validTo, "validTo"),
+    geometry: {
+      type: "point",
+      lat: requiredNumber(candidate.geometry.lat, "geometry.lat"),
+      lng: requiredNumber(candidate.geometry.lng, "geometry.lng"),
+      altitudeMslFt: optionalNumber(
+        candidate.geometry.altitudeMslFt,
+        "geometry.altitudeMslFt",
+      ),
+    },
+    headingDegrees: optionalNumber(candidate.headingDegrees, "headingDegrees"),
+    speedKnots: optionalNumber(candidate.speedKnots, "speedKnots"),
+    severity: optionalSeverity(candidate.severity),
+    confidence: optionalNumber(candidate.confidence, "confidence"),
+    freshnessSeconds:
+      candidate.freshnessSeconds == null
+        ? null
+        : requiredNumber(candidate.freshnessSeconds, "freshnessSeconds"),
+    metadata: {
+      trafficId: requiredString(candidate.metadata.trafficId, "metadata.trafficId"),
+      callsign: optionalString(candidate.metadata.callsign),
+      trackSource: requiredString(
+        candidate.metadata.trackSource,
+        "metadata.trackSource",
+      ),
+      aircraftCategory: optionalString(candidate.metadata.aircraftCategory),
+      verticalRateFpm: optionalNumber(
+        candidate.metadata.verticalRateFpm,
+        "metadata.verticalRateFpm",
+      ),
     },
   };
 };

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -92,7 +92,7 @@ describe("mission external overlays integration", () => {
     });
 
     const listResponse = await request(app).get(
-      `/missions/${missionId}/external-overlays?kind=weather`,
+      `/missions/${missionId}/external-overlays`,
     );
 
     expect(listResponse.status).toBe(200);
@@ -142,16 +142,160 @@ describe("mission external overlays integration", () => {
     expect(createResponse.status).toBe(201);
 
     const listResponse = await request(app).get(
-      `/missions/${firstMissionId}/external-overlays?kind=weather`,
+      `/missions/${firstMissionId}/external-overlays`,
     );
 
     expect(listResponse.status).toBe(200);
     expect(listResponse.body.overlays).toEqual([]);
   });
 
+  it("creates and lists crewed traffic overlays through the mission-linked external overlay boundary", async () => {
+    const missionId = await createMission();
+
+    const createResponse = await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "crewed_traffic",
+        source: {
+          provider: "traffic-hub",
+          sourceType: "adsb_exchange",
+          sourceRecordId: "track-2002",
+        },
+        observedAt: "2026-04-21T10:04:00.000Z",
+        geometry: {
+          type: "point",
+          lat: 51.5091,
+          lng: -0.1215,
+          altitudeMslFt: 1800,
+        },
+        headingDegrees: 122,
+        speedKnots: 135,
+        severity: "info",
+        freshnessSeconds: 45,
+        metadata: {
+          trafficId: "traffic-2002",
+          callsign: "HELIMED21",
+          trackSource: "adsb_exchange",
+          aircraftCategory: "helicopter",
+          verticalRateFpm: 200,
+        },
+      });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.overlay).toMatchObject({
+      missionId,
+      kind: "crewed_traffic",
+      source: {
+        provider: "traffic-hub",
+        sourceType: "adsb_exchange",
+        sourceRecordId: "track-2002",
+      },
+      geometry: {
+        type: "point",
+        lat: 51.5091,
+        lng: -0.1215,
+        altitudeMslFt: 1800,
+      },
+      headingDegrees: 122,
+      speedKnots: 135,
+      metadata: {
+        trafficId: "traffic-2002",
+        callsign: "HELIMED21",
+        trackSource: "adsb_exchange",
+        aircraftCategory: "helicopter",
+        verticalRateFpm: 200,
+      },
+    });
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body).toMatchObject({
+      missionId,
+      overlays: [
+        expect.objectContaining({
+          kind: "crewed_traffic",
+          headingDegrees: 122,
+          speedKnots: 135,
+          metadata: expect.objectContaining({
+            trafficId: "traffic-2002",
+            callsign: "HELIMED21",
+            aircraftCategory: "helicopter",
+          }),
+        }),
+      ],
+    });
+  });
+
+  it("keeps weather and crewed traffic overlay paths intact when listed together", async () => {
+    const missionId = await createMission();
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "weather",
+        source: {
+          provider: "met-office",
+          sourceType: "surface_observation",
+        },
+        observedAt: "2026-04-21T10:00:00.000Z",
+        geometry: {
+          type: "point",
+          lat: 51.5074,
+          lng: -0.1278,
+        },
+        metadata: {
+          windSpeedKnots: 12,
+          windDirectionDegrees: 205,
+          temperatureC: 10,
+          precipitation: "none",
+        },
+      });
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "crewed_traffic",
+        source: {
+          provider: "traffic-hub",
+          sourceType: "adsb_exchange",
+        },
+        observedAt: "2026-04-21T10:03:00.000Z",
+        geometry: {
+          type: "point",
+          lat: 51.508,
+          lng: -0.12,
+          altitudeMslFt: 2400,
+        },
+        headingDegrees: 80,
+        speedKnots: 148,
+        metadata: {
+          trafficId: "traffic-3003",
+          callsign: "N123AB",
+          trackSource: "adsb_exchange",
+          aircraftCategory: "fixed_wing",
+          verticalRateFpm: null,
+        },
+      });
+
+    const listAllResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays`,
+    );
+
+    expect(listAllResponse.status).toBe(200);
+    expect(listAllResponse.body.overlays).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "weather" }),
+        expect.objectContaining({ kind: "crewed_traffic" }),
+      ]),
+    );
+  });
+
   it("returns 404 for missing missions on external overlay reads", async () => {
     const response = await request(app).get(
-      `/missions/${randomUUID()}/external-overlays?kind=weather`,
+      `/missions/${randomUUID()}/external-overlays`,
     );
 
     expect(response.status).toBe(404);

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -1976,7 +1976,7 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("/missions/${missionId}/replay");
     expect(response.text).toContain("/missions/${missionId}/telemetry/latest");
     expect(response.text).toContain("/missions/${missionId}/alerts");
-    expect(response.text).toContain("/missions/${missionId}/external-overlays?kind=weather");
+    expect(response.text).toContain("/missions/${missionId}/external-overlays");
     expect(response.text).toContain("/missions/${missionId}/planning-workspace");
     expect(response.text).toContain("/missions/${missionId}/dispatch-workspace");
     expect(response.text).toContain("/missions/${missionId}/operations-timeline");
@@ -2004,5 +2004,8 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("weatherOverlays");
     expect(response.text).toContain("activeWeatherOverlay");
     expect(response.text).toContain("weatherSummary");
+    expect(response.text).toContain("crewedTrafficOverlays");
+    expect(response.text).toContain("activeCrewedTrafficOverlays");
+    expect(response.text).toContain("crewedTrafficSummary");
   });
 });

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -88,6 +88,11 @@ const renderBadge = (value) =>
 const weatherOverlays = () =>
   (uiState.externalOverlays ?? []).filter((overlay) => overlay.kind === "weather");
 
+const crewedTrafficOverlays = () =>
+  (uiState.externalOverlays ?? []).filter(
+    (overlay) => overlay.kind === "crewed_traffic",
+  );
+
 const formatDateTime = (value) => {
   if (!value) {
     return "Not recorded";
@@ -241,6 +246,60 @@ const weatherSummary = () => {
     label: `Weather ${metadata.precipitation ?? "unknown"}`,
     tone: overlay.severity ?? "info",
     detail: `${metadata.windSpeedKnots ?? "?"} kt @ ${metadata.windDirectionDegrees ?? "?"}° · ${metadata.temperatureC ?? "?"}°C · observed ${formatDateTime(overlay.observedAt)}`,
+  };
+};
+
+const activeCrewedTrafficOverlays = () => {
+  const replayPoint = activeReplayPoint();
+  const replayTime = replayPoint?.timestamp ? Date.parse(replayPoint.timestamp) : null;
+
+  return crewedTrafficOverlays()
+    .map((overlay) => {
+      const observedAt = Date.parse(overlay.observedAt ?? "");
+      const validFrom = overlay.validFrom ? Date.parse(overlay.validFrom) : observedAt;
+      const validTo = overlay.validTo ? Date.parse(overlay.validTo) : null;
+      const activeAtReplay =
+        replayTime != null &&
+        Number.isFinite(validFrom) &&
+        replayTime >= validFrom &&
+        (validTo == null || replayTime <= validTo);
+      const relativeMs =
+        replayTime == null || !Number.isFinite(observedAt)
+          ? Number.POSITIVE_INFINITY
+          : Math.abs(replayTime - observedAt);
+
+      return {
+        ...overlay,
+        activeAtReplay,
+        relativeMs,
+      };
+    })
+    .sort((left, right) => {
+      if (left.activeAtReplay !== right.activeAtReplay) {
+        return left.activeAtReplay ? -1 : 1;
+      }
+
+      return left.relativeMs - right.relativeMs;
+    })
+    .slice(0, 5);
+};
+
+const crewedTrafficSummary = () => {
+  const traffic = activeCrewedTrafficOverlays();
+  if (traffic.length === 0) {
+    return {
+      label: "Crewed traffic missing",
+      tone: "warning",
+      detail: "No mission-linked crewed traffic overlays are available for the current replay position.",
+    };
+  }
+
+  const primary = traffic[0];
+  const metadata = primary.metadata ?? {};
+  return {
+    label: `${traffic.length} crewed traffic contact${traffic.length === 1 ? "" : "s"}`,
+    tone: primary.severity ?? "info",
+    detail: `${metadata.callsign ?? metadata.trafficId ?? "Unknown"} · ${primary.speedKnots ?? "?"} kt · ${primary.geometry?.altitudeMslFt ?? "?"} ft · observed ${formatDateTime(primary.observedAt)}`,
   };
 };
 
@@ -546,6 +605,7 @@ const buildOverlayCards = () => {
     summarizeReadinessState(planningWorkspace, dispatchWorkspace),
     summarizeDispatchState(dispatchWorkspace),
     weatherSummary(),
+    crewedTrafficSummary(),
     summarizeTelemetryAlerts(uiState.alerts),
   ];
 
@@ -629,6 +689,9 @@ const renderOverview = () => {
   const openAlertCount = (uiState.alerts ?? []).filter((alert) => alert.status !== "resolved").length;
   const activeWeather = activeWeatherOverlay();
   const weatherMeta = activeWeather?.metadata ?? null;
+  const activeTraffic = activeCrewedTrafficOverlays();
+  const primaryTraffic = activeTraffic[0];
+  const primaryTrafficMeta = primaryTraffic?.metadata ?? null;
 
   overviewPanel.innerHTML = `
     <article class="metric">
@@ -682,6 +745,19 @@ const renderOverview = () => {
         weatherMeta
           ? `${weatherMeta.temperatureC}°C at ${formatDateTime(activeWeather.observedAt)}`
           : "No weather overlay loaded for this mission.",
+      )}</div>
+    </article>
+    <article class="metric">
+      <div class="label">Crewed traffic</div>
+      <div class="value ${toneClass(primaryTraffic?.severity ?? "missing")}">${escapeHtml(
+        activeTraffic.length === 0
+          ? "Missing"
+          : `${activeTraffic.length} contact${activeTraffic.length === 1 ? "" : "s"}`,
+      )}</div>
+      <div class="meta">${escapeHtml(
+        primaryTrafficMeta
+          ? `${primaryTrafficMeta.callsign ?? primaryTrafficMeta.trafficId ?? "Unknown"} at ${formatDateTime(primaryTraffic.observedAt)}`
+          : "No crewed traffic overlay loaded for this mission.",
       )}</div>
     </article>
   `;
@@ -765,6 +841,7 @@ const buildMapMarkup = () => {
     summarizeRiskState(uiState.planningWorkspace).label,
     summarizeAirspaceState(uiState.planningWorkspace).label,
     weatherOverlays().length > 0 ? `Weather overlays ${weatherOverlays().length}` : "Weather overlays 0",
+    crewedTrafficOverlays().length > 0 ? `Crewed traffic ${crewedTrafficOverlays().length}` : "Crewed traffic 0",
   ];
 
   const openAlerts = (uiState.alerts ?? []).filter((alert) => alert.status !== "resolved");
@@ -788,6 +865,7 @@ const buildMapMarkup = () => {
   const riskState = summarizeRiskState(uiState.planningWorkspace);
   const airspaceState = summarizeAirspaceState(uiState.planningWorkspace);
   const weatherState = weatherSummary();
+  const trafficState = crewedTrafficSummary();
   const mapRiskSeverity = [highestAlertSeverity, readinessState.tone, dispatchState.tone, riskState.tone, airspaceState.tone]
     .sort((left, right) => severityRank(right) - severityRank(left))[0];
   const weatherOverlay = activeWeatherOverlay();
@@ -864,6 +942,33 @@ const buildMapMarkup = () => {
       )}</text>
     `
     : "";
+  const crewedTrafficMarkers = activeCrewedTrafficOverlays()
+    .map((overlay) => {
+      const trafficPoint =
+        Number.isFinite(overlay.geometry?.lat) &&
+        Number.isFinite(overlay.geometry?.lng)
+          ? toPoint(Number(overlay.geometry.lat), Number(overlay.geometry.lng))
+          : null;
+
+      if (!trafficPoint) {
+        return "";
+      }
+
+      const metadata = overlay.metadata ?? {};
+      return `
+        <g>
+          <circle cx="${trafficPoint.x}" cy="${trafficPoint.y}" r="11" fill="rgba(251,191,36,0.18)" stroke="#fbbf24" stroke-width="2" />
+          <path d="M ${trafficPoint.x} ${trafficPoint.y - 10} L ${trafficPoint.x + 7} ${trafficPoint.y + 9} L ${trafficPoint.x} ${trafficPoint.y + 4} L ${trafficPoint.x - 7} ${trafficPoint.y + 9} Z" fill="#fbbf24" opacity="0.92" />
+          <text x="${trafficPoint.x + 14}" y="${trafficPoint.y - 3}" fill="#f8fafc" font-size="11" font-weight="700">${escapeHtml(
+            metadata.callsign ?? metadata.trafficId ?? "Traffic",
+          )}</text>
+          <text x="${trafficPoint.x + 14}" y="${trafficPoint.y + 11}" fill="#d8ecff" font-size="10">${escapeHtml(
+            `${overlay.geometry?.altitudeMslFt ?? "?"}ft · ${overlay.speedKnots ?? "?"}kt`,
+          )}</text>
+        </g>
+      `;
+    })
+    .join("");
 
   return `
     <div class="map-grid"></div>
@@ -883,6 +988,7 @@ const buildMapMarkup = () => {
       ${alertTrackHighlight}
       ${replayDots}
       ${weatherMarker}
+      ${crewedTrafficMarkers}
       ${
         currentMapPoint
           ? `
@@ -1004,6 +1110,32 @@ const renderStatus = () => {
           <div>${escapeHtml(
             activeWeatherOverlay()
               ? formatDateTime(activeWeatherOverlay().observedAt)
+              : "Not recorded",
+          )}</div>
+          <div class="k">Crewed traffic</div>
+          <div>${renderBadge(trafficState.label)}</div>
+          <div class="k">Primary contact</div>
+          <div>${escapeHtml(
+            activeCrewedTrafficOverlays()[0]
+              ? `${activeCrewedTrafficOverlays()[0].metadata?.callsign ?? activeCrewedTrafficOverlays()[0].metadata?.trafficId ?? "Unknown"}`
+              : "Missing",
+          )}</div>
+          <div class="k">Heading / speed</div>
+          <div>${escapeHtml(
+            activeCrewedTrafficOverlays()[0]
+              ? `${activeCrewedTrafficOverlays()[0].headingDegrees ?? "?"}° · ${activeCrewedTrafficOverlays()[0].speedKnots ?? "?"} kt`
+              : "Missing",
+          )}</div>
+          <div class="k">Altitude</div>
+          <div>${escapeHtml(
+            activeCrewedTrafficOverlays()[0]
+              ? `${activeCrewedTrafficOverlays()[0].geometry?.altitudeMslFt ?? "?"} ft`
+              : "Missing",
+          )}</div>
+          <div class="k">Observed</div>
+          <div>${escapeHtml(
+            activeCrewedTrafficOverlays()[0]
+              ? formatDateTime(activeCrewedTrafficOverlays()[0].observedAt)
               : "Not recorded",
           )}</div>
         </div>
@@ -1212,7 +1344,7 @@ const loadLiveOperationsView = async (missionId) => {
       fetchJson(`/missions/${missionId}/replay`),
       fetchJson(`/missions/${missionId}/telemetry/latest`),
       fetchJson(`/missions/${missionId}/alerts`),
-      fetchJson(`/missions/${missionId}/external-overlays?kind=weather`),
+      fetchJson(`/missions/${missionId}/external-overlays`),
     ]);
 
     uiState.planningWorkspace = planningResponse.workspace;


### PR DESCRIPTION
## Summary

Implements GitHub issue #149 by extending the mission-linked external overlay boundary to support crewed traffic and wiring it into the live operations view.

## What changed

- Extended the existing migration-backed external overlay model to support:
  - `crewed_traffic`
- Kept the implementation on the existing mission-linked external overlay boundary:
  - `POST /missions/:missionId/external-overlays`
  - `GET /missions/:missionId/external-overlays`
- Added vendor-neutral crewed traffic validation and storage for:
  - traffic identifier
  - callsign where available
  - source/provider metadata
  - observed time
  - position
  - altitude
  - heading
  - speed
  - freshness / confidence
  - optional validity window
- Reused the existing migration-backed `mission_external_overlays` table rather than creating a second traffic-specific store.
- Updated the operator live operations view to consume the shared external overlay path and display crewed traffic context including:
  - traffic markers on the map
  - callsign / traffic identifier
  - heading / speed
  - altitude
  - observation time
- Kept the operator live ops UI read-only.
- Preserved the existing weather overlay path and list behavior while extending the boundary for crewed traffic.
- Added integration coverage for:
  - crewed traffic overlay creation
  - crewed traffic overlay listing
  - mission isolation
  - mixed weather + crewed overlay listing
  - live ops bundle wiring for crewed traffic rendering
- Updated the save point to the next implementation slice:
  - drone traffic overlays

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 5 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 22 files, 325 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

## Notes

This issue implements crewed traffic only. It does not implement:
- drone traffic overlays
- conflict detection
- traffic collision avoidance logic
- advisory or avoidance commands

Closes #149.
