### PR TITLE
Add drone traffic external overlay support

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add migration-backed drone traffic external overlay ingestion and live operations display using the mission-linked external overlay model.",
+ "nextBuildStep": "Add mission-linked traffic conflict assessment on top of weather, crewed traffic, and drone traffic overlays without introducing operator command automation.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -29,9 +29,14 @@ export class ExternalOverlayController {
           req.params.missionId,
           req.body,
         );
+      } else if (req.body?.kind === "drone_traffic") {
+        overlay = await this.externalOverlayService.createDroneTrafficOverlay(
+          req.params.missionId,
+          req.body,
+        );
       } else {
         throw new Error(
-          "Supported overlay kinds are: weather, crewed_traffic",
+          "Supported overlay kinds are: weather, crewed_traffic, drone_traffic",
         );
       }
 

--- a/src/external-overlays/external-overlay.repository.ts
+++ b/src/external-overlays/external-overlay.repository.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import type { PoolClient, QueryResultRow } from "pg";
 import type {
   CreateCrewedTrafficExternalOverlayInput,
+  CreateDroneTrafficExternalOverlayInput,
   CreateWeatherExternalOverlayInput,
   ExternalOverlay,
   ExternalOverlayKind,
@@ -162,6 +163,63 @@ export class ExternalOverlayRepository {
       )
       values (
         $1, $2, 'crewed_traffic', $3, $4, $5, $6, $7, $8, 'point', $9, $10, $11, $12, $13, $14, $15, $16, $17::jsonb
+      )
+      returning *
+      `,
+      [
+        randomUUID(),
+        missionId,
+        input.source.provider,
+        input.source.sourceType,
+        input.source.sourceRecordId,
+        input.observedAt,
+        input.validFrom,
+        input.validTo,
+        input.geometry.lat,
+        input.geometry.lng,
+        input.geometry.altitudeMslFt,
+        input.headingDegrees,
+        input.speedKnots,
+        input.severity,
+        input.confidence,
+        input.freshnessSeconds,
+        JSON.stringify(input.metadata),
+      ],
+    );
+
+    return toExternalOverlay(result.rows[0]);
+  }
+
+  async insertDroneTrafficOverlay(
+    tx: PoolClient,
+    missionId: string,
+    input: CreateDroneTrafficExternalOverlayInput,
+  ): Promise<ExternalOverlay> {
+    const result = await tx.query<ExternalOverlayRow>(
+      `
+      insert into mission_external_overlays (
+        id,
+        mission_id,
+        overlay_kind,
+        source_provider,
+        source_type,
+        source_record_id,
+        observed_at,
+        valid_from,
+        valid_to,
+        geometry_type,
+        latitude,
+        longitude,
+        altitude_msl_ft,
+        heading_degrees,
+        speed_knots,
+        severity,
+        confidence,
+        freshness_seconds,
+        metadata
+      )
+      values (
+        $1, $2, 'drone_traffic', $3, $4, $5, $6, $7, $8, 'point', $9, $10, $11, $12, $13, $14, $15, $16, $17::jsonb
       )
       returning *
       `,

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -3,12 +3,14 @@ import { ExternalOverlayRepository } from "./external-overlay.repository";
 import { MissionExternalOverlayMissionNotFoundError } from "./external-overlay.errors";
 import type {
   CreateCrewedTrafficExternalOverlayInput,
+  CreateDroneTrafficExternalOverlayInput,
   CreateWeatherExternalOverlayInput,
   ExternalOverlay,
   ExternalOverlayKind,
 } from "./external-overlay.types";
 import {
   validateCreateCrewedTrafficExternalOverlayInput,
+  validateCreateDroneTrafficExternalOverlayInput,
   validateCreateWeatherExternalOverlayInput,
 } from "./external-overlay.validators";
 
@@ -63,6 +65,33 @@ export class ExternalOverlayService {
       }
 
       return await this.externalOverlayRepository.insertCrewedTrafficOverlay(
+        client,
+        missionId,
+        validated,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  async createDroneTrafficOverlay(
+    missionId: string,
+    input: unknown,
+  ): Promise<ExternalOverlay> {
+    const validated = validateCreateDroneTrafficExternalOverlayInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.externalOverlayRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new MissionExternalOverlayMissionNotFoundError(missionId);
+      }
+
+      return await this.externalOverlayRepository.insertDroneTrafficOverlay(
         client,
         missionId,
         validated,

--- a/src/external-overlays/external-overlay.types.ts
+++ b/src/external-overlays/external-overlay.types.ts
@@ -41,6 +41,14 @@ export interface CrewedTrafficOverlayMetadata {
   verticalRateFpm: number | null;
 }
 
+export interface DroneTrafficOverlayMetadata {
+  trafficId: string;
+  trackSource: string;
+  vehicleType: string | null;
+  operatorReference: string | null;
+  verticalRateFpm: number | null;
+}
+
 export interface ExternalOverlay {
   id: string;
   missionId: string;
@@ -104,6 +112,30 @@ export interface CreateCrewedTrafficExternalOverlayInput {
   confidence?: number | null;
   freshnessSeconds?: number | null;
   metadata: CrewedTrafficOverlayMetadata;
+}
+
+export interface CreateDroneTrafficExternalOverlayInput {
+  kind: "drone_traffic";
+  source: {
+    provider: string;
+    sourceType: string;
+    sourceRecordId?: string | null;
+  };
+  observedAt: string;
+  validFrom?: string | null;
+  validTo?: string | null;
+  geometry: {
+    type: "point";
+    lat: number;
+    lng: number;
+    altitudeMslFt?: number | null;
+  };
+  headingDegrees?: number | null;
+  speedKnots?: number | null;
+  severity?: ExternalOverlaySeverity | null;
+  confidence?: number | null;
+  freshnessSeconds?: number | null;
+  metadata: DroneTrafficOverlayMetadata;
 }
 
 export interface ListExternalOverlaysFilters {

--- a/src/external-overlays/external-overlay.validators.ts
+++ b/src/external-overlays/external-overlay.validators.ts
@@ -1,5 +1,6 @@
 import type {
   CreateCrewedTrafficExternalOverlayInput,
+  CreateDroneTrafficExternalOverlayInput,
   CreateWeatherExternalOverlayInput,
   ExternalOverlaySeverity,
 } from "./external-overlay.types";
@@ -229,6 +230,77 @@ export const validateCreateCrewedTrafficExternalOverlayInput = (
         "metadata.trackSource",
       ),
       aircraftCategory: optionalString(candidate.metadata.aircraftCategory),
+      verticalRateFpm: optionalNumber(
+        candidate.metadata.verticalRateFpm,
+        "metadata.verticalRateFpm",
+      ),
+    },
+  };
+};
+
+export const validateCreateDroneTrafficExternalOverlayInput = (
+  input: unknown,
+): CreateDroneTrafficExternalOverlayInput => {
+  if (!input || typeof input !== "object") {
+    throw new Error("request body is required");
+  }
+
+  const candidate = input as Record<string, any>;
+  if (candidate.kind !== "drone_traffic") {
+    throw new Error("kind must be 'drone_traffic'");
+  }
+
+  if (!candidate.source || typeof candidate.source !== "object") {
+    throw new Error("source is required");
+  }
+
+  if (!candidate.geometry || typeof candidate.geometry !== "object") {
+    throw new Error("geometry is required");
+  }
+
+  if (!candidate.metadata || typeof candidate.metadata !== "object") {
+    throw new Error("metadata is required");
+  }
+
+  if (candidate.geometry.type !== "point") {
+    throw new Error("geometry.type must be 'point'");
+  }
+
+  return {
+    kind: "drone_traffic",
+    source: {
+      provider: requiredString(candidate.source.provider, "source.provider"),
+      sourceType: requiredString(candidate.source.sourceType, "source.sourceType"),
+      sourceRecordId: optionalString(candidate.source.sourceRecordId),
+    },
+    observedAt: requiredTimestamp(candidate.observedAt, "observedAt"),
+    validFrom: optionalTimestamp(candidate.validFrom, "validFrom"),
+    validTo: optionalTimestamp(candidate.validTo, "validTo"),
+    geometry: {
+      type: "point",
+      lat: requiredNumber(candidate.geometry.lat, "geometry.lat"),
+      lng: requiredNumber(candidate.geometry.lng, "geometry.lng"),
+      altitudeMslFt: optionalNumber(
+        candidate.geometry.altitudeMslFt,
+        "geometry.altitudeMslFt",
+      ),
+    },
+    headingDegrees: optionalNumber(candidate.headingDegrees, "headingDegrees"),
+    speedKnots: optionalNumber(candidate.speedKnots, "speedKnots"),
+    severity: optionalSeverity(candidate.severity),
+    confidence: optionalNumber(candidate.confidence, "confidence"),
+    freshnessSeconds:
+      candidate.freshnessSeconds == null
+        ? null
+        : requiredNumber(candidate.freshnessSeconds, "freshnessSeconds"),
+    metadata: {
+      trafficId: requiredString(candidate.metadata.trafficId, "metadata.trafficId"),
+      trackSource: requiredString(
+        candidate.metadata.trackSource,
+        "metadata.trackSource",
+      ),
+      vehicleType: optionalString(candidate.metadata.vehicleType),
+      operatorReference: optionalString(candidate.metadata.operatorReference),
       verticalRateFpm: optionalNumber(
         candidate.metadata.verticalRateFpm,
         "metadata.verticalRateFpm",

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -293,6 +293,172 @@ describe("mission external overlays integration", () => {
     );
   });
 
+  it("creates and lists drone traffic overlays through the mission-linked external overlay boundary", async () => {
+    const missionId = await createMission();
+
+    const createResponse = await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "drone_traffic",
+        source: {
+          provider: "utm-hub",
+          sourceType: "remote_id",
+          sourceRecordId: "drone-4004",
+        },
+        observedAt: "2026-04-21T10:06:00.000Z",
+        geometry: {
+          type: "point",
+          lat: 51.5062,
+          lng: -0.1193,
+          altitudeMslFt: 420,
+        },
+        headingDegrees: 44,
+        speedKnots: 28,
+        severity: "info",
+        freshnessSeconds: 20,
+        metadata: {
+          trafficId: "drone-4004",
+          trackSource: "remote_id",
+          vehicleType: "multirotor",
+          operatorReference: "op-ref-77",
+          verticalRateFpm: 120,
+        },
+      });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.overlay).toMatchObject({
+      missionId,
+      kind: "drone_traffic",
+      geometry: {
+        type: "point",
+        lat: 51.5062,
+        lng: -0.1193,
+        altitudeMslFt: 420,
+      },
+      headingDegrees: 44,
+      speedKnots: 28,
+      metadata: {
+        trafficId: "drone-4004",
+        trackSource: "remote_id",
+        vehicleType: "multirotor",
+        operatorReference: "op-ref-77",
+        verticalRateFpm: 120,
+      },
+    });
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays?kind=drone_traffic`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body).toMatchObject({
+      missionId,
+      overlays: [
+        expect.objectContaining({
+          kind: "drone_traffic",
+          headingDegrees: 44,
+          speedKnots: 28,
+          metadata: expect.objectContaining({
+            trafficId: "drone-4004",
+            operatorReference: "op-ref-77",
+            vehicleType: "multirotor",
+          }),
+        }),
+      ],
+    });
+  });
+
+  it("keeps weather, crewed traffic, and drone traffic paths intact when listed together", async () => {
+    const missionId = await createMission();
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "weather",
+        source: {
+          provider: "met-office",
+          sourceType: "surface_observation",
+        },
+        observedAt: "2026-04-21T10:00:00.000Z",
+        geometry: {
+          type: "point",
+          lat: 51.5074,
+          lng: -0.1278,
+        },
+        metadata: {
+          windSpeedKnots: 12,
+          windDirectionDegrees: 205,
+          temperatureC: 10,
+          precipitation: "none",
+        },
+      });
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "crewed_traffic",
+        source: {
+          provider: "traffic-hub",
+          sourceType: "adsb_exchange",
+        },
+        observedAt: "2026-04-21T10:03:00.000Z",
+        geometry: {
+          type: "point",
+          lat: 51.508,
+          lng: -0.12,
+          altitudeMslFt: 2400,
+        },
+        headingDegrees: 80,
+        speedKnots: 148,
+        metadata: {
+          trafficId: "traffic-3003",
+          callsign: "N123AB",
+          trackSource: "adsb_exchange",
+          aircraftCategory: "fixed_wing",
+          verticalRateFpm: null,
+        },
+      });
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "drone_traffic",
+        source: {
+          provider: "utm-hub",
+          sourceType: "remote_id",
+        },
+        observedAt: "2026-04-21T10:05:00.000Z",
+        geometry: {
+          type: "point",
+          lat: 51.5068,
+          lng: -0.1186,
+          altitudeMslFt: 390,
+        },
+        headingDegrees: 140,
+        speedKnots: 32,
+        metadata: {
+          trafficId: "drone-5005",
+          trackSource: "remote_id",
+          vehicleType: "multirotor",
+          operatorReference: "fleet-4",
+          verticalRateFpm: 90,
+        },
+      });
+
+    const listAllResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays`,
+    );
+
+    expect(listAllResponse.status).toBe(200);
+    expect(listAllResponse.body.overlays).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "weather" }),
+        expect.objectContaining({ kind: "crewed_traffic" }),
+        expect.objectContaining({ kind: "drone_traffic" }),
+      ]),
+    );
+  });
+
   it("returns 404 for missing missions on external overlay reads", async () => {
     const response = await request(app).get(
       `/missions/${randomUUID()}/external-overlays`,

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2007,5 +2007,8 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("crewedTrafficOverlays");
     expect(response.text).toContain("activeCrewedTrafficOverlays");
     expect(response.text).toContain("crewedTrafficSummary");
+    expect(response.text).toContain("droneTrafficOverlays");
+    expect(response.text).toContain("activeDroneTrafficOverlays");
+    expect(response.text).toContain("droneTrafficSummary");
   });
 });

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -93,6 +93,11 @@ const crewedTrafficOverlays = () =>
     (overlay) => overlay.kind === "crewed_traffic",
   );
 
+const droneTrafficOverlays = () =>
+  (uiState.externalOverlays ?? []).filter(
+    (overlay) => overlay.kind === "drone_traffic",
+  );
+
 const formatDateTime = (value) => {
   if (!value) {
     return "Not recorded";
@@ -300,6 +305,60 @@ const crewedTrafficSummary = () => {
     label: `${traffic.length} crewed traffic contact${traffic.length === 1 ? "" : "s"}`,
     tone: primary.severity ?? "info",
     detail: `${metadata.callsign ?? metadata.trafficId ?? "Unknown"} · ${primary.speedKnots ?? "?"} kt · ${primary.geometry?.altitudeMslFt ?? "?"} ft · observed ${formatDateTime(primary.observedAt)}`,
+  };
+};
+
+const activeDroneTrafficOverlays = () => {
+  const replayPoint = activeReplayPoint();
+  const replayTime = replayPoint?.timestamp ? Date.parse(replayPoint.timestamp) : null;
+
+  return droneTrafficOverlays()
+    .map((overlay) => {
+      const observedAt = Date.parse(overlay.observedAt ?? "");
+      const validFrom = overlay.validFrom ? Date.parse(overlay.validFrom) : observedAt;
+      const validTo = overlay.validTo ? Date.parse(overlay.validTo) : null;
+      const activeAtReplay =
+        replayTime != null &&
+        Number.isFinite(validFrom) &&
+        replayTime >= validFrom &&
+        (validTo == null || replayTime <= validTo);
+      const relativeMs =
+        replayTime == null || !Number.isFinite(observedAt)
+          ? Number.POSITIVE_INFINITY
+          : Math.abs(replayTime - observedAt);
+
+      return {
+        ...overlay,
+        activeAtReplay,
+        relativeMs,
+      };
+    })
+    .sort((left, right) => {
+      if (left.activeAtReplay !== right.activeAtReplay) {
+        return left.activeAtReplay ? -1 : 1;
+      }
+
+      return left.relativeMs - right.relativeMs;
+    })
+    .slice(0, 6);
+};
+
+const droneTrafficSummary = () => {
+  const traffic = activeDroneTrafficOverlays();
+  if (traffic.length === 0) {
+    return {
+      label: "Drone traffic missing",
+      tone: "warning",
+      detail: "No mission-linked drone traffic overlays are available for the current replay position.",
+    };
+  }
+
+  const primary = traffic[0];
+  const metadata = primary.metadata ?? {};
+  return {
+    label: `${traffic.length} drone traffic contact${traffic.length === 1 ? "" : "s"}`,
+    tone: primary.severity ?? "info",
+    detail: `${metadata.operatorReference ?? metadata.trafficId ?? "Unknown"} · ${primary.speedKnots ?? "?"} kt · ${primary.geometry?.altitudeMslFt ?? "?"} ft · observed ${formatDateTime(primary.observedAt)}`,
   };
 };
 
@@ -606,6 +665,7 @@ const buildOverlayCards = () => {
     summarizeDispatchState(dispatchWorkspace),
     weatherSummary(),
     crewedTrafficSummary(),
+    droneTrafficSummary(),
     summarizeTelemetryAlerts(uiState.alerts),
   ];
 
@@ -692,6 +752,9 @@ const renderOverview = () => {
   const activeTraffic = activeCrewedTrafficOverlays();
   const primaryTraffic = activeTraffic[0];
   const primaryTrafficMeta = primaryTraffic?.metadata ?? null;
+  const activeDroneTraffic = activeDroneTrafficOverlays();
+  const primaryDroneTraffic = activeDroneTraffic[0];
+  const primaryDroneMeta = primaryDroneTraffic?.metadata ?? null;
 
   overviewPanel.innerHTML = `
     <article class="metric">
@@ -758,6 +821,19 @@ const renderOverview = () => {
         primaryTrafficMeta
           ? `${primaryTrafficMeta.callsign ?? primaryTrafficMeta.trafficId ?? "Unknown"} at ${formatDateTime(primaryTraffic.observedAt)}`
           : "No crewed traffic overlay loaded for this mission.",
+      )}</div>
+    </article>
+    <article class="metric">
+      <div class="label">Drone traffic</div>
+      <div class="value ${toneClass(primaryDroneTraffic?.severity ?? "missing")}">${escapeHtml(
+        activeDroneTraffic.length === 0
+          ? "Missing"
+          : `${activeDroneTraffic.length} contact${activeDroneTraffic.length === 1 ? "" : "s"}`,
+      )}</div>
+      <div class="meta">${escapeHtml(
+        primaryDroneMeta
+          ? `${primaryDroneMeta.operatorReference ?? primaryDroneMeta.trafficId ?? "Unknown"} at ${formatDateTime(primaryDroneTraffic.observedAt)}`
+          : "No drone traffic overlay loaded for this mission.",
       )}</div>
     </article>
   `;
@@ -842,6 +918,7 @@ const buildMapMarkup = () => {
     summarizeAirspaceState(uiState.planningWorkspace).label,
     weatherOverlays().length > 0 ? `Weather overlays ${weatherOverlays().length}` : "Weather overlays 0",
     crewedTrafficOverlays().length > 0 ? `Crewed traffic ${crewedTrafficOverlays().length}` : "Crewed traffic 0",
+    droneTrafficOverlays().length > 0 ? `Drone traffic ${droneTrafficOverlays().length}` : "Drone traffic 0",
   ];
 
   const openAlerts = (uiState.alerts ?? []).filter((alert) => alert.status !== "resolved");
@@ -866,6 +943,7 @@ const buildMapMarkup = () => {
   const airspaceState = summarizeAirspaceState(uiState.planningWorkspace);
   const weatherState = weatherSummary();
   const trafficState = crewedTrafficSummary();
+  const droneState = droneTrafficSummary();
   const mapRiskSeverity = [highestAlertSeverity, readinessState.tone, dispatchState.tone, riskState.tone, airspaceState.tone]
     .sort((left, right) => severityRank(right) - severityRank(left))[0];
   const weatherOverlay = activeWeatherOverlay();
@@ -969,6 +1047,33 @@ const buildMapMarkup = () => {
       `;
     })
     .join("");
+  const droneTrafficMarkers = activeDroneTrafficOverlays()
+    .map((overlay) => {
+      const trafficPoint =
+        Number.isFinite(overlay.geometry?.lat) &&
+        Number.isFinite(overlay.geometry?.lng)
+          ? toPoint(Number(overlay.geometry.lat), Number(overlay.geometry.lng))
+          : null;
+
+      if (!trafficPoint) {
+        return "";
+      }
+
+      const metadata = overlay.metadata ?? {};
+      return `
+        <g>
+          <circle cx="${trafficPoint.x}" cy="${trafficPoint.y}" r="9" fill="rgba(34,197,94,0.16)" stroke="#22c55e" stroke-width="2" />
+          <rect x="${trafficPoint.x - 5}" y="${trafficPoint.y - 5}" width="10" height="10" rx="2" fill="#22c55e" opacity="0.94" />
+          <text x="${trafficPoint.x + 12}" y="${trafficPoint.y - 2}" fill="#f8fafc" font-size="11" font-weight="700">${escapeHtml(
+            metadata.operatorReference ?? metadata.trafficId ?? "Drone",
+          )}</text>
+          <text x="${trafficPoint.x + 12}" y="${trafficPoint.y + 12}" fill="#d8ecff" font-size="10">${escapeHtml(
+            `${overlay.geometry?.altitudeMslFt ?? "?"}ft · ${overlay.speedKnots ?? "?"}kt`,
+          )}</text>
+        </g>
+      `;
+    })
+    .join("");
 
   return `
     <div class="map-grid"></div>
@@ -989,6 +1094,7 @@ const buildMapMarkup = () => {
       ${replayDots}
       ${weatherMarker}
       ${crewedTrafficMarkers}
+      ${droneTrafficMarkers}
       ${
         currentMapPoint
           ? `
@@ -1136,6 +1242,32 @@ const renderStatus = () => {
           <div>${escapeHtml(
             activeCrewedTrafficOverlays()[0]
               ? formatDateTime(activeCrewedTrafficOverlays()[0].observedAt)
+              : "Not recorded",
+          )}</div>
+          <div class="k">Drone traffic</div>
+          <div>${renderBadge(droneState.label)}</div>
+          <div class="k">Primary drone</div>
+          <div>${escapeHtml(
+            activeDroneTrafficOverlays()[0]
+              ? `${activeDroneTrafficOverlays()[0].metadata?.operatorReference ?? activeDroneTrafficOverlays()[0].metadata?.trafficId ?? "Unknown"}`
+              : "Missing",
+          )}</div>
+          <div class="k">Vehicle / speed</div>
+          <div>${escapeHtml(
+            activeDroneTrafficOverlays()[0]
+              ? `${activeDroneTrafficOverlays()[0].metadata?.vehicleType ?? "Unknown"} · ${activeDroneTrafficOverlays()[0].speedKnots ?? "?"} kt`
+              : "Missing",
+          )}</div>
+          <div class="k">Altitude</div>
+          <div>${escapeHtml(
+            activeDroneTrafficOverlays()[0]
+              ? `${activeDroneTrafficOverlays()[0].geometry?.altitudeMslFt ?? "?"} ft`
+              : "Missing",
+          )}</div>
+          <div class="k">Observed</div>
+          <div>${escapeHtml(
+            activeDroneTrafficOverlays()[0]
+              ? formatDateTime(activeDroneTrafficOverlays()[0].observedAt)
               : "Not recorded",
           )}</div>
         </div>


### PR DESCRIPTION
## Summary

Implements GitHub issue #151 by extending the mission-linked external overlay boundary to support drone traffic and wiring it into the live operations view.

## What changed

- Extended the existing migration-backed external overlay model to support:
  - `drone_traffic`
- Kept the implementation on the existing mission-linked external overlay boundary:
  - `POST /missions/:missionId/external-overlays`
  - `GET /missions/:missionId/external-overlays`
- Added vendor-neutral drone traffic validation and storage for:
  - traffic identifier
  - source/provider metadata
  - observed time
  - position
  - altitude
  - heading
  - speed
  - optional operator reference
  - optional vehicle type
  - freshness / confidence
  - optional validity window
- Reused the existing migration-backed `mission_external_overlays` table rather than creating a second drone-specific store.
- Updated the operator live operations view to consume the shared external overlay path and display drone traffic context including:
  - drone markers on the map
  - operator / traffic identifier
  - vehicle type
  - speed
  - altitude
  - observation time
- Kept the operator live ops UI read-only.
- Preserved the existing weather and crewed traffic overlay paths while extending the boundary for drone traffic.
- Added integration coverage for:
  - drone traffic overlay creation
  - drone traffic overlay listing
  - mission isolation
  - mixed weather + crewed traffic + drone traffic listing
  - live ops bundle wiring for drone traffic rendering
- Updated the save point to the next implementation step:
  - mission-linked traffic conflict assessment on top of the raw overlay layer

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 7 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 22 files, 327 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

## Notes

This issue implements drone traffic only. It does not implement:
- conflict detection
- traffic collision avoidance logic
- advisory or avoidance commands

Closes #151.
