### PR TITLE
Add live ops mission selection

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add mission selection integration to the live operations entry flow so operators can choose a mission from the live operations route without manual UUID entry.",
+  "nextBuildStep": "Add mission-focused filters to the live operations entry browser so operators can narrow the live operations mission list by status and current activity without leaving the route.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -1933,6 +1933,10 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("Conflict Advisory Guidance");
     expect(response.text).toContain("Enter mission UUID");
     expect(response.text).toContain("Open workspace");
+    expect(response.text).toContain("live-ops-mission-search-input");
+    expect(response.text).toContain("live-ops-mission-search-btn");
+    expect(response.text).toContain("live-ops-mission-browser-list");
+    expect(response.text).toContain("live-ops-mission-browser-detail");
     expect(response.text).toContain("live-ops-replay-play-btn");
     expect(response.text).toContain("live-ops-replay-slider");
     expect(response.text).toContain("live-ops-replay-markers");
@@ -1992,6 +1996,11 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("isPlaceholderMissionId");
     expect(response.text).toContain("hasSelectedMissionId");
     expect(response.text).toContain("renderEntryState");
+    expect(response.text).toContain("loadMissionList");
+    expect(response.text).toContain("renderMissionBrowser");
+    expect(response.text).toContain('fetchJson(`/missions?${params.toString()}`)');
+    expect(response.text).toContain('data-open-mission');
+    expect(response.text).toContain("live-ops-mission-search-input");
     expect(response.text).toContain("map-alert-card");
     expect(response.text).toContain("severityStroke");
     expect(response.text).toContain("alertTrackHighlight");

--- a/static/operator-live-operations-map.html
+++ b/static/operator-live-operations-map.html
@@ -116,6 +116,65 @@
       background: rgba(255,255,255,0.04);
       color: var(--muted);
     }
+    .entry-browser {
+      margin-top: 16px;
+      border: 1px solid var(--border);
+      background: rgba(255,255,255,0.03);
+      box-shadow: var(--shadow);
+    }
+    .entry-browser-header {
+      display: flex;
+      align-items: end;
+      gap: 12px;
+      padding: 16px 18px;
+      border-bottom: 1px solid var(--border);
+      background: rgba(255,255,255,0.02);
+    }
+    .entry-browser-header .field {
+      flex: 1;
+    }
+    .entry-browser-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+      gap: 0;
+    }
+    .entry-browser-list,
+    .entry-browser-detail {
+      min-height: 220px;
+      padding: 16px 18px;
+    }
+    .entry-browser-detail {
+      border-left: 1px solid var(--border);
+      background: rgba(255,255,255,0.02);
+    }
+    .mission-row {
+      padding: 14px;
+      border: 1px solid var(--border);
+      background: var(--bg-soft);
+    }
+    .mission-row-title {
+      display: flex;
+      align-items: start;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 8px;
+    }
+    .mission-row-meta {
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.45;
+    }
+    .action-button {
+      min-height: 40px;
+      padding: 0 14px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--bg-accent);
+      color: var(--text);
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
     .band { padding: 18px 0; }
     .metric-grid {
       display: grid;
@@ -577,6 +636,7 @@
     }
     @media (max-width: 1120px) {
       .controls-grid,
+      .entry-browser-grid,
       .metric-grid,
       .live-grid,
       .summary-grid,
@@ -623,6 +683,22 @@
             <div id="live-ops-loaded-mission-pill" class="status-pill">None</div>
           </div>
         </div>
+        <section class="entry-browser">
+          <div class="entry-browser-header">
+            <div class="field">
+              <label for="live-ops-mission-search-input">Mission search</label>
+              <input id="live-ops-mission-search-input" type="text" placeholder="Search missions by plan ID, status, platform, or pilot" />
+            </div>
+            <div class="field" style="max-width: 180px;">
+              <label>&nbsp;</label>
+              <button id="live-ops-mission-search-btn" class="secondary" type="button">Search missions</button>
+            </div>
+          </div>
+          <div class="entry-browser-grid">
+            <div id="live-ops-mission-browser-list" class="entry-browser-list"></div>
+            <div id="live-ops-mission-browser-detail" class="entry-browser-detail"></div>
+          </div>
+        </section>
       </div>
     </header>
 

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -21,6 +21,10 @@ const replayTimeReadout = document.getElementById("live-ops-replay-time");
 const replayProgress = document.getElementById("live-ops-replay-progress");
 const replayMarkers = document.getElementById("live-ops-replay-markers");
 const replaySpeedSelect = document.getElementById("live-ops-replay-speed");
+const missionSearchInput = document.getElementById("live-ops-mission-search-input");
+const missionSearchButton = document.getElementById("live-ops-mission-search-btn");
+const missionBrowserList = document.getElementById("live-ops-mission-browser-list");
+const missionBrowserDetail = document.getElementById("live-ops-mission-browser-detail");
 const missionRoutePattern = /^\/operator\/missions\/([^/]+)\/live-operations$/;
 
 const uiState = {
@@ -33,6 +37,8 @@ const uiState = {
   alerts: [],
   externalOverlays: [],
   conflictAssessment: null,
+  missionList: [],
+  missionQuery: "",
   replayPlayback: {
     index: 0,
     playing: false,
@@ -88,6 +94,9 @@ const escapeHtml = (value) =>
 
 const renderBadge = (value) =>
   `<span class="badge ${toneClass(value)}">${escapeHtml(value ?? "Unknown")}</span>`;
+
+const missionDisplayName = (mission) =>
+  mission?.missionPlanId || mission?.id || "Unknown mission";
 
 const weatherOverlays = () =>
   (uiState.externalOverlays ?? []).filter((overlay) => overlay.kind === "weather");
@@ -176,6 +185,152 @@ const resetLiveOperationsState = () => {
   uiState.replayPlayback.index = 0;
 };
 
+const renderMissionBrowser = () => {
+  const missions = uiState.missionList ?? [];
+
+  if (!missionBrowserList || !missionBrowserDetail) {
+    return;
+  }
+
+  if (missions.length === 0) {
+    missionBrowserList.innerHTML =
+      '<div class="empty-state">No missions match the current filter.</div>';
+    missionBrowserDetail.innerHTML = `
+      <div class="empty-state">
+        Search recent missions or clear the filter to choose a mission for the live operations view.
+      </div>
+    `;
+    return;
+  }
+
+  missionBrowserList.innerHTML = `
+    <div class="stack">
+      ${missions
+        .map((mission) => {
+          const loaded = mission.id === uiState.missionId;
+          const lastEvent = mission.latestEventSummary ?? "No lifecycle events yet";
+          const platform =
+            mission.platform?.name ?? mission.platform?.id ?? "Platform not assigned";
+          const pilot =
+            mission.pilot?.displayName ?? mission.pilot?.id ?? "Pilot not assigned";
+
+          return `
+            <article class="mission-row" data-mission-id="${escapeHtml(mission.id)}">
+              <div class="mission-row-title">
+                <div>
+                  <strong>${escapeHtml(missionDisplayName(mission))}</strong>
+                  <div class="mission-row-meta">Mission ID: ${escapeHtml(mission.id)}</div>
+                </div>
+                <div>${renderBadge(mission.status ?? "Unknown")}</div>
+              </div>
+              <div class="mission-row-meta">
+                Platform: ${escapeHtml(platform)}<br />
+                Pilot: ${escapeHtml(pilot)}<br />
+                Last event: ${escapeHtml(lastEvent)}<br />
+                Updated: ${escapeHtml(formatDateTime(mission.latestEventAt ?? mission.updatedAt))}
+              </div>
+              <div style="margin-top: 10px;">
+                <button class="action-button" type="button" data-open-mission="${escapeHtml(
+                  mission.id,
+                )}">
+                  ${loaded ? "Loaded" : "Load live ops"}
+                </button>
+              </div>
+            </article>
+          `;
+        })
+        .join("")}
+    </div>
+  `;
+
+  missionBrowserList.querySelectorAll("[data-open-mission]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const missionId = button.getAttribute("data-open-mission");
+      if (!missionId) {
+        return;
+      }
+
+      missionIdInput.value = missionId;
+      loadLiveOperationsView(missionId);
+    });
+  });
+
+  const selectedMission =
+    missions.find((mission) => mission.id === uiState.missionId) ?? missions[0];
+  const selectedPlatform =
+    selectedMission.platform?.name ??
+    selectedMission.platform?.id ??
+    "Platform not assigned";
+  const selectedPilot =
+    selectedMission.pilot?.displayName ??
+    selectedMission.pilot?.id ??
+    "Pilot not assigned";
+
+  missionBrowserDetail.innerHTML = `
+    <section class="summary-block">
+      <h4>Selected Mission</h4>
+      <div class="kv">
+        <div class="k">Mission</div>
+        <div>${escapeHtml(missionDisplayName(selectedMission))}</div>
+        <div class="k">Mission ID</div>
+        <div>${escapeHtml(selectedMission.id)}</div>
+        <div class="k">Status</div>
+        <div>${renderBadge(selectedMission.status ?? "Unknown")}</div>
+        <div class="k">Platform</div>
+        <div>${escapeHtml(selectedPlatform)}</div>
+        <div class="k">Pilot</div>
+        <div>${escapeHtml(selectedPilot)}</div>
+        <div class="k">Latest event</div>
+        <div>${escapeHtml(selectedMission.latestEventSummary ?? "No lifecycle events yet")}</div>
+      </div>
+      <div style="margin-top: 12px;">
+        <button class="action-button" type="button" data-load-selected-mission="${escapeHtml(
+          selectedMission.id,
+        )}">
+          ${selectedMission.id === uiState.missionId ? "Reload live ops" : "Load selected mission"}
+        </button>
+      </div>
+    </section>
+  `;
+
+  missionBrowserDetail
+    .querySelector("[data-load-selected-mission]")
+    ?.addEventListener("click", () => {
+      missionIdInput.value = selectedMission.id;
+      loadLiveOperationsView(selectedMission.id);
+    });
+};
+
+const loadMissionList = async (query = "") => {
+  uiState.missionQuery = query;
+
+  if (!missionBrowserList || !missionBrowserDetail) {
+    return;
+  }
+
+  missionBrowserList.innerHTML =
+    '<div class="empty-state">Loading mission list...</div>';
+
+  const params = new URLSearchParams();
+  if (query) {
+    params.set("q", query);
+  }
+  params.set("limit", "12");
+
+  try {
+    const response = await fetchJson(`/missions?${params.toString()}`);
+    uiState.missionList = response.missions ?? [];
+    renderMissionBrowser();
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to load mission list";
+    uiState.missionList = [];
+    missionBrowserList.innerHTML = `<div class="empty-state">${escapeHtml(message)}</div>`;
+    missionBrowserDetail.innerHTML =
+      '<div class="empty-state">Mission selection is unavailable because the mission list did not load.</div>';
+  }
+};
+
 const replayPlaybackIntervalMs = () =>
   Math.max(150, Math.round(900 / (uiState.replayPlayback.speed || 1)));
 
@@ -224,9 +379,6 @@ const renderReplayControls = () => {
           ...conflictReplayMarkers(replayStart, replaySpan),
         ].join("");
 };
-
-const missionDisplayName = (mission) =>
-  mission?.missionPlanId || mission?.id || "Unknown mission";
 
 const activeWeatherOverlay = () => {
   const replayPoint = activeReplayPoint();
@@ -2203,6 +2355,7 @@ const renderEntryState = ({
   timelinePanel.innerHTML =
     '<div class="empty-state">Mission event context will appear after mission selection.</div>';
   renderReplayControls();
+  renderMissionBrowser();
 };
 
 const loadLiveOperationsView = async (missionId) => {
@@ -2259,6 +2412,7 @@ const loadLiveOperationsView = async (missionId) => {
     uiState.externalOverlays = externalOverlayResponse.overlays ?? [];
     uiState.conflictAssessment = conflictAssessmentResponse;
     uiState.replayPlayback.index = 0;
+    renderMissionBrowser();
     renderLiveOperations();
     setConnectionState("Live operations view loaded", "tone-ok");
   } catch (error) {
@@ -2273,6 +2427,7 @@ const loadLiveOperationsView = async (missionId) => {
     uiState.externalOverlays = [];
     uiState.conflictAssessment = null;
     uiState.replayPlayback.index = 0;
+    renderMissionBrowser();
     clearPanels(message);
     setConnectionState(message, "tone-bad");
   }
@@ -2285,6 +2440,16 @@ loadButton.addEventListener("click", () => {
 missionIdInput.addEventListener("keydown", (event) => {
   if (event.key === "Enter") {
     loadLiveOperationsView(normalizeMissionId(missionIdInput.value));
+  }
+});
+
+missionSearchButton?.addEventListener("click", () => {
+  loadMissionList(normalizeMissionId(missionSearchInput?.value ?? ""));
+});
+
+missionSearchInput?.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    loadMissionList(normalizeMissionId(missionSearchInput.value));
   }
 });
 
@@ -2374,6 +2539,8 @@ const initialMissionId = normalizeMissionId(getMissionIdFromLocation());
 if (initialMissionId) {
   missionIdInput.value = initialMissionId;
 }
+
+loadMissionList();
 
 if (hasSelectedMissionId(initialMissionId)) {
   loadLiveOperationsView(initialMissionId);


### PR DESCRIPTION
## Summary

Implements GitHub issue #169 by adding mission selection integration to the generic live operations entry flow.

## What changed

- Extended the generic live operations route so operators can choose a mission without manual UUID entry:
  - `GET /operator/live-operations-map`
- Preserved the existing mission-specific route behavior:
  - `GET /operator/missions/:missionId/live-operations`
- Added mission search controls to the live ops entry screen:
  - mission search input
  - search action
  - mission browser list
  - selected mission detail
- Reused the existing mission list/search backend path rather than introducing a second mission-picker model:
  - `GET /missions?q=...&limit=12`
- Added mission browser rendering to the live ops entry flow so operators can:
  - browse recent missions
  - filter missions
  - inspect selected mission detail
  - load live operations directly from the generic route
- Kept manual mission UUID entry available as an optional fallback.
- Kept replay, overlay, alert, conflict, and advisory behavior unchanged once a valid mission is loaded.
- Updated route and bundle coverage to verify:
  - the generic live ops route now includes mission selection controls
  - the live ops bundle includes mission list loading and mission browser rendering
  - selecting a mission still leads into the existing live-ops load path

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 331 tests.

## Notes

This issue is limited to entry-flow UX and reuse of existing mission search/list behavior. It does not change:
- mission lifecycle behavior
- live-ops data models
- conflict assessment logic
- operator command automation

Closes #169.
