### PR TITLE
Add live operations conflict advisory presentation

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add mission-linked conflict advisory presentation in the live operations view without introducing operator command automation.",
+  "nextBuildStep": "Add mission-linked conflict replay correlation and timeline emphasis in the live operations view without introducing operator command automation.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -1930,6 +1930,7 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("Telemetry and Risk Status");
     expect(response.text).toContain("Alert Timeline Correlation");
     expect(response.text).toContain("Conflict Assessment");
+    expect(response.text).toContain("Conflict Advisory Guidance");
     expect(response.text).toContain("live-ops-replay-play-btn");
     expect(response.text).toContain("live-ops-replay-slider");
     expect(response.text).toContain("live-ops-replay-markers");
@@ -2013,6 +2014,8 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("activeDroneTrafficOverlays");
     expect(response.text).toContain("droneTrafficSummary");
     expect(response.text).toContain("conflictAssessmentSummary");
+    expect(response.text).toContain("conflictAdvisorySummary");
     expect(response.text).toContain("renderConflictAssessment");
+    expect(response.text).toContain("renderConflictAdvisory");
   });
 });

--- a/static/operator-live-operations-map.html
+++ b/static/operator-live-operations-map.html
@@ -628,6 +628,13 @@
           </div>
           <div class="panel">
             <div class="panel-header">
+              <h3>Conflict Advisory Guidance</h3>
+              <p>Presentation-only operator guidance derived from the current interpreted conflict picture.</p>
+            </div>
+            <div id="live-ops-conflict-advisory" class="panel-body"></div>
+          </div>
+          <div class="panel">
+            <div class="panel-header">
               <h3>Event Context</h3>
               <p>Recent mission narrative items to keep flight picture and timeline context together.</p>
             </div>

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -10,6 +10,7 @@ const statusPanel = document.getElementById("live-ops-status");
 const timelinePanel = document.getElementById("live-ops-timeline");
 const alertCorrelationPanel = document.getElementById("live-ops-alert-correlation");
 const conflictAssessmentPanel = document.getElementById("live-ops-conflict-assessment");
+const conflictAdvisoryPanel = document.getElementById("live-ops-conflict-advisory");
 const jumpControlsPanel = document.getElementById("live-ops-jump-controls");
 const replayPlayButton = document.getElementById("live-ops-replay-play-btn");
 const replayPauseButton = document.getElementById("live-ops-replay-pause-btn");
@@ -415,6 +416,54 @@ const conflictAssessmentSummary = () => {
   };
 };
 
+const deriveConflictAdvisories = () =>
+  activeConflictAssessmentItems().slice(0, 5).map((conflict) => {
+    let headline = "Monitor traffic proximity";
+    let recommendation = "Monitor";
+
+    if (conflict.severity === "critical") {
+      headline = "Immediate deconfliction review";
+      recommendation = "Review immediately";
+    } else if (conflict.severity === "caution") {
+      headline = "Deconfliction review recommended";
+      recommendation = "Deconflict";
+    }
+
+    const replayRelevance = conflict.replayRelevant
+      ? "Current replay window"
+      : `${conflict.replayTimeDeltaSeconds} s from replay cursor`;
+
+    return {
+      id: conflict.id,
+      tone: conflict.severity,
+      headline,
+      recommendation,
+      relatedObject: conflict.overlayLabel,
+      relatedSource: `${conflict.relatedSource.provider} / ${conflict.relatedSource.sourceType}`,
+      reasoning: conflict.explanation,
+      relevance: replayRelevance,
+      summary: `${conflict.metrics?.lateralDistanceMeters ?? "?"} m lateral · ${conflict.metrics?.altitudeDeltaFt ?? "?"} ft vertical`,
+    };
+  });
+
+const conflictAdvisorySummary = () => {
+  const advisories = deriveConflictAdvisories();
+  if (advisories.length === 0) {
+    return {
+      label: "Advisory layer clear",
+      tone: "pass",
+      detail: "No conflict advisory presentation is currently required.",
+    };
+  }
+
+  const primary = advisories[0];
+  return {
+    label: `${advisories.length} advisory item${advisories.length === 1 ? "" : "s"}`,
+    tone: primary.tone,
+    detail: `${primary.recommendation} · ${primary.relatedObject} · ${primary.summary}`,
+  };
+};
+
 const replayTrack = () =>
   (uiState.replay?.replay ?? []).filter(
     (point) => Number.isFinite(point?.lat) && Number.isFinite(point?.lng),
@@ -721,6 +770,7 @@ const buildOverlayCards = () => {
     droneTrafficSummary(),
     summarizeTelemetryAlerts(uiState.alerts),
     conflictAssessmentSummary(),
+    conflictAdvisorySummary(),
   ];
 
   return cards
@@ -811,6 +861,8 @@ const renderOverview = () => {
   const primaryDroneMeta = primaryDroneTraffic?.metadata ?? null;
   const conflicts = activeConflictAssessmentItems();
   const primaryConflict = conflicts[0];
+  const advisories = deriveConflictAdvisories();
+  const primaryAdvisory = advisories[0];
 
   overviewPanel.innerHTML = `
     <article class="metric">
@@ -903,6 +955,19 @@ const renderOverview = () => {
         primaryConflict
           ? `${primaryConflict.overlayLabel} at ${primaryConflict.metrics?.lateralDistanceMeters ?? "?"} m lateral / ${primaryConflict.metrics?.altitudeDeltaFt ?? "?"} ft vertical`
           : "No current interpreted traffic conflict candidates.",
+      )}</div>
+    </article>
+    <article class="metric">
+      <div class="label">Conflict advisory</div>
+      <div class="value ${toneClass(primaryAdvisory?.tone ?? "clear")}">${escapeHtml(
+        advisories.length === 0
+          ? "Clear"
+          : primaryAdvisory.recommendation,
+      )}</div>
+      <div class="meta">${escapeHtml(
+        primaryAdvisory
+          ? `${primaryAdvisory.relatedObject} · ${primaryAdvisory.summary}`
+          : "No advisory-grade conflict presentation is currently required.",
       )}</div>
     </article>
   `;
@@ -1201,6 +1266,7 @@ const renderStatus = () => {
   const trafficState = crewedTrafficSummary();
   const droneState = droneTrafficSummary();
   const conflictState = conflictAssessmentSummary();
+  const advisoryState = conflictAdvisorySummary();
   const alertSignals = (uiState.alerts ?? []).map((alert) => ({
     label: `${alert.alertType} - ${alert.severity}`,
     value: `${alert.status}: ${alert.message}`,
@@ -1365,6 +1431,16 @@ const renderStatus = () => {
             activeConflictAssessmentItems()[0]
               ? formatDateTime(activeConflictAssessmentItems()[0].assessedAt)
               : "Not recorded",
+          )}</div>
+          <div class="k">Advisory presentation</div>
+          <div>${renderBadge(advisoryState.label)}</div>
+          <div class="k">Recommended attention</div>
+          <div>${escapeHtml(
+            deriveConflictAdvisories()[0]?.recommendation ?? "Clear",
+          )}</div>
+          <div class="k">Advisory target</div>
+          <div>${escapeHtml(
+            deriveConflictAdvisories()[0]?.relatedObject ?? "None",
           )}</div>
         </div>
       </section>
@@ -1531,6 +1607,36 @@ const renderConflictAssessment = () => {
   `;
 };
 
+const renderConflictAdvisory = () => {
+  const advisories = deriveConflictAdvisories();
+
+  if (advisories.length === 0) {
+    conflictAdvisoryPanel.innerHTML =
+      '<div class="empty-state">No advisory presentation is currently required. The live operations view remains read-only and no automated action is available here.</div>';
+    return;
+  }
+
+  conflictAdvisoryPanel.innerHTML = `
+    <div class="stack">
+      ${advisories.map(
+        (advisory) => `
+          <article class="alert-window ${toneClass(advisory.tone)}">
+            <strong>${escapeHtml(advisory.headline)}</strong>
+            <div>${escapeHtml(advisory.reasoning)}</div>
+            <div class="alert-window-meta">
+              Recommended attention: ${escapeHtml(advisory.recommendation)}<br />
+              Related object: ${escapeHtml(advisory.relatedObject)}<br />
+              Related source: ${escapeHtml(advisory.relatedSource)}<br />
+              Relevance: ${escapeHtml(advisory.relevance)}<br />
+              Separation: ${escapeHtml(advisory.summary)}
+            </div>
+          </article>
+        `,
+      ).join("")}
+    </div>
+  `;
+};
+
 const renderTimeline = () => {
   const items = uiState.timeline?.items ?? [];
   const relevant = items.slice(-8).reverse();
@@ -1574,6 +1680,7 @@ const renderLiveOperations = () => {
   renderStatus();
   renderAlertCorrelation();
   renderConflictAssessment();
+  renderConflictAdvisory();
   renderTimeline();
 };
 
@@ -1584,6 +1691,7 @@ const clearPanels = (message) => {
   statusPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
   alertCorrelationPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
   conflictAssessmentPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
+  conflictAdvisoryPanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
   timelinePanel.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
   renderReplayControls();
 };


### PR DESCRIPTION
## Summary

Implements GitHub issue #155 by adding mission-linked conflict advisory presentation in the live operations view without introducing operator command automation.

## What changed

- Extended the operator live operations view with a dedicated `Conflict Advisory Guidance` panel.
- Kept the implementation presentation-only and client-side.
- Derived advisory presentation from the existing mission-linked conflict assessment layer rather than changing:
  - raw overlay records
  - interpreted conflict assessment records
  - operator/system action flows
- Added advisory-grade presentation including:
  - advisory headline
  - recommended operator attention cue
  - related assessed object
  - related source/provider context
  - concise reasoning
  - replay/live-time relevance
  - separation summary
- Added advisory summary state into the live ops overview and operational posture sections.
- Kept the operator live operations routes unchanged:
  - `GET /operator/live-operations-map`
  - `GET /operator/missions/:missionId/live-operations`
- Kept the existing conflict assessment path intact:
  - `GET /missions/:missionId/conflict-assessment`
- Did not introduce:
  - operator command automation
  - lifecycle transitions
  - avoidance execution
  - alert auto-resolution
- Updated route/bundle coverage to verify the advisory presentation is present in the served UI assets.
- Updated the save point to the next replay/context refinement step.

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 331 tests.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

## Notes

This issue is presentation-only. It does not implement:
- command execution
- automated deconfliction
- lifecycle automation
- conflict advisory persistence

Closes #155.
