### PR TITLE
Add area conflict altitude-band gating

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add altitude-band gating and vertical context refinement to mission-linked area conflict assessment so normalized danger areas and NOTAM-derived restrictions only trigger within relevant operating volumes.",
+  "nextBuildStep": "Add validity-window gating to mission-linked area conflict assessment so normalized danger areas and NOTAM-derived restrictions only trigger when the replay or telemetry reference time falls inside the active restriction window.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/conflict-assessment/traffic-conflict-assessment.service.ts
+++ b/src/conflict-assessment/traffic-conflict-assessment.service.ts
@@ -372,22 +372,51 @@ const classifyTrafficConflict = (
   return null;
 };
 
-const areaAltitudeRelevant = (
+const deriveAreaVerticalContext = (
   referenceAltitudeFt: number | null,
   floorFt: number | null,
   ceilingFt: number | null,
-): boolean => {
-  if (referenceAltitudeFt == null) {
-    return true;
-  }
-  if (floorFt != null && referenceAltitudeFt < floorFt) {
-    return false;
-  }
-  if (ceilingFt != null && referenceAltitudeFt > ceilingFt) {
-    return false;
+): TrafficConflictAssessmentItem["verticalContext"] => {
+  if (floorFt == null && ceilingFt == null) {
+    return {
+      referenceAltitudeFt,
+      altitudeFloorFt: null,
+      altitudeCeilingFt: null,
+      relation: "not_applicable",
+    };
   }
 
-  return true;
+  if (referenceAltitudeFt == null) {
+    return {
+      referenceAltitudeFt: null,
+      altitudeFloorFt: floorFt,
+      altitudeCeilingFt: ceilingFt,
+      relation: "unknown",
+    };
+  }
+  if (floorFt != null && referenceAltitudeFt < floorFt) {
+    return {
+      referenceAltitudeFt,
+      altitudeFloorFt: floorFt,
+      altitudeCeilingFt: ceilingFt,
+      relation: "below_band",
+    };
+  }
+  if (ceilingFt != null && referenceAltitudeFt > ceilingFt) {
+    return {
+      referenceAltitudeFt,
+      altitudeFloorFt: floorFt,
+      altitudeCeilingFt: ceilingFt,
+      relation: "above_band",
+    };
+  }
+
+  return {
+    referenceAltitudeFt,
+    altitudeFloorFt: floorFt,
+    altitudeCeilingFt: ceilingFt,
+    relation: "inside_band",
+  };
 };
 
 const classifyAreaConflict = (
@@ -542,13 +571,15 @@ export class TrafficConflictAssessmentService {
               geometry.type === "circle"
                 ? geometry.altitudeCeilingFt
                 : geometry.altitudeCeilingFt;
+            const verticalContext = deriveAreaVerticalContext(
+              referenceAltitudeFt,
+              altitudeFloorFt,
+              altitudeCeilingFt,
+            );
 
             if (
-              !areaAltitudeRelevant(
-                referenceAltitudeFt,
-                altitudeFloorFt,
-                altitudeCeilingFt,
-              )
+              verticalContext.relation === "below_band" ||
+              verticalContext.relation === "above_band"
             ) {
               return null;
             }
@@ -566,8 +597,6 @@ export class TrafficConflictAssessmentService {
               return null;
             }
 
-            const areaMetadata =
-              overlay.metadata as unknown as AreaConflictOverlayMetadata;
             const severity = escalateSeverity(
               overlay.severity ?? classification.severity,
               weather.steps,
@@ -578,23 +607,29 @@ export class TrafficConflictAssessmentService {
               classification.status === "conflict_candidate"
                 ? `${overlayLabel} area conflict candidate`
                 : `${overlayLabel} area monitor candidate`;
-            const verticalContext =
+            const altitudeBandText =
               altitudeFloorFt != null || altitudeCeilingFt != null
                 ? ` altitude band ${altitudeFloorFt ?? "surface"}-${altitudeCeilingFt ?? "open"} ft`
                 : "";
+            const verticalRelationText =
+              verticalContext.relation === "inside_band"
+                ? "mission reference altitude is inside the active altitude band"
+                : verticalContext.relation === "unknown"
+                  ? "mission reference altitude is unknown for altitude-band gating"
+                  : "altitude band not applicable";
             const explanation = geometryAssessment.insideArea
               ? `Area conflict proximity candidate: mission reference is inside ${geometryLabel} ${overlayLabel}; nearest boundary ${round(geometryAssessment.rangeMeters)} m away, ${
                   geometryAssessment.bearingDegrees == null
                     ? "unknown bearing"
                     : `${round(geometryAssessment.bearingDegrees)}° bearing from mission reference`
-                },${verticalContext}${weather.reason ? ` ${weather.reason}` : ""}.`
+                }, ${verticalRelationText}.${altitudeBandText ? `${altitudeBandText}.` : ""}${weather.reason ? ` ${weather.reason}.` : ""}`
               : `Area conflict proximity candidate: ${overlayLabel} boundary is ${round(
                   geometryAssessment.rangeMeters,
                 )} m away at ${
                   geometryAssessment.bearingDegrees == null
                     ? "unknown bearing"
                     : `${round(geometryAssessment.bearingDegrees)}° bearing from mission reference`
-                },${verticalContext}${weather.reason ? ` ${weather.reason}` : ""}.`;
+                }, ${verticalRelationText}.${altitudeBandText ? `${altitudeBandText}.` : ""}${weather.reason ? ` ${weather.reason}.` : ""}`;
 
             return {
               id: randomUUID(),
@@ -617,6 +652,7 @@ export class TrafficConflictAssessmentService {
                 rangeRule: "nearest_boundary",
                 bearingReference: "true_north",
               },
+              verticalContext,
               metrics: {
                 rangeMeters: round(geometryAssessment.rangeMeters),
                 bearingDegrees: round(geometryAssessment.bearingDegrees),
@@ -707,6 +743,12 @@ export class TrafficConflictAssessmentService {
               rangeRule: "point_to_point",
               bearingReference: "true_north",
             },
+            verticalContext: {
+              referenceAltitudeFt,
+              altitudeFloorFt: null,
+              altitudeCeilingFt: null,
+              relation: "not_applicable",
+            },
             metrics: {
               rangeMeters: round(lateralDistanceMeters),
               bearingDegrees: round(bearingToOverlayDegrees),
@@ -749,3 +791,4 @@ export class TrafficConflictAssessmentService {
     }
   }
 }
+

--- a/src/conflict-assessment/traffic-conflict-assessment.types.ts
+++ b/src/conflict-assessment/traffic-conflict-assessment.types.ts
@@ -41,6 +41,17 @@ export interface TrafficConflictAssessmentItem {
     rangeRule: "point_to_point" | "nearest_boundary";
     bearingReference: "true_north";
   };
+  verticalContext: {
+    referenceAltitudeFt: number | null;
+    altitudeFloorFt: number | null;
+    altitudeCeilingFt: number | null;
+    relation:
+      | "not_applicable"
+      | "unknown"
+      | "below_band"
+      | "inside_band"
+      | "above_band";
+  };
   metrics: {
     rangeMeters: number | null;
     bearingDegrees: number | null;

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2035,10 +2035,12 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("conflictAssessmentSummary");
     expect(response.text).toContain("conflictAdvisorySummary");
     expect(response.text).toContain("formatRangeBearing");
+    expect(response.text).toContain("formatVerticalContext");
     expect(response.text).toContain("formatBearingDegrees");
     expect(response.text).toContain("rangeMeters");
     expect(response.text).toContain("bearingDegrees");
     expect(response.text).toContain("insideArea");
+    expect(response.text).toContain("inside_band");
     expect(response.text).toContain("primaryConflictAssessmentItem");
     expect(response.text).toContain("secondaryConflictAssessmentItems");
     expect(response.text).toContain("primaryConflictAdvisory");

--- a/src/tests/traffic-conflict-assessment.test.ts
+++ b/src/tests/traffic-conflict-assessment.test.ts
@@ -291,6 +291,12 @@ describe("traffic conflict assessment integration", () => {
             rangeRule: "nearest_boundary",
             bearingReference: "true_north",
           },
+          verticalContext: {
+            referenceAltitudeFt: expect.any(Number),
+            altitudeFloorFt: 0,
+            altitudeCeilingFt: 1000,
+            relation: "inside_band",
+          },
           metrics: expect.objectContaining({
             rangeMeters: expect.any(Number),
             bearingDegrees: expect.any(Number),
@@ -307,6 +313,12 @@ describe("traffic conflict assessment integration", () => {
             rangeRule: "nearest_boundary",
             bearingReference: "true_north",
           },
+          verticalContext: {
+            referenceAltitudeFt: expect.any(Number),
+            altitudeFloorFt: 0,
+            altitudeCeilingFt: 900,
+            relation: "inside_band",
+          },
           metrics: expect.objectContaining({
             rangeMeters: expect.any(Number),
             insideArea: expect.any(Boolean),
@@ -314,6 +326,49 @@ describe("traffic conflict assessment integration", () => {
         }),
       ]),
     );
+  });
+
+  it("suppresses area conflicts when mission altitude is outside the restriction band", async () => {
+    const missionId = await createMission();
+    await recordTelemetry(missionId);
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "area_conflict",
+        source: {
+          provider: "airspace-hub",
+          sourceType: "zone_service",
+        },
+        observedAt: "2026-04-21T12:00:10.000Z",
+        geometry: {
+          type: "circle",
+          centerLat: 51.5075,
+          centerLng: -0.1277,
+          radiusMeters: 150,
+          altitudeFloorFt: 0,
+          altitudeCeilingFt: 300,
+        },
+        severity: "critical",
+        metadata: {
+          areaId: "zone-high",
+          label: "Low ceiling restriction",
+          areaType: "restricted_zone",
+          description: "Should not apply above the ceiling",
+        },
+      });
+
+    const response = await request(app).get(
+      `/missions/${missionId}/conflict-assessment`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(
+      response.body.assessment.conflicts.some(
+        (item: { overlayLabel: string }) =>
+          item.overlayLabel === "Low ceiling restriction",
+      ),
+    ).toBe(false);
   });
 
   it("consumes normalized authoritative area overlays without source-specific conflict branching", async () => {
@@ -402,6 +457,9 @@ describe("traffic conflict assessment integration", () => {
           measurementBasis: expect.objectContaining({
             rangeRule: "nearest_boundary",
           }),
+          verticalContext: expect.objectContaining({
+            relation: "inside_band",
+          }),
         }),
         expect.objectContaining({
           overlayKind: "area_conflict",
@@ -412,6 +470,9 @@ describe("traffic conflict assessment integration", () => {
           }),
           measurementBasis: expect.objectContaining({
             rangeRule: "nearest_boundary",
+          }),
+          verticalContext: expect.objectContaining({
+            relation: "inside_band",
           }),
         }),
       ]),

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -151,6 +151,32 @@ const formatBearingDegrees = (value) => {
 const formatVerticalSeparation = (value) =>
   value == null || Number.isNaN(value) ? "Not recorded" : `${Math.round(value)} ft`;
 
+const formatVerticalContext = (conflict) => {
+  const relation = conflict?.verticalContext?.relation ?? "not_applicable";
+  const floor = conflict?.verticalContext?.altitudeFloorFt;
+  const ceiling = conflict?.verticalContext?.altitudeCeilingFt;
+  const reference = conflict?.verticalContext?.referenceAltitudeFt;
+  const bandText =
+    floor == null && ceiling == null
+      ? "No altitude band"
+      : `${floor ?? "surface"}-${ceiling ?? "open"} ft`;
+
+  if (relation === "inside_band") {
+    return `Inside altitude band | ${bandText} | ref ${reference == null ? "unknown" : `${Math.round(reference)} ft`}`;
+  }
+  if (relation === "below_band") {
+    return `Below altitude band | ${bandText} | ref ${reference == null ? "unknown" : `${Math.round(reference)} ft`}`;
+  }
+  if (relation === "above_band") {
+    return `Above altitude band | ${bandText} | ref ${reference == null ? "unknown" : `${Math.round(reference)} ft`}`;
+  }
+  if (relation === "unknown") {
+    return `Altitude band ${bandText} | reference altitude unknown`;
+  }
+
+  return "Not applicable";
+};
+
 const formatRangeBearing = (metrics) => {
   const rangeMeters = metrics?.rangeMeters ?? metrics?.lateralDistanceMeters;
   if (rangeMeters == null && metrics?.bearingDegrees == null) {
@@ -631,7 +657,7 @@ const conflictAssessmentSummary = () => {
   return {
     label: `${conflicts.length} conflict candidate${conflicts.length === 1 ? "" : "s"}`,
     tone: highest.severity,
-    detail: `${highest.overlayLabel} | ${formatRangeBearing(highest.metrics)} | ${formatVerticalSeparation(highest.metrics?.altitudeDeltaFt)} vertical`,
+    detail: `${highest.overlayLabel} | ${formatRangeBearing(highest.metrics)} | ${highest.overlayKind === "area_conflict" ? formatVerticalContext(highest) : `${formatVerticalSeparation(highest.metrics?.altitudeDeltaFt)} vertical`}`,
   };
 };
 
@@ -666,7 +692,7 @@ const deriveConflictAdvisories = () =>
       relatedSource: `${conflict.relatedSource.provider} / ${conflict.relatedSource.sourceType}`,
       reasoning: conflict.explanation,
       relevance: replayRelevance,
-      summary: `${formatRangeBearing(conflict.metrics)} | ${formatVerticalSeparation(conflict.metrics?.altitudeDeltaFt)} vertical`,
+      summary: `${formatRangeBearing(conflict.metrics)} | ${conflict.overlayKind === "area_conflict" ? formatVerticalContext(conflict) : `${formatVerticalSeparation(conflict.metrics?.altitudeDeltaFt)} vertical`}`,
     };
   });
 
@@ -889,7 +915,7 @@ const conflictProximityEnvelopeSummary = () => {
   return {
     headline: `${primary.conflict.overlayLabel} proximity`,
     tone: primary.conflict.severity,
-    detail: `${primary.radii.length} severity band${primary.radii.length === 1 ? "" : "s"} | ${formatRangeBearing(primary.conflict.metrics)} | ${formatVerticalSeparation(primary.conflict.metrics?.altitudeDeltaFt)} vertical`,
+    detail: `${primary.radii.length} severity band${primary.radii.length === 1 ? "" : "s"} | ${formatRangeBearing(primary.conflict.metrics)} | ${primary.conflict.overlayKind === "area_conflict" ? formatVerticalContext(primary.conflict) : `${formatVerticalSeparation(primary.conflict.metrics?.altitudeDeltaFt)} vertical`}`,
     meta: primary.conflict.explanation,
   };
 };
@@ -1223,7 +1249,7 @@ const buildOverlayCards = () => {
       ? {
           label: "Primary conflict",
           tone: primaryConflict.severity,
-          detail: `${primaryConflict.overlayLabel} | ${formatRangeBearing(primaryConflict.metrics)} | ${formatVerticalSeparation(primaryConflict.metrics?.altitudeDeltaFt)} vertical`,
+          detail: `${primaryConflict.overlayLabel} | ${formatRangeBearing(primaryConflict.metrics)} | ${primaryConflict.overlayKind === "area_conflict" ? formatVerticalContext(primaryConflict) : `${formatVerticalSeparation(primaryConflict.metrics?.altitudeDeltaFt)} vertical`}`,
         }
       : conflictAssessmentSummary(),
     primaryAdvisory
@@ -1861,7 +1887,7 @@ const renderStatus = () => {
         },
         ...secondaryConflictAssessmentItems().map((conflict) => ({
           label: `Additional conflict ${conflict.overlayLabel}`,
-          value: `${formatRangeBearing(conflict.metrics)} | ${formatVerticalSeparation(conflict.metrics?.altitudeDeltaFt)} vertical`,
+          value: `${formatRangeBearing(conflict.metrics)} | ${conflict.overlayKind === "area_conflict" ? formatVerticalContext(conflict) : `${formatVerticalSeparation(conflict.metrics?.altitudeDeltaFt)} vertical`}`,
         })),
       ]
     : [];
@@ -2016,10 +2042,12 @@ const renderStatus = () => {
               ? formatRangeBearing(primaryConflict.metrics)
               : "Not recorded",
           )}</div>
-          <div class="k">Vertical separation</div>
+          <div class="k">Vertical context</div>
           <div>${escapeHtml(
             primaryConflict
-              ? formatVerticalSeparation(primaryConflict.metrics?.altitudeDeltaFt)
+              ? primaryConflict.overlayKind === "area_conflict"
+                ? formatVerticalContext(primaryConflict)
+                : formatVerticalSeparation(primaryConflict.metrics?.altitudeDeltaFt)
               : "Not recorded",
           )}</div>
           <div class="k">Assessment time</div>
@@ -2206,7 +2234,7 @@ const renderConflictAssessment = () => {
                   Source: ${escapeHtml(primaryConflict.relatedSource.provider)} / ${escapeHtml(primaryConflict.relatedSource.sourceType)}<br />
                   Observed: ${escapeHtml(formatDateTime(primaryConflict.overlayObservedAt))}<br />
                   Range / bearing: ${escapeHtml(formatRangeBearing(primaryConflict.metrics))}<br />
-                  Vertical separation: ${escapeHtml(formatVerticalSeparation(primaryConflict.metrics?.altitudeDeltaFt))}<br />
+                  Vertical context: ${escapeHtml(primaryConflict.overlayKind === "area_conflict" ? formatVerticalContext(primaryConflict) : formatVerticalSeparation(primaryConflict.metrics?.altitudeDeltaFt))}<br />
                   Replay relevance: ${escapeHtml(primaryConflict.replayRelevant ? "Current replay window" : `${primaryConflict.replayTimeDeltaSeconds} s from replay cursor`)}
                 </div>
               </article>
@@ -2222,7 +2250,7 @@ const renderConflictAssessment = () => {
             : renderList(
                 secondaryConflicts.map((conflict) => ({
                   label: `${conflict.overlayLabel} | ${conflict.severity}`,
-                  value: `${formatRangeBearing(conflict.metrics)} | ${formatVerticalSeparation(conflict.metrics?.altitudeDeltaFt)} vertical`,
+                  value: `${formatRangeBearing(conflict.metrics)} | ${conflict.overlayKind === "area_conflict" ? formatVerticalContext(conflict) : `${formatVerticalSeparation(conflict.metrics?.altitudeDeltaFt)} vertical`}`,
                 })),
                 "additional conflicts",
               )


### PR DESCRIPTION
## Summary

Implements GitHub issue #177 by adding altitude-band gating and vertical context refinement to mission-linked area conflict assessment.

## What changed

- Extended the mission-linked conflict assessment contract to include explicit area conflict vertical context:
  - `referenceAltitudeFt`
  - `altitudeFloorFt`
  - `altitudeCeilingFt`
  - `relation`
- Kept the change inside the interpreted conflict assessment layer.
- Replaced boolean-only area altitude gating with explicit vertical relation derivation:
  - `below_band`
  - `inside_band`
  - `above_band`
  - `unknown`
  - `not_applicable`
- Area conflicts are now suppressed when the mission reference altitude is outside the area restriction band.
- Preserved the existing geometry-aware nearest-boundary range/bearing behavior from `#173`.
- Preserved the normalized authoritative area-source ingestion path from `#175`.
- Updated area conflict explanations so vertical relevance is explicit instead of being implied only by free text.
- Surfaced read-only altitude-band context in the staged live-ops UI for area conflicts.
- Preserved existing traffic conflict behavior and kept traffic conflicts marked as `not_applicable` for area-band gating.
- Updated the save point to the next backend refinement step:
  - validity-window gating for mission-linked area conflict assessment

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 7 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 336 tests.

## Notes

This issue refines interpreted area conflict relevance only. It does not add operator automation, lifecycle changes, or avoidance execution.

Closes #177.
