### PR TITLE
Add area conflict geometry support

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add altitude-band gating and vertical context refinement to mission-linked area conflict assessment so area conflicts only trigger within relevant operating volumes.",
+  "nextBuildStep": "Add migration-backed normalized area overlay ingestion for danger areas, temporary danger areas, and NOTAM-derived restrictions so mission-linked area conflict assessment can operate on authoritative area geometry.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add area conflict geometry support to mission-linked conflict assessment so bearing and range metadata can extend beyond traffic overlays.",
+  "nextBuildStep": "Add altitude-band gating and vertical context refinement to mission-linked area conflict assessment so area conflicts only trigger within relevant operating volumes.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/conflict-assessment/traffic-conflict-assessment.service.ts
+++ b/src/conflict-assessment/traffic-conflict-assessment.service.ts
@@ -2,9 +2,12 @@ import { randomUUID } from "crypto";
 import type { Pool } from "pg";
 import { ExternalOverlayRepository } from "../external-overlays/external-overlay.repository";
 import type {
+  AreaConflictOverlayMetadata,
   CrewedTrafficOverlayMetadata,
   DroneTrafficOverlayMetadata,
   ExternalOverlay,
+  ExternalOverlayCircleGeometry,
+  ExternalOverlayPolygonGeometry,
   WeatherOverlayMetadata,
 } from "../external-overlays/external-overlay.types";
 import { MissionRepository } from "../missions/mission.repository";
@@ -60,6 +63,181 @@ const bearingDegrees = (
 const round = (value: number | null): number | null =>
   value == null || Number.isNaN(value) ? null : Math.round(value);
 
+const pointInPolygon = (
+  lat: number,
+  lng: number,
+  points: Array<{ lat: number; lng: number }>,
+): boolean => {
+  let inside = false;
+  for (let index = 0, previous = points.length - 1; index < points.length; previous = index++) {
+    const xi = points[index].lng;
+    const yi = points[index].lat;
+    const xj = points[previous].lng;
+    const yj = points[previous].lat;
+
+    const intersects =
+      yi > lat !== yj > lat &&
+      lng <
+        ((xj - xi) * (lat - yi)) / ((yj - yi) || Number.EPSILON) + xi;
+
+    if (intersects) {
+      inside = !inside;
+    }
+  }
+
+  return inside;
+};
+
+const projectMeters = (
+  originLat: number,
+  originLng: number,
+  lat: number,
+  lng: number,
+): { x: number; y: number } => ({
+  x:
+    toRadians(lng - originLng) *
+    EARTH_RADIUS_M *
+    Math.cos(toRadians((lat + originLat) / 2)),
+  y: toRadians(lat - originLat) * EARTH_RADIUS_M,
+});
+
+const unprojectMeters = (
+  originLat: number,
+  originLng: number,
+  x: number,
+  y: number,
+): { lat: number; lng: number } => ({
+  lat: originLat + toDegrees(y / EARTH_RADIUS_M),
+  lng:
+    originLng +
+    toDegrees(
+      x /
+        (EARTH_RADIUS_M * Math.cos(toRadians(originLat || Number.EPSILON))),
+    ),
+});
+
+const nearestPointOnSegment = (
+  point: { x: number; y: number },
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+): { x: number; y: number; distance: number } => {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const lengthSquared = dx * dx + dy * dy;
+
+  if (lengthSquared === 0) {
+    const distance = Math.hypot(point.x - start.x, point.y - start.y);
+    return { x: start.x, y: start.y, distance };
+  }
+
+  const t = Math.max(
+    0,
+    Math.min(
+      1,
+      ((point.x - start.x) * dx + (point.y - start.y) * dy) / lengthSquared,
+    ),
+  );
+  const nearest = {
+    x: start.x + t * dx,
+    y: start.y + t * dy,
+  };
+
+  return {
+    ...nearest,
+    distance: Math.hypot(point.x - nearest.x, point.y - nearest.y),
+  };
+};
+
+const nearestBoundaryForPolygon = (
+  referenceLat: number,
+  referenceLng: number,
+  geometry: ExternalOverlayPolygonGeometry,
+): {
+  rangeMeters: number;
+  bearingDegrees: number | null;
+  insideArea: boolean;
+} => {
+  const insideArea = pointInPolygon(referenceLat, referenceLng, geometry.points);
+  const referencePoint = { x: 0, y: 0 };
+  let best:
+    | {
+        x: number;
+        y: number;
+        distance: number;
+      }
+    | null = null;
+
+  for (let index = 0; index < geometry.points.length; index += 1) {
+    const startPoint = geometry.points[index];
+    const endPoint = geometry.points[(index + 1) % geometry.points.length];
+    const start = projectMeters(
+      referenceLat,
+      referenceLng,
+      startPoint.lat,
+      startPoint.lng,
+    );
+    const end = projectMeters(referenceLat, referenceLng, endPoint.lat, endPoint.lng);
+    const candidate = nearestPointOnSegment(referencePoint, start, end);
+
+    if (!best || candidate.distance < best.distance) {
+      best = candidate;
+    }
+  }
+
+  if (!best) {
+    return { rangeMeters: 0, bearingDegrees: null, insideArea };
+  }
+
+  const boundaryPoint = unprojectMeters(
+    referenceLat,
+    referenceLng,
+    best.x,
+    best.y,
+  );
+
+  return {
+    rangeMeters: best.distance,
+    bearingDegrees: best.distance === 0
+      ? null
+      : bearingDegrees(referenceLat, referenceLng, boundaryPoint.lat, boundaryPoint.lng),
+    insideArea,
+  };
+};
+
+const nearestBoundaryForCircle = (
+  referenceLat: number,
+  referenceLng: number,
+  geometry: ExternalOverlayCircleGeometry,
+): {
+  rangeMeters: number;
+  bearingDegrees: number | null;
+  insideArea: boolean;
+} => {
+  const distanceToCenter = haversineMeters(
+    referenceLat,
+    referenceLng,
+    geometry.centerLat,
+    geometry.centerLng,
+  );
+  const insideArea = distanceToCenter <= geometry.radiusMeters;
+  const rangeMeters = Math.abs(distanceToCenter - geometry.radiusMeters);
+  const bearingToCenter =
+    distanceToCenter === 0
+      ? null
+      : bearingDegrees(
+          referenceLat,
+          referenceLng,
+          geometry.centerLat,
+          geometry.centerLng,
+        );
+
+  return {
+    rangeMeters,
+    bearingDegrees: bearingToCenter,
+    insideArea,
+  };
+};
+
 const severityRank = (severity: TrafficConflictSeverity): number => {
   if (severity === "critical") return 3;
   if (severity === "caution") return 2;
@@ -78,6 +256,11 @@ const escalateSeverity = (
 };
 
 const trafficLabel = (overlay: ExternalOverlay): string => {
+  if (overlay.kind === "area_conflict") {
+    const metadata = overlay.metadata as unknown as AreaConflictOverlayMetadata;
+    return metadata.label ?? metadata.areaId ?? "Area conflict";
+  }
+
   if (overlay.kind === "crewed_traffic") {
     const metadata = overlay.metadata as unknown as CrewedTrafficOverlayMetadata;
     return metadata.callsign ?? metadata.trafficId ?? "Crewed traffic";
@@ -189,6 +372,47 @@ const classifyTrafficConflict = (
   return null;
 };
 
+const areaAltitudeRelevant = (
+  referenceAltitudeFt: number | null,
+  floorFt: number | null,
+  ceilingFt: number | null,
+): boolean => {
+  if (referenceAltitudeFt == null) {
+    return true;
+  }
+  if (floorFt != null && referenceAltitudeFt < floorFt) {
+    return false;
+  }
+  if (ceilingFt != null && referenceAltitudeFt > ceilingFt) {
+    return false;
+  }
+
+  return true;
+};
+
+const classifyAreaConflict = (
+  boundaryDistanceMeters: number | null,
+  insideArea: boolean,
+): { status: TrafficConflictStatus; severity: TrafficConflictSeverity } | null => {
+  if (insideArea) {
+    return { status: "conflict_candidate", severity: "critical" };
+  }
+  if (boundaryDistanceMeters == null) {
+    return null;
+  }
+  if (boundaryDistanceMeters <= 250) {
+    return { status: "conflict_candidate", severity: "critical" };
+  }
+  if (boundaryDistanceMeters <= 750) {
+    return { status: "conflict_candidate", severity: "caution" };
+  }
+  if (boundaryDistanceMeters <= 1500) {
+    return { status: "monitor", severity: "info" };
+  }
+
+  return null;
+};
+
 const buildExplanation = (
   overlay: ExternalOverlay,
   lateralDistanceMeters: number | null,
@@ -197,7 +421,9 @@ const buildExplanation = (
   weatherReason: string | null,
 ): string => {
   const base =
-    overlay.kind === "drone_traffic"
+    overlay.kind === "area_conflict"
+      ? "Area conflict proximity candidate"
+      : overlay.kind === "drone_traffic"
       ? "Drone traffic proximity candidate"
       : "Crewed traffic proximity candidate";
   const lateral =
@@ -234,6 +460,12 @@ const isTrafficOverlay = (
 ): overlay is ExternalOverlay & {
   kind: "crewed_traffic" | "drone_traffic";
 } => overlay.kind === "crewed_traffic" || overlay.kind === "drone_traffic";
+
+const isAreaConflictOverlay = (
+  overlay: ExternalOverlay,
+): overlay is ExternalOverlay & {
+  kind: "area_conflict";
+} => overlay.kind === "area_conflict";
 
 export class TrafficConflictAssessmentService {
   constructor(
@@ -278,13 +510,135 @@ export class TrafficConflictAssessmentService {
         latestTelemetry?.altitudeM == null ? null : latestTelemetry.altitudeM * FEET_PER_METER;
 
       const conflicts = overlays
-        .filter(isTrafficOverlay)
+        .filter(
+          (overlay): overlay is ExternalOverlay & {
+            kind: "crewed_traffic" | "drone_traffic" | "area_conflict";
+          } => isTrafficOverlay(overlay) || isAreaConflictOverlay(overlay),
+        )
         .map((overlay): TrafficConflictAssessmentItem | null => {
+          const overlayLabel = trafficLabel(overlay);
+          const observedAt = Date.parse(overlay.observedAt);
+          const referenceTime = Date.parse(referenceTimestamp);
+          const timeDeltaSeconds =
+            Number.isFinite(observedAt) && Number.isFinite(referenceTime)
+              ? Math.abs(referenceTime - observedAt) / 1000
+              : null;
+
+          if (overlay.kind === "area_conflict") {
+            const geometry = overlay.geometry;
+            if (
+              referenceLat == null ||
+              referenceLng == null ||
+              (geometry.type !== "circle" && geometry.type !== "polygon")
+            ) {
+              return null;
+            }
+
+            const altitudeFloorFt =
+              geometry.type === "circle"
+                ? geometry.altitudeFloorFt
+                : geometry.altitudeFloorFt;
+            const altitudeCeilingFt =
+              geometry.type === "circle"
+                ? geometry.altitudeCeilingFt
+                : geometry.altitudeCeilingFt;
+
+            if (
+              !areaAltitudeRelevant(
+                referenceAltitudeFt,
+                altitudeFloorFt,
+                altitudeCeilingFt,
+              )
+            ) {
+              return null;
+            }
+
+            const geometryAssessment =
+              geometry.type === "circle"
+                ? nearestBoundaryForCircle(referenceLat, referenceLng, geometry)
+                : nearestBoundaryForPolygon(referenceLat, referenceLng, geometry);
+            const classification = classifyAreaConflict(
+              geometryAssessment.rangeMeters,
+              geometryAssessment.insideArea,
+            );
+
+            if (!classification) {
+              return null;
+            }
+
+            const areaMetadata =
+              overlay.metadata as unknown as AreaConflictOverlayMetadata;
+            const severity = escalateSeverity(
+              overlay.severity ?? classification.severity,
+              weather.steps,
+            );
+            const geometryLabel =
+              geometry.type === "circle" ? "area circle" : "area polygon";
+            const summary =
+              classification.status === "conflict_candidate"
+                ? `${overlayLabel} area conflict candidate`
+                : `${overlayLabel} area monitor candidate`;
+            const verticalContext =
+              altitudeFloorFt != null || altitudeCeilingFt != null
+                ? ` altitude band ${altitudeFloorFt ?? "surface"}-${altitudeCeilingFt ?? "open"} ft`
+                : "";
+            const explanation = geometryAssessment.insideArea
+              ? `Area conflict proximity candidate: mission reference is inside ${geometryLabel} ${overlayLabel}; nearest boundary ${round(geometryAssessment.rangeMeters)} m away, ${
+                  geometryAssessment.bearingDegrees == null
+                    ? "unknown bearing"
+                    : `${round(geometryAssessment.bearingDegrees)}° bearing from mission reference`
+                },${verticalContext}${weather.reason ? ` ${weather.reason}` : ""}.`
+              : `Area conflict proximity candidate: ${overlayLabel} boundary is ${round(
+                  geometryAssessment.rangeMeters,
+                )} m away at ${
+                  geometryAssessment.bearingDegrees == null
+                    ? "unknown bearing"
+                    : `${round(geometryAssessment.bearingDegrees)}° bearing from mission reference`
+                },${verticalContext}${weather.reason ? ` ${weather.reason}` : ""}.`;
+
+            return {
+              id: randomUUID(),
+              missionId,
+              overlayId: overlay.id,
+              overlayKind: "area_conflict",
+              assessedAt,
+              referenceTimestamp,
+              overlayObservedAt: overlay.observedAt,
+              status: classification.status,
+              severity,
+              summary,
+              explanation,
+              overlayLabel,
+              relatedSource: { ...overlay.source },
+              measurementBasis: {
+                referencePoint: "latest_telemetry",
+                targetGeometry:
+                  geometry.type === "circle" ? "overlay_circle" : "overlay_polygon",
+                rangeRule: "nearest_boundary",
+                bearingReference: "true_north",
+              },
+              metrics: {
+                rangeMeters: round(geometryAssessment.rangeMeters),
+                bearingDegrees: round(geometryAssessment.bearingDegrees),
+                lateralDistanceMeters: round(geometryAssessment.rangeMeters),
+                altitudeDeltaFt: null,
+                timeDeltaSeconds: round(timeDeltaSeconds),
+                insideArea: geometryAssessment.insideArea,
+                overlayHeadingDegrees: null,
+                overlaySpeedKnots: null,
+              },
+            };
+          }
+
+          if (overlay.geometry.type !== "point") {
+            return null;
+          }
+
           const lateralDistanceMeters =
             referenceLat == null ||
             referenceLng == null ||
-            overlay.geometry?.lat == null ||
-            overlay.geometry?.lng == null
+            overlay.geometry.lat == null ||
+            overlay.geometry.lng == null
               ? null
               : haversineMeters(
                   referenceLat,
@@ -295,8 +649,8 @@ export class TrafficConflictAssessmentService {
           const bearingToOverlayDegrees =
             referenceLat == null ||
             referenceLng == null ||
-            overlay.geometry?.lat == null ||
-            overlay.geometry?.lng == null
+            overlay.geometry.lat == null ||
+            overlay.geometry.lng == null
               ? null
               : bearingDegrees(
                   referenceLat,
@@ -319,17 +673,10 @@ export class TrafficConflictAssessmentService {
             return null;
           }
 
-          const observedAt = Date.parse(overlay.observedAt);
-          const referenceTime = Date.parse(referenceTimestamp);
-          const timeDeltaSeconds =
-            Number.isFinite(observedAt) && Number.isFinite(referenceTime)
-              ? Math.abs(referenceTime - observedAt) / 1000
-              : null;
           const severity = escalateSeverity(
             classification.severity,
             weather.steps,
           );
-          const overlayLabel = trafficLabel(overlay);
 
           return {
             id: randomUUID(),
@@ -366,6 +713,7 @@ export class TrafficConflictAssessmentService {
               lateralDistanceMeters: round(lateralDistanceMeters),
               altitudeDeltaFt: round(altitudeDeltaFt),
               timeDeltaSeconds: round(timeDeltaSeconds),
+              insideArea: null,
               overlayHeadingDegrees: overlay.headingDegrees,
               overlaySpeedKnots: overlay.speedKnots,
             },

--- a/src/conflict-assessment/traffic-conflict-assessment.types.ts
+++ b/src/conflict-assessment/traffic-conflict-assessment.types.ts
@@ -18,7 +18,10 @@ export interface TrafficConflictAssessmentItem {
   id: string;
   missionId: string;
   overlayId: string;
-  overlayKind: Extract<ExternalOverlayKind, "crewed_traffic" | "drone_traffic">;
+  overlayKind: Extract<
+    ExternalOverlayKind,
+    "crewed_traffic" | "drone_traffic" | "area_conflict"
+  >;
   assessedAt: string;
   referenceTimestamp: string;
   overlayObservedAt: string;
@@ -34,8 +37,8 @@ export interface TrafficConflictAssessmentItem {
   };
   measurementBasis: {
     referencePoint: "latest_telemetry";
-    targetGeometry: "overlay_point";
-    rangeRule: "point_to_point";
+    targetGeometry: "overlay_point" | "overlay_circle" | "overlay_polygon";
+    rangeRule: "point_to_point" | "nearest_boundary";
     bearingReference: "true_north";
   };
   metrics: {
@@ -44,6 +47,7 @@ export interface TrafficConflictAssessmentItem {
     lateralDistanceMeters: number | null;
     altitudeDeltaFt: number | null;
     timeDeltaSeconds: number | null;
+    insideArea: boolean | null;
     overlayHeadingDegrees: number | null;
     overlaySpeedKnots: number | null;
   };

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -34,9 +34,14 @@ export class ExternalOverlayController {
           req.params.missionId,
           req.body,
         );
+      } else if (req.body?.kind === "area_conflict") {
+        overlay = await this.externalOverlayService.createAreaConflictOverlay(
+          req.params.missionId,
+          req.body,
+        );
       } else {
         throw new Error(
-          "Supported overlay kinds are: weather, crewed_traffic, drone_traffic",
+          "Supported overlay kinds are: weather, crewed_traffic, drone_traffic, area_conflict",
         );
       }
 

--- a/src/external-overlays/external-overlay.repository.ts
+++ b/src/external-overlays/external-overlay.repository.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import type { PoolClient, QueryResultRow } from "pg";
 import type {
+  CreateAreaConflictExternalOverlayInput,
   CreateCrewedTrafficExternalOverlayInput,
   CreateDroneTrafficExternalOverlayInput,
   CreateWeatherExternalOverlayInput,
@@ -19,7 +20,7 @@ interface ExternalOverlayRow extends QueryResultRow {
   observed_at: Date;
   valid_from: Date | null;
   valid_to: Date | null;
-  geometry_type: "point";
+  geometry_type: "point" | "circle" | "polygon";
   latitude: number | null;
   longitude: number | null;
   altitude_msl_ft: number | null;
@@ -33,6 +34,23 @@ interface ExternalOverlayRow extends QueryResultRow {
   updated_at: Date;
 }
 
+const polygonCentroid = (
+  points: Array<{ lat: number; lng: number }>,
+): { lat: number; lng: number } => {
+  const total = points.reduce(
+    (acc, point) => ({
+      lat: acc.lat + point.lat,
+      lng: acc.lng + point.lng,
+    }),
+    { lat: 0, lng: 0 },
+  );
+
+  return {
+    lat: total.lat / points.length,
+    lng: total.lng / points.length,
+  };
+};
+
 const toExternalOverlay = (row: ExternalOverlayRow): ExternalOverlay => ({
   id: row.id,
   missionId: row.mission_id,
@@ -45,13 +63,55 @@ const toExternalOverlay = (row: ExternalOverlayRow): ExternalOverlay => ({
   observedAt: row.observed_at.toISOString(),
   validFrom: row.valid_from ? row.valid_from.toISOString() : null,
   validTo: row.valid_to ? row.valid_to.toISOString() : null,
-  geometry: {
-    type: "point",
-    lat: Number(row.latitude),
-    lng: Number(row.longitude),
-    altitudeMslFt:
-      row.altitude_msl_ft == null ? null : Number(row.altitude_msl_ft),
-  },
+  geometry:
+    row.geometry_type === "circle"
+      ? {
+          type: "circle",
+          centerLat: Number(row.latitude),
+          centerLng: Number(row.longitude),
+          radiusMeters: Number((row.metadata as Record<string, unknown>).radiusMeters),
+          altitudeFloorFt:
+            typeof (row.metadata as Record<string, unknown>).altitudeFloorFt ===
+            "number"
+              ? Number((row.metadata as Record<string, unknown>).altitudeFloorFt)
+              : null,
+          altitudeCeilingFt:
+            typeof (row.metadata as Record<string, unknown>).altitudeCeilingFt ===
+            "number"
+              ? Number((row.metadata as Record<string, unknown>).altitudeCeilingFt)
+              : null,
+        }
+      : row.geometry_type === "polygon"
+        ? {
+            type: "polygon",
+            points: Array.isArray((row.metadata as Record<string, unknown>).points)
+              ? ((row.metadata as Record<string, unknown>).points as Array<Record<string, unknown>>).map(
+                  (point) => ({
+                    lat: Number(point.lat),
+                    lng: Number(point.lng),
+                  }),
+                )
+              : [],
+            centroidLat: Number(row.latitude),
+            centroidLng: Number(row.longitude),
+            altitudeFloorFt:
+              typeof (row.metadata as Record<string, unknown>).altitudeFloorFt ===
+              "number"
+                ? Number((row.metadata as Record<string, unknown>).altitudeFloorFt)
+                : null,
+            altitudeCeilingFt:
+              typeof (row.metadata as Record<string, unknown>).altitudeCeilingFt ===
+              "number"
+                ? Number((row.metadata as Record<string, unknown>).altitudeCeilingFt)
+                : null,
+          }
+        : {
+            type: "point",
+            lat: Number(row.latitude),
+            lng: Number(row.longitude),
+            altitudeMslFt:
+              row.altitude_msl_ft == null ? null : Number(row.altitude_msl_ft),
+          },
   headingDegrees:
     row.heading_degrees == null ? null : Number(row.heading_degrees),
   speedKnots: row.speed_knots == null ? null : Number(row.speed_knots),
@@ -241,6 +301,82 @@ export class ExternalOverlayRepository {
         input.confidence,
         input.freshnessSeconds,
         JSON.stringify(input.metadata),
+      ],
+    );
+
+    return toExternalOverlay(result.rows[0]);
+  }
+
+  async insertAreaConflictOverlay(
+    tx: PoolClient,
+    missionId: string,
+    input: CreateAreaConflictExternalOverlayInput,
+  ): Promise<ExternalOverlay> {
+    const geometryType = input.geometry.type;
+    const center =
+      geometryType === "circle"
+        ? { lat: input.geometry.centerLat, lng: input.geometry.centerLng }
+        : polygonCentroid(input.geometry.points);
+    const geometryMetadata =
+      geometryType === "circle"
+        ? {
+            radiusMeters: input.geometry.radiusMeters,
+            altitudeFloorFt: input.geometry.altitudeFloorFt ?? null,
+            altitudeCeilingFt: input.geometry.altitudeCeilingFt ?? null,
+          }
+        : {
+            points: input.geometry.points,
+            altitudeFloorFt: input.geometry.altitudeFloorFt ?? null,
+            altitudeCeilingFt: input.geometry.altitudeCeilingFt ?? null,
+          };
+
+    const result = await tx.query<ExternalOverlayRow>(
+      `
+      insert into mission_external_overlays (
+        id,
+        mission_id,
+        overlay_kind,
+        source_provider,
+        source_type,
+        source_record_id,
+        observed_at,
+        valid_from,
+        valid_to,
+        geometry_type,
+        latitude,
+        longitude,
+        altitude_msl_ft,
+        heading_degrees,
+        speed_knots,
+        severity,
+        confidence,
+        freshness_seconds,
+        metadata
+      )
+      values (
+        $1, $2, 'area_conflict', $3, $4, $5, $6, $7, $8, $9, $10, $11, null, null, null, $12, $13, $14, $15::jsonb
+      )
+      returning *
+      `,
+      [
+        randomUUID(),
+        missionId,
+        input.source.provider,
+        input.source.sourceType,
+        input.source.sourceRecordId,
+        input.observedAt,
+        input.validFrom,
+        input.validTo,
+        geometryType,
+        center.lat,
+        center.lng,
+        input.severity,
+        input.confidence,
+        input.freshnessSeconds,
+        JSON.stringify({
+          ...input.metadata,
+          ...geometryMetadata,
+        }),
       ],
     );
 

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -2,6 +2,7 @@ import type { Pool } from "pg";
 import { ExternalOverlayRepository } from "./external-overlay.repository";
 import { MissionExternalOverlayMissionNotFoundError } from "./external-overlay.errors";
 import type {
+  CreateAreaConflictExternalOverlayInput,
   CreateCrewedTrafficExternalOverlayInput,
   CreateDroneTrafficExternalOverlayInput,
   CreateWeatherExternalOverlayInput,
@@ -9,6 +10,7 @@ import type {
   ExternalOverlayKind,
 } from "./external-overlay.types";
 import {
+  validateCreateAreaConflictExternalOverlayInput,
   validateCreateCrewedTrafficExternalOverlayInput,
   validateCreateDroneTrafficExternalOverlayInput,
   validateCreateWeatherExternalOverlayInput,
@@ -92,6 +94,33 @@ export class ExternalOverlayService {
       }
 
       return await this.externalOverlayRepository.insertDroneTrafficOverlay(
+        client,
+        missionId,
+        validated,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  async createAreaConflictOverlay(
+    missionId: string,
+    input: unknown,
+  ): Promise<ExternalOverlay> {
+    const validated = validateCreateAreaConflictExternalOverlayInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.externalOverlayRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new MissionExternalOverlayMissionNotFoundError(missionId);
+      }
+
+      return await this.externalOverlayRepository.insertAreaConflictOverlay(
         client,
         missionId,
         validated,

--- a/src/external-overlays/external-overlay.types.ts
+++ b/src/external-overlays/external-overlay.types.ts
@@ -1,7 +1,8 @@
 export type ExternalOverlayKind =
   | "weather"
   | "crewed_traffic"
-  | "drone_traffic";
+  | "drone_traffic"
+  | "area_conflict";
 
 export type ExternalOverlaySeverity = "info" | "caution" | "critical";
 
@@ -18,7 +19,31 @@ export interface ExternalOverlayPointGeometry {
   altitudeMslFt: number | null;
 }
 
-export type ExternalOverlayGeometry = ExternalOverlayPointGeometry;
+export interface ExternalOverlayCircleGeometry {
+  type: "circle";
+  centerLat: number;
+  centerLng: number;
+  radiusMeters: number;
+  altitudeFloorFt: number | null;
+  altitudeCeilingFt: number | null;
+}
+
+export interface ExternalOverlayPolygonGeometry {
+  type: "polygon";
+  points: Array<{
+    lat: number;
+    lng: number;
+  }>;
+  centroidLat: number;
+  centroidLng: number;
+  altitudeFloorFt: number | null;
+  altitudeCeilingFt: number | null;
+}
+
+export type ExternalOverlayGeometry =
+  | ExternalOverlayPointGeometry
+  | ExternalOverlayCircleGeometry
+  | ExternalOverlayPolygonGeometry;
 
 export interface WeatherOverlayMetadata {
   windSpeedKnots: number;
@@ -47,6 +72,13 @@ export interface DroneTrafficOverlayMetadata {
   vehicleType: string | null;
   operatorReference: string | null;
   verticalRateFpm: number | null;
+}
+
+export interface AreaConflictOverlayMetadata {
+  areaId: string;
+  label: string;
+  areaType: string;
+  description: string | null;
 }
 
 export interface ExternalOverlay {
@@ -136,6 +168,40 @@ export interface CreateDroneTrafficExternalOverlayInput {
   confidence?: number | null;
   freshnessSeconds?: number | null;
   metadata: DroneTrafficOverlayMetadata;
+}
+
+export interface CreateAreaConflictExternalOverlayInput {
+  kind: "area_conflict";
+  source: {
+    provider: string;
+    sourceType: string;
+    sourceRecordId?: string | null;
+  };
+  observedAt: string;
+  validFrom?: string | null;
+  validTo?: string | null;
+  geometry:
+    | {
+        type: "circle";
+        centerLat: number;
+        centerLng: number;
+        radiusMeters: number;
+        altitudeFloorFt?: number | null;
+        altitudeCeilingFt?: number | null;
+      }
+    | {
+        type: "polygon";
+        points: Array<{
+          lat: number;
+          lng: number;
+        }>;
+        altitudeFloorFt?: number | null;
+        altitudeCeilingFt?: number | null;
+      };
+  severity?: ExternalOverlaySeverity | null;
+  confidence?: number | null;
+  freshnessSeconds?: number | null;
+  metadata: AreaConflictOverlayMetadata;
 }
 
 export interface ListExternalOverlaysFilters {

--- a/src/external-overlays/external-overlay.validators.ts
+++ b/src/external-overlays/external-overlay.validators.ts
@@ -1,4 +1,5 @@
 import type {
+  CreateAreaConflictExternalOverlayInput,
   CreateCrewedTrafficExternalOverlayInput,
   CreateDroneTrafficExternalOverlayInput,
   CreateWeatherExternalOverlayInput,
@@ -305,6 +306,114 @@ export const validateCreateDroneTrafficExternalOverlayInput = (
         candidate.metadata.verticalRateFpm,
         "metadata.verticalRateFpm",
       ),
+    },
+  };
+};
+
+export const validateCreateAreaConflictExternalOverlayInput = (
+  input: unknown,
+): CreateAreaConflictExternalOverlayInput => {
+  if (!input || typeof input !== "object") {
+    throw new Error("request body is required");
+  }
+
+  const candidate = input as Record<string, any>;
+  if (candidate.kind !== "area_conflict") {
+    throw new Error("kind must be 'area_conflict'");
+  }
+
+  if (!candidate.source || typeof candidate.source !== "object") {
+    throw new Error("source is required");
+  }
+
+  if (!candidate.geometry || typeof candidate.geometry !== "object") {
+    throw new Error("geometry is required");
+  }
+
+  if (!candidate.metadata || typeof candidate.metadata !== "object") {
+    throw new Error("metadata is required");
+  }
+
+  const geometryType = requiredString(
+    candidate.geometry.type,
+    "geometry.type",
+  ).toLowerCase();
+
+  let geometry: CreateAreaConflictExternalOverlayInput["geometry"];
+  if (geometryType === "circle") {
+    geometry = {
+      type: "circle",
+      centerLat: requiredNumber(candidate.geometry.centerLat, "geometry.centerLat"),
+      centerLng: requiredNumber(candidate.geometry.centerLng, "geometry.centerLng"),
+      radiusMeters: requiredNumber(
+        candidate.geometry.radiusMeters,
+        "geometry.radiusMeters",
+      ),
+      altitudeFloorFt: optionalNumber(
+        candidate.geometry.altitudeFloorFt,
+        "geometry.altitudeFloorFt",
+      ),
+      altitudeCeilingFt: optionalNumber(
+        candidate.geometry.altitudeCeilingFt,
+        "geometry.altitudeCeilingFt",
+      ),
+    };
+  } else if (geometryType === "polygon") {
+    if (
+      !Array.isArray(candidate.geometry.points) ||
+      candidate.geometry.points.length < 3
+    ) {
+      throw new Error("geometry.points must contain at least three points");
+    }
+
+    geometry = {
+      type: "polygon",
+      points: candidate.geometry.points.map((point: unknown, index: number) => {
+        if (!point || typeof point !== "object") {
+          throw new Error(`geometry.points[${index}] must be an object`);
+        }
+
+        const value = point as Record<string, unknown>;
+        return {
+          lat: requiredNumber(value.lat, `geometry.points[${index}].lat`),
+          lng: requiredNumber(value.lng, `geometry.points[${index}].lng`),
+        };
+      }),
+      altitudeFloorFt: optionalNumber(
+        candidate.geometry.altitudeFloorFt,
+        "geometry.altitudeFloorFt",
+      ),
+      altitudeCeilingFt: optionalNumber(
+        candidate.geometry.altitudeCeilingFt,
+        "geometry.altitudeCeilingFt",
+      ),
+    };
+  } else {
+    throw new Error("geometry.type must be 'circle' or 'polygon'");
+  }
+
+  return {
+    kind: "area_conflict",
+    source: {
+      provider: requiredString(candidate.source.provider, "source.provider"),
+      sourceType: requiredString(candidate.source.sourceType, "source.sourceType"),
+      sourceRecordId: optionalString(candidate.source.sourceRecordId),
+    },
+    observedAt: requiredTimestamp(candidate.observedAt, "observedAt"),
+    validFrom: optionalTimestamp(candidate.validFrom, "validFrom"),
+    validTo: optionalTimestamp(candidate.validTo, "validTo"),
+    geometry,
+    severity: optionalSeverity(candidate.severity),
+    confidence: optionalNumber(candidate.confidence, "confidence"),
+    freshnessSeconds:
+      candidate.freshnessSeconds == null
+        ? null
+        : requiredNumber(candidate.freshnessSeconds, "freshnessSeconds"),
+    metadata: {
+      areaId: requiredString(candidate.metadata.areaId, "metadata.areaId"),
+      label: requiredString(candidate.metadata.label, "metadata.label"),
+      areaType: requiredString(candidate.metadata.areaType, "metadata.areaType"),
+      description: optionalString(candidate.metadata.description),
     },
   };
 };

--- a/src/migrations/030_extend_mission_external_overlays_for_area_conflicts.sql
+++ b/src/migrations/030_extend_mission_external_overlays_for_area_conflicts.sql
@@ -1,0 +1,6 @@
+alter table mission_external_overlays
+  drop constraint if exists mission_external_overlays_kind_chk;
+
+alter table mission_external_overlays
+  add constraint mission_external_overlays_kind_chk
+    check (overlay_kind in ('weather', 'crewed_traffic', 'drone_traffic', 'area_conflict'));

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -368,7 +368,80 @@ describe("mission external overlays integration", () => {
     });
   });
 
-  it("keeps weather, crewed traffic, and drone traffic paths intact when listed together", async () => {
+  it("creates and lists area conflict overlays through the mission-linked external overlay boundary", async () => {
+    const missionId = await createMission();
+
+    const createResponse = await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "area_conflict",
+        source: {
+          provider: "airspace-hub",
+          sourceType: "zone_service",
+          sourceRecordId: "zone-6006",
+        },
+        observedAt: "2026-04-21T10:07:00.000Z",
+        geometry: {
+          type: "circle",
+          centerLat: 51.5078,
+          centerLng: -0.1269,
+          radiusMeters: 350,
+          altitudeFloorFt: 100,
+          altitudeCeilingFt: 900,
+        },
+        severity: "caution",
+        metadata: {
+          areaId: "zone-6006",
+          label: "Tower protection zone",
+          areaType: "restricted_zone",
+          description: "Temporary restricted area around event site",
+        },
+      });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.overlay).toMatchObject({
+      missionId,
+      kind: "area_conflict",
+      geometry: {
+        type: "circle",
+        centerLat: 51.5078,
+        centerLng: -0.1269,
+        radiusMeters: 350,
+        altitudeFloorFt: 100,
+        altitudeCeilingFt: 900,
+      },
+      metadata: {
+        areaId: "zone-6006",
+        label: "Tower protection zone",
+        areaType: "restricted_zone",
+        description: "Temporary restricted area around event site",
+      },
+    });
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays?kind=area_conflict`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body).toMatchObject({
+      missionId,
+      overlays: [
+        expect.objectContaining({
+          kind: "area_conflict",
+          geometry: expect.objectContaining({
+            type: "circle",
+            radiusMeters: 350,
+          }),
+          metadata: expect.objectContaining({
+            areaId: "zone-6006",
+            label: "Tower protection zone",
+          }),
+        }),
+      ],
+    });
+  });
+
+  it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 
     await request(app)
@@ -422,6 +495,34 @@ describe("mission external overlays integration", () => {
     await request(app)
       .post(`/missions/${missionId}/external-overlays`)
       .send({
+        kind: "area_conflict",
+        source: {
+          provider: "airspace-hub",
+          sourceType: "zone_service",
+        },
+        observedAt: "2026-04-21T10:06:00.000Z",
+        geometry: {
+          type: "polygon",
+          points: [
+            { lat: 51.5072, lng: -0.1285 },
+            { lat: 51.5089, lng: -0.1285 },
+            { lat: 51.5089, lng: -0.126 },
+            { lat: 51.5072, lng: -0.126 },
+          ],
+          altitudeFloorFt: 0,
+          altitudeCeilingFt: 1200,
+        },
+        metadata: {
+          areaId: "zone-7007",
+          label: "City event exclusion area",
+          areaType: "event_restriction",
+          description: null,
+        },
+      });
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
         kind: "drone_traffic",
         source: {
           provider: "utm-hub",
@@ -455,6 +556,7 @@ describe("mission external overlays integration", () => {
         expect.objectContaining({ kind: "weather" }),
         expect.objectContaining({ kind: "crewed_traffic" }),
         expect.objectContaining({ kind: "drone_traffic" }),
+        expect.objectContaining({ kind: "area_conflict" }),
       ]),
     );
   });

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2038,6 +2038,7 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("formatBearingDegrees");
     expect(response.text).toContain("rangeMeters");
     expect(response.text).toContain("bearingDegrees");
+    expect(response.text).toContain("insideArea");
     expect(response.text).toContain("primaryConflictAssessmentItem");
     expect(response.text).toContain("secondaryConflictAssessmentItems");
     expect(response.text).toContain("primaryConflictAdvisory");

--- a/src/tests/traffic-conflict-assessment.test.ts
+++ b/src/tests/traffic-conflict-assessment.test.ts
@@ -215,6 +215,107 @@ describe("traffic conflict assessment integration", () => {
     expect(after.rows).toEqual(before.rows);
   });
 
+  it("assesses area conflict geometry using nearest-boundary range and bearing metadata", async () => {
+    const missionId = await createMission();
+    await recordTelemetry(missionId);
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "area_conflict",
+        source: {
+          provider: "airspace-hub",
+          sourceType: "zone_service",
+        },
+        observedAt: "2026-04-21T12:00:10.000Z",
+        geometry: {
+          type: "circle",
+          centerLat: 51.5075,
+          centerLng: -0.1277,
+          radiusMeters: 150,
+          altitudeFloorFt: 0,
+          altitudeCeilingFt: 1000,
+        },
+        severity: "critical",
+        metadata: {
+          areaId: "zone-1",
+          label: "Restricted tower zone",
+          areaType: "restricted_zone",
+          description: "Temporary restriction",
+        },
+      });
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "area_conflict",
+        source: {
+          provider: "airspace-hub",
+          sourceType: "zone_service",
+        },
+        observedAt: "2026-04-21T12:00:20.000Z",
+        geometry: {
+          type: "polygon",
+          points: [
+            { lat: 51.5071, lng: -0.1281 },
+            { lat: 51.5071, lng: -0.1269 },
+            { lat: 51.5079, lng: -0.1269 },
+            { lat: 51.5079, lng: -0.1281 },
+          ],
+          altitudeFloorFt: 0,
+          altitudeCeilingFt: 900,
+        },
+        severity: "caution",
+        metadata: {
+          areaId: "zone-2",
+          label: "Event exclusion polygon",
+          areaType: "event_restriction",
+          description: null,
+        },
+      });
+
+    const response = await request(app).get(
+      `/missions/${missionId}/conflict-assessment`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.assessment.conflicts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          missionId,
+          overlayKind: "area_conflict",
+          overlayLabel: "Restricted tower zone",
+          measurementBasis: {
+            referencePoint: "latest_telemetry",
+            targetGeometry: "overlay_circle",
+            rangeRule: "nearest_boundary",
+            bearingReference: "true_north",
+          },
+          metrics: expect.objectContaining({
+            rangeMeters: expect.any(Number),
+            bearingDegrees: expect.any(Number),
+            insideArea: expect.any(Boolean),
+          }),
+        }),
+        expect.objectContaining({
+          missionId,
+          overlayKind: "area_conflict",
+          overlayLabel: "Event exclusion polygon",
+          measurementBasis: {
+            referencePoint: "latest_telemetry",
+            targetGeometry: "overlay_polygon",
+            rangeRule: "nearest_boundary",
+            bearingReference: "true_north",
+          },
+          metrics: expect.objectContaining({
+            rangeMeters: expect.any(Number),
+            insideArea: expect.any(Boolean),
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("preserves mission isolation for conflict assessment reads", async () => {
     const firstMissionId = await createMission();
     const secondMissionId = await createMission();

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -162,6 +162,9 @@ const formatRangeBearing = (metrics) => {
       ? "Unknown range"
       : `${Math.round(rangeMeters)} m`;
   const bearingText = formatBearingDegrees(metrics?.bearingDegrees ?? null);
+  if (metrics?.insideArea === true) {
+    return `Inside area | ${rangeText} to boundary @ ${bearingText}`;
+  }
   return `${rangeText} @ ${bearingText}`;
 };
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #173 by adding area conflict geometry support to mission-linked conflict assessment so bearing and range metadata can extend beyond traffic overlays.

## What changed

- Extended the shared mission-linked external overlay model to support:
  - `area_conflict`
  - `circle` geometry
  - `polygon` geometry
- Added migration support to allow `area_conflict` overlay kinds in `mission_external_overlays`.
- Kept the change inside the existing mission-linked overlay and interpreted conflict assessment boundaries.
- Added validation, service, controller, and repository support for creating and listing area conflict overlays through:
  - `POST /missions/:missionId/external-overlays`
  - `GET /missions/:missionId/external-overlays`
- Implemented nearest-boundary conflict assessment for area geometry:
  - circles use center/radius with nearest-boundary range
  - polygons use nearest-boundary range derived from polygon edges
- Extended conflict assessment output to make the measurement basis explicit for area conflicts:
  - `targetGeometry`
  - `rangeRule`
  - `bearingReference`
  - `insideArea`
- Preserved the existing traffic conflict behavior from `#171`.
- Updated the staged live-ops UI so area conflicts surface as read-only range/bearing context, including inside-area boundary wording where applicable.
- Updated the save point to the next backend-focused refinement step:
  - altitude-band gating and vertical context refinement for area conflicts

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 8 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 5 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 333 tests.

## Notes

This issue adds geometry-aware interpreted conflict support for area overlays. It does not add operator command automation, lifecycle automation, or avoidance execution.

Closes #173.
