### PR TITLE
Add area conflict validity-window gating

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add validity-window gating to mission-linked area conflict assessment so normalized danger areas and NOTAM-derived restrictions only trigger when the replay or telemetry reference time falls inside the active restriction window.",
+  "nextBuildStep": "Add source-priority and deduplication rules to normalized area overlay ingestion so overlapping danger areas and NOTAM-derived restrictions do not create redundant interpreted conflicts.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/conflict-assessment/traffic-conflict-assessment.service.ts
+++ b/src/conflict-assessment/traffic-conflict-assessment.service.ts
@@ -419,6 +419,63 @@ const deriveAreaVerticalContext = (
   };
 };
 
+const deriveAreaTemporalContext = (
+  referenceTimestamp: string,
+  validFrom: string | null,
+  validTo: string | null,
+): TrafficConflictAssessmentItem["temporalContext"] => {
+  if (!validFrom && !validTo) {
+    return {
+      referenceTimestamp,
+      validFrom: null,
+      validTo: null,
+      relation: "not_applicable",
+    };
+  }
+
+  const referenceTime = Date.parse(referenceTimestamp);
+  const validFromTime = validFrom ? Date.parse(validFrom) : null;
+  const validToTime = validTo ? Date.parse(validTo) : null;
+
+  if (
+    !Number.isFinite(referenceTime) ||
+    (validFromTime != null && !Number.isFinite(validFromTime)) ||
+    (validToTime != null && !Number.isFinite(validToTime))
+  ) {
+    return {
+      referenceTimestamp,
+      validFrom,
+      validTo,
+      relation: "unknown",
+    };
+  }
+
+  if (validFromTime != null && referenceTime < validFromTime) {
+    return {
+      referenceTimestamp,
+      validFrom,
+      validTo,
+      relation: "before_window",
+    };
+  }
+
+  if (validToTime != null && referenceTime > validToTime) {
+    return {
+      referenceTimestamp,
+      validFrom,
+      validTo,
+      relation: "after_window",
+    };
+  }
+
+  return {
+    referenceTimestamp,
+    validFrom,
+    validTo,
+    relation: "inside_window",
+  };
+};
+
 const classifyAreaConflict = (
   boundaryDistanceMeters: number | null,
   insideArea: boolean,
@@ -571,6 +628,11 @@ export class TrafficConflictAssessmentService {
               geometry.type === "circle"
                 ? geometry.altitudeCeilingFt
                 : geometry.altitudeCeilingFt;
+            const temporalContext = deriveAreaTemporalContext(
+              referenceTimestamp,
+              overlay.validFrom ?? null,
+              overlay.validTo ?? null,
+            );
             const verticalContext = deriveAreaVerticalContext(
               referenceAltitudeFt,
               altitudeFloorFt,
@@ -578,6 +640,8 @@ export class TrafficConflictAssessmentService {
             );
 
             if (
+              temporalContext.relation === "before_window" ||
+              temporalContext.relation === "after_window" ||
               verticalContext.relation === "below_band" ||
               verticalContext.relation === "above_band"
             ) {
@@ -617,19 +681,29 @@ export class TrafficConflictAssessmentService {
                 : verticalContext.relation === "unknown"
                   ? "mission reference altitude is unknown for altitude-band gating"
                   : "altitude band not applicable";
+            const validityWindowText =
+              overlay.validFrom != null || overlay.validTo != null
+                ? ` active window ${overlay.validFrom ?? "open"}-${overlay.validTo ?? "open"}`
+                : "";
+            const temporalRelationText =
+              temporalContext.relation === "inside_window"
+                ? "mission reference time is inside the active restriction window"
+                : temporalContext.relation === "unknown"
+                  ? "mission reference time is unknown for validity-window gating"
+                  : "validity window not applicable";
             const explanation = geometryAssessment.insideArea
               ? `Area conflict proximity candidate: mission reference is inside ${geometryLabel} ${overlayLabel}; nearest boundary ${round(geometryAssessment.rangeMeters)} m away, ${
                   geometryAssessment.bearingDegrees == null
                     ? "unknown bearing"
                     : `${round(geometryAssessment.bearingDegrees)}° bearing from mission reference`
-                }, ${verticalRelationText}.${altitudeBandText ? `${altitudeBandText}.` : ""}${weather.reason ? ` ${weather.reason}.` : ""}`
+                }, ${temporalRelationText}.${validityWindowText ? `${validityWindowText}.` : ""}${verticalRelationText ? ` ${verticalRelationText}.` : ""}${altitudeBandText ? `${altitudeBandText}.` : ""}${weather.reason ? ` ${weather.reason}.` : ""}`
               : `Area conflict proximity candidate: ${overlayLabel} boundary is ${round(
                   geometryAssessment.rangeMeters,
                 )} m away at ${
                   geometryAssessment.bearingDegrees == null
                     ? "unknown bearing"
                     : `${round(geometryAssessment.bearingDegrees)}° bearing from mission reference`
-                }, ${verticalRelationText}.${altitudeBandText ? `${altitudeBandText}.` : ""}${weather.reason ? ` ${weather.reason}.` : ""}`;
+                }, ${temporalRelationText}.${validityWindowText ? `${validityWindowText}.` : ""}${verticalRelationText ? ` ${verticalRelationText}.` : ""}${altitudeBandText ? `${altitudeBandText}.` : ""}${weather.reason ? ` ${weather.reason}.` : ""}`;
 
             return {
               id: randomUUID(),
@@ -652,6 +726,7 @@ export class TrafficConflictAssessmentService {
                 rangeRule: "nearest_boundary",
                 bearingReference: "true_north",
               },
+              temporalContext,
               verticalContext,
               metrics: {
                 rangeMeters: round(geometryAssessment.rangeMeters),
@@ -742,6 +817,12 @@ export class TrafficConflictAssessmentService {
               targetGeometry: "overlay_point",
               rangeRule: "point_to_point",
               bearingReference: "true_north",
+            },
+            temporalContext: {
+              referenceTimestamp,
+              validFrom: null,
+              validTo: null,
+              relation: "not_applicable",
             },
             verticalContext: {
               referenceAltitudeFt,

--- a/src/conflict-assessment/traffic-conflict-assessment.types.ts
+++ b/src/conflict-assessment/traffic-conflict-assessment.types.ts
@@ -41,6 +41,17 @@ export interface TrafficConflictAssessmentItem {
     rangeRule: "point_to_point" | "nearest_boundary";
     bearingReference: "true_north";
   };
+  temporalContext: {
+    referenceTimestamp: string;
+    validFrom: string | null;
+    validTo: string | null;
+    relation:
+      | "not_applicable"
+      | "unknown"
+      | "before_window"
+      | "inside_window"
+      | "after_window";
+  };
   verticalContext: {
     referenceAltitudeFt: number | null;
     altitudeFloorFt: number | null;

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2035,11 +2035,13 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("conflictAssessmentSummary");
     expect(response.text).toContain("conflictAdvisorySummary");
     expect(response.text).toContain("formatRangeBearing");
+    expect(response.text).toContain("formatTemporalContext");
     expect(response.text).toContain("formatVerticalContext");
     expect(response.text).toContain("formatBearingDegrees");
     expect(response.text).toContain("rangeMeters");
     expect(response.text).toContain("bearingDegrees");
     expect(response.text).toContain("insideArea");
+    expect(response.text).toContain("inside_window");
     expect(response.text).toContain("inside_band");
     expect(response.text).toContain("primaryConflictAssessmentItem");
     expect(response.text).toContain("secondaryConflictAssessmentItems");

--- a/src/tests/traffic-conflict-assessment.test.ts
+++ b/src/tests/traffic-conflict-assessment.test.ts
@@ -291,6 +291,12 @@ describe("traffic conflict assessment integration", () => {
             rangeRule: "nearest_boundary",
             bearingReference: "true_north",
           },
+          temporalContext: {
+            referenceTimestamp: "2026-04-21T12:00:00.000Z",
+            validFrom: null,
+            validTo: null,
+            relation: "not_applicable",
+          },
           verticalContext: {
             referenceAltitudeFt: expect.any(Number),
             altitudeFloorFt: 0,
@@ -312,6 +318,12 @@ describe("traffic conflict assessment integration", () => {
             targetGeometry: "overlay_polygon",
             rangeRule: "nearest_boundary",
             bearingReference: "true_north",
+          },
+          temporalContext: {
+            referenceTimestamp: "2026-04-21T12:00:00.000Z",
+            validFrom: null,
+            validTo: null,
+            relation: "not_applicable",
           },
           verticalContext: {
             referenceAltitudeFt: expect.any(Number),
@@ -367,6 +379,56 @@ describe("traffic conflict assessment integration", () => {
       response.body.assessment.conflicts.some(
         (item: { overlayLabel: string }) =>
           item.overlayLabel === "Low ceiling restriction",
+      ),
+    ).toBe(false);
+  });
+
+  it("suppresses area conflicts when mission reference time is outside the active window", async () => {
+    const missionId = await createMission();
+    await recordTelemetry(missionId);
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B9999/26",
+            },
+            observedAt: "2026-04-21T12:00:10.000Z",
+            validFrom: "2026-04-21T13:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5075,
+              centerLng: -0.1277,
+              radiusMeters: 150,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            area: {
+              areaId: "NOTAM-LATE",
+              label: "Future NOTAM Zone",
+              areaType: "notam_restriction",
+              description: "Should not apply before validFrom",
+              authorityName: "NATS",
+              notamNumber: "B9999/26",
+              sourceReference: "NOTAM B9999/26",
+            },
+          },
+        ],
+      });
+
+    const response = await request(app).get(
+      `/missions/${missionId}/conflict-assessment`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(
+      response.body.assessment.conflicts.some(
+        (item: { overlayLabel: string }) => item.overlayLabel === "Future NOTAM Zone",
       ),
     ).toBe(false);
   });
@@ -457,6 +519,11 @@ describe("traffic conflict assessment integration", () => {
           measurementBasis: expect.objectContaining({
             rangeRule: "nearest_boundary",
           }),
+          temporalContext: expect.objectContaining({
+            relation: "inside_window",
+            validFrom: "2026-04-21T12:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+          }),
           verticalContext: expect.objectContaining({
             relation: "inside_band",
           }),
@@ -470,6 +537,11 @@ describe("traffic conflict assessment integration", () => {
           }),
           measurementBasis: expect.objectContaining({
             rangeRule: "nearest_boundary",
+          }),
+          temporalContext: expect.objectContaining({
+            relation: "inside_window",
+            validFrom: "2026-04-21T12:00:00.000Z",
+            validTo: "2026-04-21T15:00:00.000Z",
           }),
           verticalContext: expect.objectContaining({
             relation: "inside_band",

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -177,6 +177,32 @@ const formatVerticalContext = (conflict) => {
   return "Not applicable";
 };
 
+const formatTemporalContext = (conflict) => {
+  const relation = conflict?.temporalContext?.relation ?? "not_applicable";
+  const validFrom = conflict?.temporalContext?.validFrom;
+  const validTo = conflict?.temporalContext?.validTo;
+  const referenceTimestamp = conflict?.temporalContext?.referenceTimestamp;
+  const windowText =
+    validFrom == null && validTo == null
+      ? "No active window"
+      : `${formatDateTime(validFrom)} - ${formatDateTime(validTo)}`;
+
+  if (relation === "inside_window") {
+    return `Inside active window | ${windowText} | ref ${formatDateTime(referenceTimestamp)}`;
+  }
+  if (relation === "before_window") {
+    return `Before active window | ${windowText} | ref ${formatDateTime(referenceTimestamp)}`;
+  }
+  if (relation === "after_window") {
+    return `After active window | ${windowText} | ref ${formatDateTime(referenceTimestamp)}`;
+  }
+  if (relation === "unknown") {
+    return `Active window ${windowText} | reference time unknown`;
+  }
+
+  return "Not applicable";
+};
+
 const formatRangeBearing = (metrics) => {
   const rangeMeters = metrics?.rangeMeters ?? metrics?.lateralDistanceMeters;
   if (rangeMeters == null && metrics?.bearingDegrees == null) {
@@ -657,7 +683,7 @@ const conflictAssessmentSummary = () => {
   return {
     label: `${conflicts.length} conflict candidate${conflicts.length === 1 ? "" : "s"}`,
     tone: highest.severity,
-    detail: `${highest.overlayLabel} | ${formatRangeBearing(highest.metrics)} | ${highest.overlayKind === "area_conflict" ? formatVerticalContext(highest) : `${formatVerticalSeparation(highest.metrics?.altitudeDeltaFt)} vertical`}`,
+    detail: `${highest.overlayLabel} | ${formatRangeBearing(highest.metrics)} | ${highest.overlayKind === "area_conflict" ? `${formatTemporalContext(highest)} | ${formatVerticalContext(highest)}` : `${formatVerticalSeparation(highest.metrics?.altitudeDeltaFt)} vertical`}`,
   };
 };
 
@@ -692,7 +718,7 @@ const deriveConflictAdvisories = () =>
       relatedSource: `${conflict.relatedSource.provider} / ${conflict.relatedSource.sourceType}`,
       reasoning: conflict.explanation,
       relevance: replayRelevance,
-      summary: `${formatRangeBearing(conflict.metrics)} | ${conflict.overlayKind === "area_conflict" ? formatVerticalContext(conflict) : `${formatVerticalSeparation(conflict.metrics?.altitudeDeltaFt)} vertical`}`,
+      summary: `${formatRangeBearing(conflict.metrics)} | ${conflict.overlayKind === "area_conflict" ? `${formatTemporalContext(conflict)} | ${formatVerticalContext(conflict)}` : `${formatVerticalSeparation(conflict.metrics?.altitudeDeltaFt)} vertical`}`,
     };
   });
 
@@ -2042,6 +2068,14 @@ const renderStatus = () => {
               ? formatRangeBearing(primaryConflict.metrics)
               : "Not recorded",
           )}</div>
+          <div class="k">Time relevance</div>
+          <div>${escapeHtml(
+            primaryConflict
+              ? primaryConflict.overlayKind === "area_conflict"
+                ? formatTemporalContext(primaryConflict)
+                : "Not applicable"
+              : "Not recorded",
+          )}</div>
           <div class="k">Vertical context</div>
           <div>${escapeHtml(
             primaryConflict
@@ -2234,6 +2268,7 @@ const renderConflictAssessment = () => {
                   Source: ${escapeHtml(primaryConflict.relatedSource.provider)} / ${escapeHtml(primaryConflict.relatedSource.sourceType)}<br />
                   Observed: ${escapeHtml(formatDateTime(primaryConflict.overlayObservedAt))}<br />
                   Range / bearing: ${escapeHtml(formatRangeBearing(primaryConflict.metrics))}<br />
+                  Time relevance: ${escapeHtml(primaryConflict.overlayKind === "area_conflict" ? formatTemporalContext(primaryConflict) : "Not applicable")}<br />
                   Vertical context: ${escapeHtml(primaryConflict.overlayKind === "area_conflict" ? formatVerticalContext(primaryConflict) : formatVerticalSeparation(primaryConflict.metrics?.altitudeDeltaFt))}<br />
                   Replay relevance: ${escapeHtml(primaryConflict.replayRelevant ? "Current replay window" : `${primaryConflict.replayTimeDeltaSeconds} s from replay cursor`)}
                 </div>


### PR DESCRIPTION
## Summary

Implements GitHub issue #179 by adding validity-window gating to mission-linked area conflict assessment so normalized danger areas and NOTAM-derived restrictions only trigger when the mission reference time falls inside the active restriction window.

## What changed

- Extended the mission-linked conflict assessment contract to include explicit temporal context for interpreted conflicts:
  - `referenceTimestamp`
  - `validFrom`
  - `validTo`
  - `relation`
- Kept the change inside the interpreted conflict assessment layer.
- Added validity-window relation derivation for area conflicts:
  - `before_window`
  - `inside_window`
  - `after_window`
  - `unknown`
  - `not_applicable`
- Area conflicts are now suppressed when the mission reference time falls outside the active restriction window.
- Preserved the existing geometry-aware nearest-boundary range/bearing behavior from `#173`.
- Preserved the normalized authoritative area-source ingestion path from `#175`.
- Preserved the altitude-band gating and vertical-context behavior from `#177`.
- Updated area conflict explanations so temporal relevance is explicit instead of being implied only by overlay timing fields.
- Surfaced read-only time relevance in the staged live-ops UI for area conflicts.
- Preserved existing traffic conflict behavior and kept traffic conflicts marked as `not_applicable` for validity-window gating.
- Updated the save point to the next backend refinement step:
  - source-priority and deduplication for overlapping area overlays

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 8 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 337 tests.

## Notes

This issue refines interpreted area conflict time relevance only. It does not add operator automation, lifecycle changes, or avoidance execution.

Closes #179.
