### PR TITLE
Add conflict map track emphasis

### DIFF
--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -1993,6 +1993,8 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("replaySlider");
     expect(response.text).toContain("replayMarkers");
     expect(response.text).toContain("conflictReplayMarkers");
+    expect(response.text).toContain("currentConflictWindowSummary");
+    expect(response.text).toContain("conflictTrackWindowPoints");
     expect(response.text).toContain("correlatedAlertWindows");
     expect(response.text).toContain("renderAlertCorrelation");
     expect(response.text).toContain("replaySpeedSelect");
@@ -2021,5 +2023,7 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("renderConflictAssessment");
     expect(response.text).toContain("renderConflictAdvisory");
     expect(response.text).toContain("timeline-chip-row");
+    expect(response.text).toContain("map-window-summary");
+    expect(response.text).toContain("conflictTrackHighlight");
   });
 });

--- a/static/operator-live-operations-map.html
+++ b/static/operator-live-operations-map.html
@@ -431,6 +431,30 @@
       text-transform: uppercase;
       letter-spacing: 0.08em;
     }
+    .map-window-summary {
+      position: absolute;
+      left: 16px;
+      bottom: 62px;
+      z-index: 2;
+      width: min(360px, calc(100% - 32px));
+      padding: 12px 14px;
+      border: 1px solid var(--border);
+      background: rgba(9,17,27,0.84);
+      box-shadow: var(--shadow);
+      font-size: 12px;
+      line-height: 1.5;
+    }
+    .map-window-summary strong {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .map-window-summary .meta {
+      color: var(--muted);
+      margin-top: 6px;
+    }
     .map-legend {
       position: absolute;
       left: 16px;

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -544,6 +544,50 @@ const correlatedConflictTimelineItems = () => {
     .slice(0, 8);
 };
 
+const currentConflictWindowSummary = () => {
+  const replayRelation = currentConflictReplayRelation();
+  const conflicts = activeConflictAssessmentItems();
+  const primary = conflicts[0] ?? null;
+
+  if (!primary) {
+    return {
+      headline: "No current conflict window",
+      tone: "pass",
+      detail: "No assessed conflict candidate currently overlaps the replay review context.",
+      meta: "Window summary clear.",
+    };
+  }
+
+  return {
+    headline: replayRelation.label,
+    tone: primary.severity,
+    detail: `${primary.overlayLabel} · ${primary.metrics?.lateralDistanceMeters ?? "?"} m lateral · ${primary.metrics?.altitudeDeltaFt ?? "?"} ft vertical`,
+    meta: replayRelation.detail,
+  };
+};
+
+const conflictTrackWindowPoints = () => {
+  const points = replayTrack();
+  const activeConflicts = activeConflictAssessmentItems();
+
+  if (points.length === 0 || activeConflicts.length === 0) {
+    return [];
+  }
+
+  const targetTimes = activeConflicts
+    .map((conflict) => Date.parse(conflict.referenceTimestamp ?? ""))
+    .filter((value) => Number.isFinite(value));
+
+  return points.filter((point) => {
+    const pointTime = Date.parse(point.timestamp ?? "");
+    if (!Number.isFinite(pointTime)) {
+      return false;
+    }
+
+    return targetTimes.some((targetTime) => Math.abs(pointTime - targetTime) <= 600000);
+  });
+};
+
 const replayTrack = () =>
   (uiState.replay?.replay ?? []).filter(
     (point) => Number.isFinite(point?.lat) && Number.isFinite(point?.lng),
@@ -1148,6 +1192,7 @@ const buildMapMarkup = () => {
     "Cyan track replay",
     "Red marker latest telemetry",
     `Open alerts ${openAlerts.length}`,
+    `Conflict windows ${activeConflictAssessmentItems().length}`,
   ];
 
   const highestAlertSeverity = openAlerts.reduce((highest, alert) => {
@@ -1166,8 +1211,28 @@ const buildMapMarkup = () => {
   const weatherState = weatherSummary();
   const trafficState = crewedTrafficSummary();
   const droneState = droneTrafficSummary();
+  const conflictWindowSummary = currentConflictWindowSummary();
+  const conflictTrackWindow = conflictTrackWindowPoints();
   const mapRiskSeverity = [highestAlertSeverity, readinessState.tone, dispatchState.tone, riskState.tone, airspaceState.tone]
     .sort((left, right) => severityRank(right) - severityRank(left))[0];
+  const conflictTrackHighlight = conflictTrackWindow.length >= 2
+    ? `
+      <polyline
+        points="${conflictTrackWindow
+          .map((point) => {
+            const projected = toPoint(Number(point.lat), Number(point.lng));
+            return `${projected.x},${projected.y}`;
+          })
+          .join(" ")}"
+        fill="none"
+        stroke="${severityStroke(conflictWindowSummary.tone)}"
+        stroke-width="14"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        opacity="0.26"
+      />
+    `
+    : "";
   const weatherOverlay = activeWeatherOverlay();
   const weatherPoint =
     weatherOverlay &&
@@ -1312,6 +1377,7 @@ const buildMapMarkup = () => {
       ${riskCorridor}
       ${replayPath ? `<polyline points="${replayPath}" fill="none" stroke="#224665" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" opacity="0.72" />` : ""}
       ${completedReplayPath ? `<polyline points="${completedReplayPath}" fill="none" stroke="#38bdf8" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.98" />` : ""}
+      ${conflictTrackHighlight}
       ${alertTrackHighlight}
       ${replayDots}
       ${weatherMarker}
@@ -1328,6 +1394,11 @@ const buildMapMarkup = () => {
           : ""
       }
     </svg>
+    <div class="map-window-summary ${toneClass(conflictWindowSummary.tone)}">
+      <strong>${escapeHtml(conflictWindowSummary.headline)}</strong>
+      <div>${escapeHtml(conflictWindowSummary.detail)}</div>
+      <div class="meta">${escapeHtml(conflictWindowSummary.meta)}</div>
+    </div>
     <div class="map-overlay">
       ${overlays.map((item) => `<div class="overlay-pill">${escapeHtml(item)}</div>`).join("")}
     </div>


### PR DESCRIPTION
## Summary

Implements GitHub issue #159 by adding mission-linked conflict map track emphasis and window summaries in the live operations view without introducing operator command automation.

## What changed

- Extended the operator live operations map with stronger map-native conflict emphasis.
- Kept the implementation presentation-only and read-only.
- Added conflict track emphasis derived from the existing mission-linked conflict assessment layer.
- Added conflict window summary presentation tied to the current replay context, including:
  - current conflict window headline
  - separation summary
  - replay-related detail
- Added conflict window context directly onto the map surface via:
  - highlighted conflict-relevant track sections
  - a dedicated map window summary card
  - map overlay legend/context updates
- Preserved the existing conflict assessment and advisory layers while making the relationship between:
  - replay markers
  - advisory presentation
  - map-native conflict emphasis
  more explicit
- Kept the existing live ops routes unchanged:
  - `GET /operator/live-operations-map`
  - `GET /operator/missions/:missionId/live-operations`
- Did not introduce:
  - command execution
  - lifecycle changes
  - automated avoidance
  - operator command automation
- Updated route/bundle coverage so the served UI assets explicitly include:
  - conflict window summary logic
  - conflict track window point selection
  - conflict track highlight rendering
  - map window summary rendering

## Verification

- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 331 tests.

## Notes

This issue is presentation-only. It does not implement:
- conflict command execution
- automated deconfliction
- lifecycle automation
- advisory persistence

Closes #159.
