### PR TITLE
Add mission traffic conflict assessment

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
- "nextBuildStep": "Add mission-linked traffic conflict assessment on top of weather, crewed traffic, and drone traffic overlays without introducing operator command automation.",
+  "nextBuildStep": "Add mission-linked conflict advisory presentation in the live operations view without introducing operator command automation.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -66,6 +66,9 @@ import { ExternalOverlayRepository } from "./external-overlays/external-overlay.
 import { ExternalOverlayService } from "./external-overlays/external-overlay.service";
 import { ExternalOverlayController } from "./external-overlays/external-overlay.controller";
 import { createExternalOverlayRouter } from "./external-overlays/external-overlay.routes";
+import { TrafficConflictAssessmentService } from "./conflict-assessment/traffic-conflict-assessment.service";
+import { TrafficConflictAssessmentController } from "./conflict-assessment/traffic-conflict-assessment.controller";
+import { createTrafficConflictAssessmentRouter } from "./conflict-assessment/traffic-conflict-assessment.routes";
 
 dotenv.config({
   path: path.resolve(process.cwd(), ".env"),
@@ -206,6 +209,14 @@ const externalOverlayService = new ExternalOverlayService(
 const externalOverlayController = new ExternalOverlayController(
   externalOverlayService,
 );
+const trafficConflictAssessmentService = new TrafficConflictAssessmentService(
+  pool,
+  missionRepo,
+  missionTelemetryRepo,
+  externalOverlayRepository,
+);
+const trafficConflictAssessmentController =
+  new TrafficConflictAssessmentController(trafficConflictAssessmentService);
 
 app.use("/mission-plans", createMissionPlanningRouter(missionPlanningController));
 app.use("/sms", createSmsFrameworkRouter(smsFrameworkController));
@@ -216,6 +227,10 @@ app.use(
 app.use("/safety-events", createSafetyEventRouter(safetyEventController));
 app.use("/missions", createMissionRouter(missionController));
 app.use("/missions", createExternalOverlayRouter(externalOverlayController));
+app.use(
+  "/missions",
+  createTrafficConflictAssessmentRouter(trafficConflictAssessmentController),
+);
 app.use("/missions", createMissionRiskRouter(missionRiskController));
 app.use("/missions", createAirspaceComplianceRouter(airspaceComplianceController));
 app.use("/missions", createAuditEvidenceRouter(auditEvidenceController));

--- a/src/conflict-assessment/traffic-conflict-assessment.controller.ts
+++ b/src/conflict-assessment/traffic-conflict-assessment.controller.ts
@@ -1,0 +1,29 @@
+import type { NextFunction, Request, Response } from "express";
+import { TrafficConflictAssessmentService } from "./traffic-conflict-assessment.service";
+
+type MissionIdParams = {
+  missionId: string;
+};
+
+export class TrafficConflictAssessmentController {
+  constructor(
+    private readonly trafficConflictAssessmentService: TrafficConflictAssessmentService,
+  ) {}
+
+  getMissionConflictAssessment = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const assessment =
+        await this.trafficConflictAssessmentService.assessMission(
+          req.params.missionId,
+        );
+
+      res.status(200).json({ assessment });
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/conflict-assessment/traffic-conflict-assessment.routes.ts
+++ b/src/conflict-assessment/traffic-conflict-assessment.routes.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import { TrafficConflictAssessmentController } from "./traffic-conflict-assessment.controller";
+
+export function createTrafficConflictAssessmentRouter(
+  controller: TrafficConflictAssessmentController,
+): Router {
+  const router = Router();
+
+  router.get(
+    "/:missionId/conflict-assessment",
+    controller.getMissionConflictAssessment,
+  );
+
+  return router;
+}

--- a/src/conflict-assessment/traffic-conflict-assessment.service.ts
+++ b/src/conflict-assessment/traffic-conflict-assessment.service.ts
@@ -1,0 +1,360 @@
+import { randomUUID } from "crypto";
+import type { Pool } from "pg";
+import { ExternalOverlayRepository } from "../external-overlays/external-overlay.repository";
+import type {
+  CrewedTrafficOverlayMetadata,
+  DroneTrafficOverlayMetadata,
+  ExternalOverlay,
+  WeatherOverlayMetadata,
+} from "../external-overlays/external-overlay.types";
+import { MissionRepository } from "../missions/mission.repository";
+import { MissionTelemetryRepository } from "../missions/mission-telemetry.repository";
+import type { MissionTelemetryRow } from "../missions/mission-telemetry.types";
+import type {
+  MissionTrafficConflictAssessmentResult,
+  TrafficConflictAssessmentItem,
+  TrafficConflictReferencePoint,
+  TrafficConflictSeverity,
+  TrafficConflictStatus,
+} from "./traffic-conflict-assessment.types";
+
+const FEET_PER_METER = 3.28084;
+const EARTH_RADIUS_M = 6371000;
+
+const toRadians = (degrees: number): number => (degrees * Math.PI) / 180;
+
+const haversineMeters = (
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number,
+): number => {
+  const dLat = toRadians(lat2 - lat1);
+  const dLng = toRadians(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRadians(lat1)) *
+      Math.cos(toRadians(lat2)) *
+      Math.sin(dLng / 2) ** 2;
+
+  return 2 * EARTH_RADIUS_M * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+};
+
+const round = (value: number | null): number | null =>
+  value == null || Number.isNaN(value) ? null : Math.round(value);
+
+const severityRank = (severity: TrafficConflictSeverity): number => {
+  if (severity === "critical") return 3;
+  if (severity === "caution") return 2;
+  return 1;
+};
+
+const escalateSeverity = (
+  severity: TrafficConflictSeverity,
+  steps: number,
+): TrafficConflictSeverity => {
+  const ranked = Math.min(severityRank(severity) + steps, 3);
+
+  if (ranked >= 3) return "critical";
+  if (ranked === 2) return "caution";
+  return "info";
+};
+
+const trafficLabel = (overlay: ExternalOverlay): string => {
+  if (overlay.kind === "crewed_traffic") {
+    const metadata = overlay.metadata as unknown as CrewedTrafficOverlayMetadata;
+    return metadata.callsign ?? metadata.trafficId ?? "Crewed traffic";
+  }
+
+  const metadata = overlay.metadata as unknown as DroneTrafficOverlayMetadata;
+  return metadata.operatorReference ?? metadata.trafficId ?? "Drone traffic";
+};
+
+const weatherModifier = (
+  weatherOverlay: ExternalOverlay | null,
+): { steps: number; reason: string | null } => {
+  if (!weatherOverlay || weatherOverlay.kind !== "weather") {
+    return { steps: 0, reason: null };
+  }
+
+  const metadata = weatherOverlay.metadata as unknown as WeatherOverlayMetadata;
+  const wind = Number(metadata.windSpeedKnots ?? 0);
+  const precipitation = String(metadata.precipitation ?? "none");
+
+  if (wind >= 35 || ["hail", "snow", "mixed"].includes(precipitation)) {
+    return {
+      steps: 1,
+      reason: `weather escalation: ${wind} kt wind and ${precipitation} precipitation`,
+    };
+  }
+
+  if (wind >= 25 || precipitation !== "none") {
+    return {
+      steps: 1,
+      reason: `weather context: ${wind} kt wind and ${precipitation} precipitation`,
+    };
+  }
+
+  return { steps: 0, reason: null };
+};
+
+const activeWeatherOverlayAt = (
+  overlays: ExternalOverlay[],
+  referenceTimestamp: string,
+): ExternalOverlay | null => {
+  const referenceTime = Date.parse(referenceTimestamp);
+
+  if (!Number.isFinite(referenceTime)) {
+    return overlays.find((overlay) => overlay.kind === "weather") ?? null;
+  }
+
+  return (
+    overlays
+      .filter((overlay) => overlay.kind === "weather")
+      .map((overlay) => {
+        const observedAt = Date.parse(overlay.observedAt);
+        const validFrom = overlay.validFrom ? Date.parse(overlay.validFrom) : observedAt;
+        const validTo = overlay.validTo ? Date.parse(overlay.validTo) : null;
+        const active =
+          Number.isFinite(validFrom) &&
+          referenceTime >= validFrom &&
+          (validTo == null || referenceTime <= validTo);
+        const distance = Number.isFinite(observedAt)
+          ? Math.abs(referenceTime - observedAt)
+          : Number.POSITIVE_INFINITY;
+
+        return { overlay, active, distance };
+      })
+      .sort((left, right) => {
+        if (left.active !== right.active) {
+          return left.active ? -1 : 1;
+        }
+
+        return left.distance - right.distance;
+      })[0]?.overlay ?? null
+  );
+};
+
+const classifyTrafficConflict = (
+  overlay: ExternalOverlay,
+  lateralDistanceMeters: number | null,
+  altitudeDeltaFt: number | null,
+): { status: TrafficConflictStatus; severity: TrafficConflictSeverity } | null => {
+  if (lateralDistanceMeters == null) {
+    return null;
+  }
+
+  const altitude = altitudeDeltaFt ?? Number.POSITIVE_INFINITY;
+
+  if (overlay.kind === "drone_traffic") {
+    if (lateralDistanceMeters <= 250 && altitude <= 200) {
+      return { status: "conflict_candidate", severity: "critical" };
+    }
+    if (lateralDistanceMeters <= 600 && altitude <= 400) {
+      return { status: "conflict_candidate", severity: "caution" };
+    }
+    if (lateralDistanceMeters <= 1200 && altitude <= 800) {
+      return { status: "monitor", severity: "info" };
+    }
+    return null;
+  }
+
+  if (lateralDistanceMeters <= 800 && altitude <= 500) {
+    return { status: "conflict_candidate", severity: "critical" };
+  }
+  if (lateralDistanceMeters <= 2000 && altitude <= 1000) {
+    return { status: "conflict_candidate", severity: "caution" };
+  }
+  if (lateralDistanceMeters <= 4000 && altitude <= 2000) {
+    return { status: "monitor", severity: "info" };
+  }
+
+  return null;
+};
+
+const buildExplanation = (
+  overlay: ExternalOverlay,
+  lateralDistanceMeters: number | null,
+  altitudeDeltaFt: number | null,
+  weatherReason: string | null,
+): string => {
+  const base =
+    overlay.kind === "drone_traffic"
+      ? "Drone traffic proximity candidate"
+      : "Crewed traffic proximity candidate";
+  const lateral =
+    lateralDistanceMeters == null ? "unknown lateral distance" : `${round(lateralDistanceMeters)} m lateral separation`;
+  const vertical =
+    altitudeDeltaFt == null ? "unknown vertical separation" : `${round(altitudeDeltaFt)} ft vertical separation`;
+
+  return weatherReason
+    ? `${base}: ${lateral}, ${vertical}, ${weatherReason}.`
+    : `${base}: ${lateral}, ${vertical}.`;
+};
+
+const toReferenceTelemetry = (
+  row: MissionTelemetryRow | null,
+): TrafficConflictReferencePoint | null =>
+  row
+    ? {
+        timestamp: row.recordedAt.toISOString(),
+        lat: row.lat,
+        lng: row.lng,
+        altitudeM: row.altitudeM,
+        speedMps: row.speedMps,
+        headingDeg: row.headingDeg,
+        progressPct: row.progressPct,
+      }
+    : null;
+
+const isTrafficOverlay = (
+  overlay: ExternalOverlay,
+): overlay is ExternalOverlay & {
+  kind: "crewed_traffic" | "drone_traffic";
+} => overlay.kind === "crewed_traffic" || overlay.kind === "drone_traffic";
+
+export class TrafficConflictAssessmentService {
+  constructor(
+    private readonly pool: Pool,
+    private readonly missionRepository: MissionRepository,
+    private readonly missionTelemetryRepository: MissionTelemetryRepository,
+    private readonly externalOverlayRepository: ExternalOverlayRepository,
+  ) {}
+
+  async assessMission(
+    missionId: string,
+  ): Promise<MissionTrafficConflictAssessmentResult> {
+    const client = await this.pool.connect();
+
+    try {
+      await this.missionRepository.getById(client, missionId);
+
+      const replay = await this.missionTelemetryRepository.findReplayByMissionId(
+        missionId,
+        client,
+        {},
+      );
+      const latestTelemetry =
+        replay.at(-1) ??
+        (await this.missionTelemetryRepository.findLatestByMissionId(
+          missionId,
+          client,
+        ));
+      const overlays = await this.externalOverlayRepository.listForMission(
+        client,
+        missionId,
+      );
+
+      const referenceTimestamp =
+        latestTelemetry?.recordedAt.toISOString() ?? new Date().toISOString();
+      const assessedAt = new Date().toISOString();
+      const relevantWeather = activeWeatherOverlayAt(overlays, referenceTimestamp);
+      const weather = weatherModifier(relevantWeather);
+      const referenceLat = latestTelemetry?.lat;
+      const referenceLng = latestTelemetry?.lng;
+      const referenceAltitudeFt =
+        latestTelemetry?.altitudeM == null ? null : latestTelemetry.altitudeM * FEET_PER_METER;
+
+      const conflicts = overlays
+        .filter(isTrafficOverlay)
+        .map((overlay): TrafficConflictAssessmentItem | null => {
+          const lateralDistanceMeters =
+            referenceLat == null ||
+            referenceLng == null ||
+            overlay.geometry?.lat == null ||
+            overlay.geometry?.lng == null
+              ? null
+              : haversineMeters(
+                  referenceLat,
+                  referenceLng,
+                  overlay.geometry.lat,
+                  overlay.geometry.lng,
+                );
+
+          const altitudeDeltaFt =
+            referenceAltitudeFt == null || overlay.geometry.altitudeMslFt == null
+              ? null
+              : Math.abs(referenceAltitudeFt - overlay.geometry.altitudeMslFt);
+          const classification = classifyTrafficConflict(
+            overlay,
+            lateralDistanceMeters,
+            altitudeDeltaFt,
+          );
+
+          if (!classification) {
+            return null;
+          }
+
+          const observedAt = Date.parse(overlay.observedAt);
+          const referenceTime = Date.parse(referenceTimestamp);
+          const timeDeltaSeconds =
+            Number.isFinite(observedAt) && Number.isFinite(referenceTime)
+              ? Math.abs(referenceTime - observedAt) / 1000
+              : null;
+          const severity = escalateSeverity(
+            classification.severity,
+            weather.steps,
+          );
+          const overlayLabel = trafficLabel(overlay);
+
+          return {
+            id: randomUUID(),
+            missionId,
+            overlayId: overlay.id,
+            overlayKind: overlay.kind,
+            assessedAt,
+            referenceTimestamp,
+            overlayObservedAt: overlay.observedAt,
+            status: classification.status,
+            severity,
+            summary:
+              classification.status === "conflict_candidate"
+                ? `${overlayLabel} conflict candidate`
+                : `${overlayLabel} monitor candidate`,
+            explanation: buildExplanation(
+              overlay,
+              lateralDistanceMeters,
+              altitudeDeltaFt,
+              weather.reason,
+            ),
+            overlayLabel,
+            relatedSource: { ...overlay.source },
+            metrics: {
+              lateralDistanceMeters: round(lateralDistanceMeters),
+              altitudeDeltaFt: round(altitudeDeltaFt),
+              timeDeltaSeconds: round(timeDeltaSeconds),
+              overlayHeadingDegrees: overlay.headingDegrees,
+              overlaySpeedKnots: overlay.speedKnots,
+            },
+          };
+        })
+        .filter(
+          (item): item is TrafficConflictAssessmentItem => item !== null,
+        )
+        .sort((left, right) => {
+          const severityDiff = severityRank(right.severity) - severityRank(left.severity);
+          if (severityDiff !== 0) {
+            return severityDiff;
+          }
+
+          const leftDistance = left.metrics.lateralDistanceMeters ?? Number.POSITIVE_INFINITY;
+          const rightDistance =
+            right.metrics.lateralDistanceMeters ?? Number.POSITIVE_INFINITY;
+
+          return leftDistance - rightDistance;
+        });
+
+      return {
+        missionId,
+        assessedAt,
+        reference: {
+          replayPointCount: replay.length,
+          telemetry: toReferenceTelemetry(latestTelemetry),
+        },
+        conflicts,
+      };
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/src/conflict-assessment/traffic-conflict-assessment.types.ts
+++ b/src/conflict-assessment/traffic-conflict-assessment.types.ts
@@ -1,0 +1,52 @@
+import type { ExternalOverlayKind } from "../external-overlays/external-overlay.types";
+
+export type TrafficConflictStatus = "monitor" | "conflict_candidate";
+
+export type TrafficConflictSeverity = "info" | "caution" | "critical";
+
+export interface TrafficConflictReferencePoint {
+  timestamp: string;
+  lat: number | null;
+  lng: number | null;
+  altitudeM: number | null;
+  speedMps: number | null;
+  headingDeg: number | null;
+  progressPct: number | null;
+}
+
+export interface TrafficConflictAssessmentItem {
+  id: string;
+  missionId: string;
+  overlayId: string;
+  overlayKind: Extract<ExternalOverlayKind, "crewed_traffic" | "drone_traffic">;
+  assessedAt: string;
+  referenceTimestamp: string;
+  overlayObservedAt: string;
+  status: TrafficConflictStatus;
+  severity: TrafficConflictSeverity;
+  summary: string;
+  explanation: string;
+  overlayLabel: string;
+  relatedSource: {
+    provider: string;
+    sourceType: string;
+    sourceRecordId: string | null;
+  };
+  metrics: {
+    lateralDistanceMeters: number | null;
+    altitudeDeltaFt: number | null;
+    timeDeltaSeconds: number | null;
+    overlayHeadingDegrees: number | null;
+    overlaySpeedKnots: number | null;
+  };
+}
+
+export interface MissionTrafficConflictAssessmentResult {
+  missionId: string;
+  assessedAt: string;
+  reference: {
+    replayPointCount: number;
+    telemetry: TrafficConflictReferencePoint | null;
+  };
+  conflicts: TrafficConflictAssessmentItem[];
+}

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -1929,6 +1929,7 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("Map and Replay Surface");
     expect(response.text).toContain("Telemetry and Risk Status");
     expect(response.text).toContain("Alert Timeline Correlation");
+    expect(response.text).toContain("Conflict Assessment");
     expect(response.text).toContain("live-ops-replay-play-btn");
     expect(response.text).toContain("live-ops-replay-slider");
     expect(response.text).toContain("live-ops-replay-markers");
@@ -1977,6 +1978,7 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("/missions/${missionId}/telemetry/latest");
     expect(response.text).toContain("/missions/${missionId}/alerts");
     expect(response.text).toContain("/missions/${missionId}/external-overlays");
+    expect(response.text).toContain("/missions/${missionId}/conflict-assessment");
     expect(response.text).toContain("/missions/${missionId}/planning-workspace");
     expect(response.text).toContain("/missions/${missionId}/dispatch-workspace");
     expect(response.text).toContain("/missions/${missionId}/operations-timeline");
@@ -2010,5 +2012,7 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("droneTrafficOverlays");
     expect(response.text).toContain("activeDroneTrafficOverlays");
     expect(response.text).toContain("droneTrafficSummary");
+    expect(response.text).toContain("conflictAssessmentSummary");
+    expect(response.text).toContain("renderConflictAssessment");
   });
 });

--- a/src/tests/traffic-conflict-assessment.test.ts
+++ b/src/tests/traffic-conflict-assessment.test.ts
@@ -1,0 +1,250 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import { randomUUID } from "crypto";
+import app, { pool } from "../app";
+import { runMigrations } from "../migrations/runMigrations";
+
+const clearTables = async () => {
+  await pool.query("delete from mission_external_overlays");
+  await pool.query("delete from mission_telemetry");
+  await pool.query("delete from mission_planning_approval_handoffs");
+  await pool.query("delete from mission_decision_evidence_links");
+  await pool.query("delete from audit_evidence_snapshots");
+  await pool.query("delete from airspace_compliance_inputs");
+  await pool.query("delete from mission_risk_inputs");
+  await pool.query("delete from mission_events");
+  await pool.query("delete from missions");
+};
+
+const createMission = async () => {
+  const response = await request(app).post("/mission-plans/drafts").send({});
+  expect(response.status).toBe(201);
+  return response.body.draft.missionId as string;
+};
+
+const recordTelemetry = async (missionId: string) => {
+  await pool.query(
+    `
+    insert into mission_telemetry (
+      id,
+      mission_id,
+      recorded_at,
+      lat,
+      lng,
+      altitude_m,
+      speed_mps,
+      heading_deg,
+      progress_pct,
+      payload
+    )
+    values (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7, $8, '{}'::jsonb)
+    `,
+    [missionId, "2026-04-21T12:00:00.000Z", 51.5074, -0.1278, 120, 15, 90, 40],
+  );
+};
+
+describe("traffic conflict assessment integration", () => {
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  beforeEach(async () => {
+    await clearTables();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("returns no conflicts when a mission has telemetry but no traffic overlays", async () => {
+    const missionId = await createMission();
+    await recordTelemetry(missionId);
+
+    const response = await request(app).get(
+      `/missions/${missionId}/conflict-assessment`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.assessment).toMatchObject({
+      missionId,
+      reference: {
+        replayPointCount: 1,
+        telemetry: expect.objectContaining({
+          timestamp: "2026-04-21T12:00:00.000Z",
+        }),
+      },
+      conflicts: [],
+    });
+  });
+
+  it("assesses crewed and drone traffic conflict candidates without mutating raw overlay records", async () => {
+    const missionId = await createMission();
+    await recordTelemetry(missionId);
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "weather",
+        source: {
+          provider: "met-office",
+          sourceType: "surface_observation",
+        },
+        observedAt: "2026-04-21T12:00:00.000Z",
+        geometry: {
+          type: "point",
+          lat: 51.5074,
+          lng: -0.1278,
+        },
+        severity: "caution",
+        metadata: {
+          windSpeedKnots: 28,
+          windDirectionDegrees: 235,
+          temperatureC: 9,
+          precipitation: "rain",
+        },
+      });
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "crewed_traffic",
+        source: {
+          provider: "traffic-hub",
+          sourceType: "adsb_exchange",
+        },
+        observedAt: "2026-04-21T12:00:30.000Z",
+        geometry: {
+          type: "point",
+          lat: 51.5125,
+          lng: -0.1218,
+          altitudeMslFt: 620,
+        },
+        headingDegrees: 110,
+        speedKnots: 145,
+        metadata: {
+          trafficId: "crewed-22",
+          callsign: "HELIMED21",
+          trackSource: "adsb_exchange",
+          aircraftCategory: "helicopter",
+          verticalRateFpm: 150,
+        },
+      });
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "drone_traffic",
+        source: {
+          provider: "utm-hub",
+          sourceType: "remote_id",
+        },
+        observedAt: "2026-04-21T12:00:15.000Z",
+        geometry: {
+          type: "point",
+          lat: 51.5077,
+          lng: -0.1275,
+          altitudeMslFt: 410,
+        },
+        headingDegrees: 38,
+        speedKnots: 24,
+        metadata: {
+          trafficId: "drone-44",
+          trackSource: "remote_id",
+          vehicleType: "multirotor",
+          operatorReference: "op-44",
+          verticalRateFpm: 80,
+        },
+      });
+
+    const before = await pool.query<{
+      mission_id: string;
+      overlay_kind: string;
+    }>("select mission_id, overlay_kind from mission_external_overlays order by id");
+
+    const response = await request(app).get(
+      `/missions/${missionId}/conflict-assessment`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.assessment.conflicts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          missionId,
+          overlayKind: "crewed_traffic",
+          overlayLabel: "HELIMED21",
+        }),
+        expect.objectContaining({
+          missionId,
+          overlayKind: "drone_traffic",
+          overlayLabel: "op-44",
+        }),
+      ]),
+    );
+    expect(
+      response.body.assessment.conflicts.every(
+        (item: { status: string }) =>
+          item.status === "monitor" || item.status === "conflict_candidate",
+      ),
+    ).toBe(true);
+
+    const after = await pool.query<{
+      mission_id: string;
+      overlay_kind: string;
+    }>("select mission_id, overlay_kind from mission_external_overlays order by id");
+
+    expect(after.rows).toEqual(before.rows);
+  });
+
+  it("preserves mission isolation for conflict assessment reads", async () => {
+    const firstMissionId = await createMission();
+    const secondMissionId = await createMission();
+    await recordTelemetry(firstMissionId);
+    await recordTelemetry(secondMissionId);
+
+    await request(app)
+      .post(`/missions/${secondMissionId}/external-overlays`)
+      .send({
+        kind: "drone_traffic",
+        source: {
+          provider: "utm-hub",
+          sourceType: "remote_id",
+        },
+        observedAt: "2026-04-21T12:00:15.000Z",
+        geometry: {
+          type: "point",
+          lat: 51.5077,
+          lng: -0.1275,
+          altitudeMslFt: 410,
+        },
+        headingDegrees: 38,
+        speedKnots: 24,
+        metadata: {
+          trafficId: "drone-44",
+          trackSource: "remote_id",
+          vehicleType: "multirotor",
+          operatorReference: "op-44",
+          verticalRateFpm: 80,
+        },
+      });
+
+    const response = await request(app).get(
+      `/missions/${firstMissionId}/conflict-assessment`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.assessment.conflicts).toEqual([]);
+  });
+
+  it("returns 404 for missing missions on conflict assessment reads", async () => {
+    const response = await request(app).get(
+      `/missions/${randomUUID()}/conflict-assessment`,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: {
+        type: "mission_not_found",
+      },
+    });
+  });
+});

--- a/static/operator-live-operations-map.html
+++ b/static/operator-live-operations-map.html
@@ -621,6 +621,13 @@
           </div>
           <div class="panel">
             <div class="panel-header">
+              <h3>Conflict Assessment</h3>
+              <p>Interpreted crewed and drone traffic proximity candidates over the current mission track.</p>
+            </div>
+            <div id="live-ops-conflict-assessment" class="panel-body"></div>
+          </div>
+          <div class="panel">
+            <div class="panel-header">
               <h3>Event Context</h3>
               <p>Recent mission narrative items to keep flight picture and timeline context together.</p>
             </div>

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -9,6 +9,7 @@ const mapPanel = document.getElementById("live-ops-map");
 const statusPanel = document.getElementById("live-ops-status");
 const timelinePanel = document.getElementById("live-ops-timeline");
 const alertCorrelationPanel = document.getElementById("live-ops-alert-correlation");
+const conflictAssessmentPanel = document.getElementById("live-ops-conflict-assessment");
 const jumpControlsPanel = document.getElementById("live-ops-jump-controls");
 const replayPlayButton = document.getElementById("live-ops-replay-play-btn");
 const replayPauseButton = document.getElementById("live-ops-replay-pause-btn");
@@ -29,6 +30,7 @@ const uiState = {
   latestTelemetry: null,
   alerts: [],
   externalOverlays: [],
+  conflictAssessment: null,
   replayPlayback: {
     index: 0,
     playing: false,
@@ -362,6 +364,57 @@ const droneTrafficSummary = () => {
   };
 };
 
+const currentConflictAssessment = () => uiState.conflictAssessment?.assessment ?? null;
+
+const conflictAssessmentItems = () =>
+  currentConflictAssessment()?.conflicts ?? [];
+
+const activeConflictAssessmentItems = () => {
+  const replayPoint = activeReplayPoint();
+  const replayTime = replayPoint?.timestamp ? Date.parse(replayPoint.timestamp) : null;
+
+  return conflictAssessmentItems()
+    .map((conflict) => {
+      const conflictTime = Date.parse(conflict.referenceTimestamp ?? "");
+      const timeDeltaSeconds =
+        replayTime != null && Number.isFinite(conflictTime)
+          ? Math.abs(replayTime - conflictTime) / 1000
+          : conflict.metrics?.timeDeltaSeconds ?? Number.POSITIVE_INFINITY;
+
+      return {
+        ...conflict,
+        replayRelevant: timeDeltaSeconds <= 600,
+        replayTimeDeltaSeconds: Math.round(timeDeltaSeconds),
+      };
+    })
+    .sort((left, right) => {
+      if (left.replayRelevant !== right.replayRelevant) {
+        return left.replayRelevant ? -1 : 1;
+      }
+
+      const order = { critical: 3, caution: 2, info: 1 };
+      return (order[right.severity] ?? 0) - (order[left.severity] ?? 0);
+    });
+};
+
+const conflictAssessmentSummary = () => {
+  const conflicts = activeConflictAssessmentItems();
+  if (conflicts.length === 0) {
+    return {
+      label: "Conflict assessment clear",
+      tone: "pass",
+      detail: "No current traffic conflict candidates are assessed for the selected mission context.",
+    };
+  }
+
+  const highest = conflicts[0];
+  return {
+    label: `${conflicts.length} conflict candidate${conflicts.length === 1 ? "" : "s"}`,
+    tone: highest.severity,
+    detail: `${highest.overlayLabel} · ${highest.metrics?.lateralDistanceMeters ?? "?"} m lateral · ${highest.metrics?.altitudeDeltaFt ?? "?"} ft vertical`,
+  };
+};
+
 const replayTrack = () =>
   (uiState.replay?.replay ?? []).filter(
     (point) => Number.isFinite(point?.lat) && Number.isFinite(point?.lng),
@@ -667,6 +720,7 @@ const buildOverlayCards = () => {
     crewedTrafficSummary(),
     droneTrafficSummary(),
     summarizeTelemetryAlerts(uiState.alerts),
+    conflictAssessmentSummary(),
   ];
 
   return cards
@@ -755,6 +809,8 @@ const renderOverview = () => {
   const activeDroneTraffic = activeDroneTrafficOverlays();
   const primaryDroneTraffic = activeDroneTraffic[0];
   const primaryDroneMeta = primaryDroneTraffic?.metadata ?? null;
+  const conflicts = activeConflictAssessmentItems();
+  const primaryConflict = conflicts[0];
 
   overviewPanel.innerHTML = `
     <article class="metric">
@@ -834,6 +890,19 @@ const renderOverview = () => {
         primaryDroneMeta
           ? `${primaryDroneMeta.operatorReference ?? primaryDroneMeta.trafficId ?? "Unknown"} at ${formatDateTime(primaryDroneTraffic.observedAt)}`
           : "No drone traffic overlay loaded for this mission.",
+      )}</div>
+    </article>
+    <article class="metric">
+      <div class="label">Conflict assessment</div>
+      <div class="value ${toneClass(primaryConflict?.severity ?? "clear")}">${escapeHtml(
+        conflicts.length === 0
+          ? "Clear"
+          : `${conflicts.length} candidate${conflicts.length === 1 ? "" : "s"}`,
+      )}</div>
+      <div class="meta">${escapeHtml(
+        primaryConflict
+          ? `${primaryConflict.overlayLabel} at ${primaryConflict.metrics?.lateralDistanceMeters ?? "?"} m lateral / ${primaryConflict.metrics?.altitudeDeltaFt ?? "?"} ft vertical`
+          : "No current interpreted traffic conflict candidates.",
       )}</div>
     </article>
   `;
@@ -1128,9 +1197,17 @@ const renderStatus = () => {
   const dispatchWorkspace = uiState.dispatchWorkspace;
   const currentReplayPoint = activeReplayPoint();
   const latestTelemetry = uiState.latestTelemetry?.telemetry;
+  const weatherState = weatherSummary();
+  const trafficState = crewedTrafficSummary();
+  const droneState = droneTrafficSummary();
+  const conflictState = conflictAssessmentSummary();
   const alertSignals = (uiState.alerts ?? []).map((alert) => ({
     label: `${alert.alertType} - ${alert.severity}`,
     value: `${alert.status}: ${alert.message}`,
+  }));
+  const conflictSignals = activeConflictAssessmentItems().map((conflict) => ({
+    label: `${conflict.overlayKind} ${conflict.severity}`,
+    value: `${conflict.summary}: ${conflict.explanation}`,
   }));
   const riskSignals = [
     ...((planningWorkspace.blockingReasons ?? []).map((reason) => ({
@@ -1146,6 +1223,7 @@ const renderStatus = () => {
       value: reason,
     }))),
     ...alertSignals,
+    ...conflictSignals,
   ];
 
   statusPanel.innerHTML = `
@@ -1270,6 +1348,24 @@ const renderStatus = () => {
               ? formatDateTime(activeDroneTrafficOverlays()[0].observedAt)
               : "Not recorded",
           )}</div>
+          <div class="k">Conflict assessment</div>
+          <div>${renderBadge(conflictState.label)}</div>
+          <div class="k">Primary conflict</div>
+          <div>${escapeHtml(
+            activeConflictAssessmentItems()[0]?.overlayLabel ?? "Clear",
+          )}</div>
+          <div class="k">Separation</div>
+          <div>${escapeHtml(
+            activeConflictAssessmentItems()[0]
+              ? `${activeConflictAssessmentItems()[0].metrics?.lateralDistanceMeters ?? "?"} m · ${activeConflictAssessmentItems()[0].metrics?.altitudeDeltaFt ?? "?"} ft`
+              : "Not recorded",
+          )}</div>
+          <div class="k">Assessment time</div>
+          <div>${escapeHtml(
+            activeConflictAssessmentItems()[0]
+              ? formatDateTime(activeConflictAssessmentItems()[0].assessedAt)
+              : "Not recorded",
+          )}</div>
         </div>
       </section>
     </div>
@@ -1381,6 +1477,60 @@ const renderAlertCorrelation = () => {
   `;
 };
 
+const renderConflictAssessment = () => {
+  const assessment = currentConflictAssessment();
+  const conflicts = activeConflictAssessmentItems();
+
+  if (!assessment) {
+    conflictAssessmentPanel.innerHTML =
+      '<div class="empty-state">Conflict assessment has not been loaded for this mission yet.</div>';
+    return;
+  }
+
+  if (conflicts.length === 0) {
+    conflictAssessmentPanel.innerHTML = `
+      <div class="empty-state">
+        No interpreted crewed or drone traffic conflict candidates are currently assessed.
+        Reference telemetry: ${escapeHtml(formatDateTime(assessment.reference?.telemetry?.timestamp))}
+      </div>
+    `;
+    return;
+  }
+
+  conflictAssessmentPanel.innerHTML = `
+    <div class="stack">
+      <section class="correlation-card">
+        <h4>Assessment Reference</h4>
+        <div class="kv">
+          <div class="k">Assessed at</div>
+          <div>${escapeHtml(formatDateTime(assessment.assessedAt))}</div>
+          <div class="k">Reference telemetry</div>
+          <div>${escapeHtml(formatDateTime(assessment.reference?.telemetry?.timestamp))}</div>
+          <div class="k">Replay points</div>
+          <div>${escapeHtml(String(assessment.reference?.replayPointCount ?? 0))}</div>
+        </div>
+      </section>
+      ${conflicts
+        .slice(0, 6)
+        .map(
+          (conflict) => `
+            <article class="alert-window ${toneClass(conflict.severity)}">
+              <strong>${escapeHtml(conflict.summary)}</strong>
+              <div>${escapeHtml(conflict.explanation)}</div>
+              <div class="alert-window-meta">
+                Source: ${escapeHtml(conflict.relatedSource.provider)} / ${escapeHtml(conflict.relatedSource.sourceType)}<br />
+                Observed: ${escapeHtml(formatDateTime(conflict.overlayObservedAt))}<br />
+                Separation: ${escapeHtml(`${conflict.metrics?.lateralDistanceMeters ?? "?"} m lateral · ${conflict.metrics?.altitudeDeltaFt ?? "?"} ft vertical`)}<br />
+                Replay relevance: ${escapeHtml(conflict.replayRelevant ? "Current replay window" : `${conflict.replayTimeDeltaSeconds} s from replay cursor`)}
+              </div>
+            </article>
+          `,
+        )
+        .join("")}
+    </div>
+  `;
+};
+
 const renderTimeline = () => {
   const items = uiState.timeline?.items ?? [];
   const relevant = items.slice(-8).reverse();
@@ -1423,6 +1573,7 @@ const renderLiveOperations = () => {
   renderJumpControls();
   renderStatus();
   renderAlertCorrelation();
+  renderConflictAssessment();
   renderTimeline();
 };
 
@@ -1432,6 +1583,7 @@ const clearPanels = (message) => {
   jumpControlsPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
   statusPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
   alertCorrelationPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
+  conflictAssessmentPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
   timelinePanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
   renderReplayControls();
 };
@@ -1448,6 +1600,7 @@ const loadLiveOperationsView = async (missionId) => {
     uiState.latestTelemetry = null;
     uiState.alerts = [];
     uiState.externalOverlays = [];
+    uiState.conflictAssessment = null;
     uiState.replayPlayback.index = 0;
     setLoadedMission("");
     setConnectionState("Enter a mission UUID", "tone-warn");
@@ -1469,6 +1622,7 @@ const loadLiveOperationsView = async (missionId) => {
       latestTelemetryResponse,
       alertsResponse,
       externalOverlayResponse,
+      conflictAssessmentResponse,
     ] = await Promise.all([
       fetchJson(`/missions/${missionId}/planning-workspace`),
       fetchJson(`/missions/${missionId}/dispatch-workspace`),
@@ -1477,6 +1631,7 @@ const loadLiveOperationsView = async (missionId) => {
       fetchJson(`/missions/${missionId}/telemetry/latest`),
       fetchJson(`/missions/${missionId}/alerts`),
       fetchJson(`/missions/${missionId}/external-overlays`),
+      fetchJson(`/missions/${missionId}/conflict-assessment`),
     ]);
 
     uiState.planningWorkspace = planningResponse.workspace;
@@ -1486,6 +1641,7 @@ const loadLiveOperationsView = async (missionId) => {
     uiState.latestTelemetry = latestTelemetryResponse;
     uiState.alerts = alertsResponse.alerts ?? [];
     uiState.externalOverlays = externalOverlayResponse.overlays ?? [];
+    uiState.conflictAssessment = conflictAssessmentResponse;
     uiState.replayPlayback.index = 0;
     renderLiveOperations();
     setConnectionState("Live operations view loaded", "tone-ok");
@@ -1499,6 +1655,7 @@ const loadLiveOperationsView = async (missionId) => {
     uiState.latestTelemetry = null;
     uiState.alerts = [];
     uiState.externalOverlays = [];
+    uiState.conflictAssessment = null;
     uiState.replayPlayback.index = 0;
     clearPanels(message);
     setConnectionState(message, "tone-bad");


### PR DESCRIPTION
## Summary

Implements GitHub issue #153 by adding mission-linked traffic conflict assessment on top of weather, crewed traffic, and drone traffic overlays without introducing operator command automation.

## What changed

- Added a dedicated read-only conflict assessment endpoint:
  - `GET /missions/:missionId/conflict-assessment`
- Kept the interpreted conflict layer separate from:
  - raw external overlay records
  - advisory generation
  - mission command/action flows
- Built conflict assessment on top of existing mission-linked state:
  - mission telemetry / replay
  - weather overlays
  - crewed traffic overlays
  - drone traffic overlays
- Added conflict assessment output including:
  - assessed overlay kind
  - related overlay id
  - mission id
  - assessment timestamp
  - conflict status
  - severity
  - summary / explanation
  - distance, altitude, and timing metrics
- Used the existing weather overlay as contextual severity escalation only; no advisory or command automation was introduced.
- Extended the operator live operations view to load and render conflict assessment results through the existing review surface.
- Added a dedicated `Conflict Assessment` panel plus summary-state integration into the live ops screen.
- Kept the operator UI read-only.
- Added integration coverage for:
  - empty conflict assessment
  - crewed/drone conflict candidate assessment
  - mission isolation
  - missing mission handling
  - no mutation of raw overlay records
- Updated the save point to the next implementation step:
  - conflict advisory presentation without operator command automation

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 4 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 331 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

## Notes

This issue adds interpreted conflict assessment only. It does not implement:
- conflict advisory generation
- traffic collision avoidance commands
- operator command automation
- lifecycle auto-transitions

Closes #153.
