### PR TITLE
Add normalized area overlay ingestion

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add migration-backed normalized area overlay ingestion for danger areas, temporary danger areas, and NOTAM-derived restrictions so mission-linked area conflict assessment can operate on authoritative area geometry.",
+  "nextBuildStep": "Add altitude-band gating and vertical context refinement to mission-linked area conflict assessment so normalized danger areas and NOTAM-derived restrictions only trigger within relevant operating volumes.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -51,6 +51,24 @@ export class ExternalOverlayController {
     }
   };
 
+  normalizeAreaOverlaySources = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const result =
+        await this.externalOverlayService.normalizeAreaOverlaySources(
+          req.params.missionId,
+          req.body,
+        );
+
+      res.status(201).json(result);
+    } catch (error) {
+      next(error);
+    }
+  };
+
   listExternalOverlays = async (
     req: Request<MissionIdParams>,
     res: Response,

--- a/src/external-overlays/external-overlay.routes.ts
+++ b/src/external-overlays/external-overlay.routes.ts
@@ -6,6 +6,10 @@ export function createExternalOverlayRouter(
 ): Router {
   const router = Router();
 
+  router.post(
+    "/:missionId/external-overlays/normalize-area-sources",
+    controller.normalizeAreaOverlaySources,
+  );
   router.post("/:missionId/external-overlays", controller.createExternalOverlay);
   router.get("/:missionId/external-overlays", controller.listExternalOverlays);
 

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -8,11 +8,13 @@ import type {
   CreateWeatherExternalOverlayInput,
   ExternalOverlay,
   ExternalOverlayKind,
+  NormalizeAreaOverlaySourcesInput,
 } from "./external-overlay.types";
 import {
   validateCreateAreaConflictExternalOverlayInput,
   validateCreateCrewedTrafficExternalOverlayInput,
   validateCreateDroneTrafficExternalOverlayInput,
+  validateNormalizeAreaOverlaySourcesInput,
   validateCreateWeatherExternalOverlayInput,
 } from "./external-overlay.validators";
 
@@ -125,6 +127,62 @@ export class ExternalOverlayService {
         missionId,
         validated,
       );
+    } finally {
+      client.release();
+    }
+  }
+
+  async normalizeAreaOverlaySources(
+    missionId: string,
+    input: unknown,
+  ): Promise<{ missionId: string; overlays: ExternalOverlay[] }> {
+    const validated = validateNormalizeAreaOverlaySourcesInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.externalOverlayRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new MissionExternalOverlayMissionNotFoundError(missionId);
+      }
+
+      const overlays: ExternalOverlay[] = [];
+      for (const record of validated.records) {
+        overlays.push(
+          await this.externalOverlayRepository.insertAreaConflictOverlay(
+            client,
+            missionId,
+            {
+              kind: "area_conflict",
+              source: record.source,
+              observedAt: record.observedAt,
+              validFrom: record.validFrom,
+              validTo: record.validTo,
+              geometry: record.geometry,
+              severity: record.severity,
+              confidence: record.confidence,
+              freshnessSeconds: record.freshnessSeconds,
+              metadata: {
+                areaId: record.area.areaId,
+                label: record.area.label,
+                areaType: record.area.areaType,
+                description: record.area.description ?? null,
+                authorityName: record.area.authorityName ?? null,
+                notamNumber: record.area.notamNumber ?? null,
+                sourceReference: record.area.sourceReference ?? null,
+              },
+            },
+          ),
+        );
+      }
+
+      return {
+        missionId,
+        overlays,
+      };
     } finally {
       client.release();
     }

--- a/src/external-overlays/external-overlay.types.ts
+++ b/src/external-overlays/external-overlay.types.ts
@@ -79,6 +79,9 @@ export interface AreaConflictOverlayMetadata {
   label: string;
   areaType: string;
   description: string | null;
+  authorityName?: string | null;
+  notamNumber?: string | null;
+  sourceReference?: string | null;
 }
 
 export interface ExternalOverlay {
@@ -202,6 +205,57 @@ export interface CreateAreaConflictExternalOverlayInput {
   confidence?: number | null;
   freshnessSeconds?: number | null;
   metadata: AreaConflictOverlayMetadata;
+}
+
+export interface NormalizeAreaOverlaySourceRecordInput {
+  source: {
+    provider: string;
+    sourceType:
+      | "danger_area"
+      | "temporary_danger_area"
+      | "notam_restriction";
+    sourceRecordId?: string | null;
+  };
+  observedAt: string;
+  validFrom?: string | null;
+  validTo?: string | null;
+  geometry:
+    | {
+        type: "circle";
+        centerLat: number;
+        centerLng: number;
+        radiusMeters: number;
+        altitudeFloorFt?: number | null;
+        altitudeCeilingFt?: number | null;
+      }
+    | {
+        type: "polygon";
+        points: Array<{
+          lat: number;
+          lng: number;
+        }>;
+        altitudeFloorFt?: number | null;
+        altitudeCeilingFt?: number | null;
+      };
+  severity?: ExternalOverlaySeverity | null;
+  confidence?: number | null;
+  freshnessSeconds?: number | null;
+  area: {
+    areaId: string;
+    label: string;
+    areaType:
+      | "danger_area"
+      | "temporary_danger_area"
+      | "notam_restriction";
+    description?: string | null;
+    authorityName?: string | null;
+    notamNumber?: string | null;
+    sourceReference?: string | null;
+  };
+}
+
+export interface NormalizeAreaOverlaySourcesInput {
+  records: NormalizeAreaOverlaySourceRecordInput[];
 }
 
 export interface ListExternalOverlaysFilters {

--- a/src/external-overlays/external-overlay.validators.ts
+++ b/src/external-overlays/external-overlay.validators.ts
@@ -4,10 +4,16 @@ import type {
   CreateDroneTrafficExternalOverlayInput,
   CreateWeatherExternalOverlayInput,
   ExternalOverlaySeverity,
+  NormalizeAreaOverlaySourcesInput,
 } from "./external-overlay.types";
 
 const SEVERITIES: ExternalOverlaySeverity[] = ["info", "caution", "critical"];
 const PRECIPITATION = ["none", "drizzle", "rain", "snow", "hail", "mixed"];
+const AREA_SOURCE_TYPES = [
+  "danger_area",
+  "temporary_danger_area",
+  "notam_restriction",
+] as const;
 
 const requiredString = (value: unknown, fieldName: string): string => {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -414,6 +420,124 @@ export const validateCreateAreaConflictExternalOverlayInput = (
       label: requiredString(candidate.metadata.label, "metadata.label"),
       areaType: requiredString(candidate.metadata.areaType, "metadata.areaType"),
       description: optionalString(candidate.metadata.description),
+      authorityName: optionalString(candidate.metadata.authorityName),
+      notamNumber: optionalString(candidate.metadata.notamNumber),
+      sourceReference: optionalString(candidate.metadata.sourceReference),
     },
+  };
+};
+
+export const validateNormalizeAreaOverlaySourcesInput = (
+  input: unknown,
+): NormalizeAreaOverlaySourcesInput => {
+  if (!input || typeof input !== "object") {
+    throw new Error("request body is required");
+  }
+
+  const candidate = input as Record<string, unknown>;
+  if (!Array.isArray(candidate.records) || candidate.records.length === 0) {
+    throw new Error("records must be a non-empty array");
+  }
+
+  return {
+    records: candidate.records.map((record, index) => {
+      if (!record || typeof record !== "object") {
+        throw new Error(`records[${index}] must be an object`);
+      }
+
+      const value = record as Record<string, any>;
+      if (!value.source || typeof value.source !== "object") {
+        throw new Error(`records[${index}].source is required`);
+      }
+      if (!value.area || typeof value.area !== "object") {
+        throw new Error(`records[${index}].area is required`);
+      }
+      if (!value.geometry || typeof value.geometry !== "object") {
+        throw new Error(`records[${index}].geometry is required`);
+      }
+
+      const sourceType = requiredString(
+        value.source.sourceType,
+        `records[${index}].source.sourceType`,
+      ).toLowerCase();
+      if (
+        !AREA_SOURCE_TYPES.includes(
+          sourceType as (typeof AREA_SOURCE_TYPES)[number],
+        )
+      ) {
+        throw new Error(
+          `records[${index}].source.sourceType must be one of: danger_area, temporary_danger_area, notam_restriction`,
+        );
+      }
+
+      const areaType = requiredString(
+        value.area.areaType,
+        `records[${index}].area.areaType`,
+      ).toLowerCase();
+      if (
+        !AREA_SOURCE_TYPES.includes(
+          areaType as (typeof AREA_SOURCE_TYPES)[number],
+        )
+      ) {
+        throw new Error(
+          `records[${index}].area.areaType must be one of: danger_area, temporary_danger_area, notam_restriction`,
+        );
+      }
+
+      const normalized = validateCreateAreaConflictExternalOverlayInput({
+        kind: "area_conflict",
+        source: {
+          provider: value.source.provider,
+          sourceType,
+          sourceRecordId: value.source.sourceRecordId,
+        },
+        observedAt: value.observedAt,
+        validFrom: value.validFrom,
+        validTo: value.validTo,
+        geometry: value.geometry,
+        severity: value.severity,
+        confidence: value.confidence,
+        freshnessSeconds: value.freshnessSeconds,
+        metadata: {
+          areaId: value.area.areaId,
+          label: value.area.label,
+          areaType,
+          description: value.area.description,
+          authorityName: value.area.authorityName,
+          notamNumber: value.area.notamNumber,
+          sourceReference: value.area.sourceReference,
+        },
+      });
+
+      return {
+        source: {
+          provider: normalized.source.provider,
+          sourceType: normalized.source.sourceType as
+            | "danger_area"
+            | "temporary_danger_area"
+            | "notam_restriction",
+          sourceRecordId: normalized.source.sourceRecordId,
+        },
+        observedAt: normalized.observedAt,
+        validFrom: normalized.validFrom,
+        validTo: normalized.validTo,
+        geometry: normalized.geometry,
+        severity: normalized.severity,
+        confidence: normalized.confidence,
+        freshnessSeconds: normalized.freshnessSeconds,
+        area: {
+          areaId: normalized.metadata.areaId,
+          label: normalized.metadata.label,
+          areaType: normalized.metadata.areaType as
+            | "danger_area"
+            | "temporary_danger_area"
+            | "notam_restriction",
+          description: normalized.metadata.description ?? null,
+          authorityName: normalized.metadata.authorityName ?? null,
+          notamNumber: normalized.metadata.notamNumber ?? null,
+          sourceReference: normalized.metadata.sourceReference ?? null,
+        },
+      };
+    }),
   };
 };

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -441,6 +441,126 @@ describe("mission external overlays integration", () => {
     });
   });
 
+  it("normalizes authoritative danger area and NOTAM records into area conflict overlays", async () => {
+    const missionId = await createMission();
+
+    const normalizeResponse = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-101",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-101",
+              label: "Danger Area EGD-101",
+              areaType: "danger_area",
+              description: "Permanent danger area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1234/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:15:00.000Z",
+            validTo: "2026-04-21T16:00:00.000Z",
+            geometry: {
+              type: "polygon",
+              points: [
+                { lat: 51.5072, lng: -0.1285 },
+                { lat: 51.5089, lng: -0.1285 },
+                { lat: 51.5089, lng: -0.126 },
+                { lat: 51.5072, lng: -0.126 },
+              ],
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1234-26",
+              label: "Stadium TFR",
+              areaType: "notam_restriction",
+              description: "Event restriction from NOTAM",
+              authorityName: "NATS",
+              notamNumber: "B1234/26",
+              sourceReference: "NOTAM B1234/26",
+            },
+          },
+        ],
+      });
+
+    expect(normalizeResponse.status).toBe(201);
+    expect(normalizeResponse.body).toMatchObject({
+      missionId,
+      overlays: [
+        expect.objectContaining({
+          kind: "area_conflict",
+          source: expect.objectContaining({
+            provider: "uk-ais",
+            sourceType: "danger_area",
+            sourceRecordId: "EGD-101",
+          }),
+          metadata: expect.objectContaining({
+            areaId: "EGD-101",
+            areaType: "danger_area",
+            authorityName: "CAA",
+            sourceReference: "ENR 5.1",
+          }),
+        }),
+        expect.objectContaining({
+          kind: "area_conflict",
+          source: expect.objectContaining({
+            provider: "uk-ais",
+            sourceType: "notam_restriction",
+            sourceRecordId: "B1234/26",
+          }),
+          metadata: expect.objectContaining({
+            areaId: "NOTAM-B1234-26",
+            areaType: "notam_restriction",
+            notamNumber: "B1234/26",
+            sourceReference: "NOTAM B1234/26",
+          }),
+        }),
+      ],
+    });
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays?kind=area_conflict`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.overlays).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: expect.objectContaining({ sourceType: "danger_area" }),
+        }),
+        expect.objectContaining({
+          source: expect.objectContaining({ sourceType: "notam_restriction" }),
+        }),
+      ]),
+    );
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 

--- a/src/tests/traffic-conflict-assessment.test.ts
+++ b/src/tests/traffic-conflict-assessment.test.ts
@@ -316,6 +316,108 @@ describe("traffic conflict assessment integration", () => {
     );
   });
 
+  it("consumes normalized authoritative area overlays without source-specific conflict branching", async () => {
+    const missionId = await createMission();
+    await recordTelemetry(missionId);
+
+    const normalizeResponse = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-33",
+            },
+            observedAt: "2026-04-21T12:00:10.000Z",
+            validFrom: "2026-04-21T12:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5075,
+              centerLng: -0.1277,
+              radiusMeters: 150,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            area: {
+              areaId: "TDA-33",
+              label: "Temporary Danger Area 33",
+              areaType: "temporary_danger_area",
+              description: "Temporary activity area",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1234/26",
+            },
+            observedAt: "2026-04-21T12:00:20.000Z",
+            validFrom: "2026-04-21T12:00:00.000Z",
+            validTo: "2026-04-21T15:00:00.000Z",
+            geometry: {
+              type: "polygon",
+              points: [
+                { lat: 51.5071, lng: -0.1281 },
+                { lat: 51.5071, lng: -0.1269 },
+                { lat: 51.5079, lng: -0.1269 },
+                { lat: 51.5079, lng: -0.1281 },
+              ],
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            area: {
+              areaId: "NOTAM-B1234-26",
+              label: "NOTAM Restricted Zone",
+              areaType: "notam_restriction",
+              description: "Event restriction",
+              authorityName: "NATS",
+              notamNumber: "B1234/26",
+              sourceReference: "NOTAM B1234/26",
+            },
+          },
+        ],
+      });
+
+    expect(normalizeResponse.status).toBe(201);
+
+    const response = await request(app).get(
+      `/missions/${missionId}/conflict-assessment`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.assessment.conflicts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          overlayKind: "area_conflict",
+          overlayLabel: "Temporary Danger Area 33",
+          relatedSource: expect.objectContaining({
+            provider: "uk-ais",
+            sourceType: "temporary_danger_area",
+          }),
+          measurementBasis: expect.objectContaining({
+            rangeRule: "nearest_boundary",
+          }),
+        }),
+        expect.objectContaining({
+          overlayKind: "area_conflict",
+          overlayLabel: "NOTAM Restricted Zone",
+          relatedSource: expect.objectContaining({
+            provider: "uk-ais",
+            sourceType: "notam_restriction",
+          }),
+          measurementBasis: expect.objectContaining({
+            rangeRule: "nearest_boundary",
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("preserves mission isolation for conflict assessment reads", async () => {
     const firstMissionId = await createMission();
     const secondMissionId = await createMission();


### PR DESCRIPTION
## Summary

Implements GitHub issue #175 by adding normalized area overlay ingestion for danger areas, temporary danger areas, and NOTAM-derived restrictions.

## What changed

- Added a dedicated normalization endpoint on the existing mission-linked external overlay boundary:
  - `POST /missions/:missionId/external-overlays/normalize-area-sources`
- Kept normalized outputs on the existing mission-linked area overlay model:
  - `area_conflict`
- Added normalized authoritative area-source input support for:
  - `danger_area`
  - `temporary_danger_area`
  - `notam_restriction`
- Normalized ingested records into the existing mission-linked external overlay boundary with:
  - geometry
  - altitude floor / ceiling
  - valid-from / valid-to window
  - source provider
  - source record id
  - traceability metadata
- Preserved source traceability metadata on normalized area overlays, including where available:
  - authority name
  - NOTAM number
  - source reference
- Kept the interpreted conflict assessment layer source-agnostic by feeding it normalized area overlays instead of raw source-specific formats.
- Verified that mission-linked conflict assessment can consume normalized area overlays without source-specific branching logic.
- Updated the save point to the next backend refinement step:
  - altitude-band gating and vertical context refinement for normalized area conflicts

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 9 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 6 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 335 tests.

## Notes

This issue adds authoritative area-source normalization only. It does not add operator automation, advisory execution, or lifecycle changes.

Closes #175.
