### PR TITLE
Add area overlay deduplication rules

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add source-priority and deduplication rules to normalized area overlay ingestion so overlapping danger areas and NOTAM-derived restrictions do not create redundant interpreted conflicts.",
+  "nextBuildStep": "Add supersession updates to normalized area overlay ingestion so higher-priority NOTAM-derived restrictions can replace existing lower-priority area overlays across repeated normalization runs.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -2,6 +2,7 @@ import type { Pool } from "pg";
 import { ExternalOverlayRepository } from "./external-overlay.repository";
 import { MissionExternalOverlayMissionNotFoundError } from "./external-overlay.errors";
 import type {
+  AreaConflictOverlayMetadata,
   CreateAreaConflictExternalOverlayInput,
   CreateCrewedTrafficExternalOverlayInput,
   CreateDroneTrafficExternalOverlayInput,
@@ -17,6 +18,110 @@ import {
   validateNormalizeAreaOverlaySourcesInput,
   validateCreateWeatherExternalOverlayInput,
 } from "./external-overlay.validators";
+
+const AREA_SOURCE_PRIORITY: Record<string, number> = {
+  danger_area: 1,
+  temporary_danger_area: 2,
+  notam_restriction: 3,
+};
+
+const severityRank: Record<string, number> = {
+  info: 1,
+  caution: 2,
+  critical: 3,
+};
+
+const roundCoordinate = (value: number): number => Math.round(value * 100000) / 100000;
+
+const dedupeGeometryKey = (
+  geometry: NormalizeAreaOverlaySourcesInput["records"][number]["geometry"],
+): string => {
+  if (geometry.type === "circle") {
+    return [
+      "circle",
+      roundCoordinate(geometry.centerLat),
+      roundCoordinate(geometry.centerLng),
+      Math.round(geometry.radiusMeters),
+      geometry.altitudeFloorFt ?? "surface",
+      geometry.altitudeCeilingFt ?? "open",
+    ].join("|");
+  }
+
+  return [
+    "polygon",
+    ...geometry.points.flatMap((point) => [
+      roundCoordinate(point.lat),
+      roundCoordinate(point.lng),
+    ]),
+    geometry.altitudeFloorFt ?? "surface",
+    geometry.altitudeCeilingFt ?? "open",
+  ].join("|");
+};
+
+const dedupeWindowKey = (
+  validFrom: string | null | undefined,
+  validTo: string | null | undefined,
+): string => `${validFrom ?? "open"}|${validTo ?? "open"}`;
+
+const buildAreaDedupeKey = (
+  record: NormalizeAreaOverlaySourcesInput["records"][number],
+): string =>
+  [
+    dedupeGeometryKey(record.geometry),
+    dedupeWindowKey(record.validFrom, record.validTo),
+  ].join("|");
+
+const areaSourcePriority = (sourceType: string): number =>
+  AREA_SOURCE_PRIORITY[sourceType] ?? 0;
+
+const normalizedAreaMetadata = (
+  record: NormalizeAreaOverlaySourcesInput["records"][number],
+  extras: Partial<AreaConflictOverlayMetadata> = {},
+): AreaConflictOverlayMetadata => ({
+  areaId: record.area.areaId,
+  label: record.area.label,
+  areaType: record.area.areaType,
+  description: record.area.description ?? null,
+  authorityName: record.area.authorityName ?? null,
+  notamNumber: record.area.notamNumber ?? null,
+  sourceReference: record.area.sourceReference ?? null,
+  normalizedSourcePriority: areaSourcePriority(record.source.sourceType),
+  dedupeKey: buildAreaDedupeKey(record),
+  sourceTrace: [
+    {
+      provider: record.source.provider,
+      sourceType: record.source.sourceType,
+      sourceRecordId: record.source.sourceRecordId ?? null,
+      authorityName: record.area.authorityName ?? null,
+      notamNumber: record.area.notamNumber ?? null,
+      sourceReference: record.area.sourceReference ?? null,
+      areaId: record.area.areaId,
+      label: record.area.label,
+    },
+  ],
+  ...extras,
+});
+
+const compareAreaNormalizationPriority = (
+  left: NormalizeAreaOverlaySourcesInput["records"][number],
+  right: NormalizeAreaOverlaySourcesInput["records"][number],
+): number => {
+  const priorityDiff =
+    areaSourcePriority(left.source.sourceType) - areaSourcePriority(right.source.sourceType);
+  if (priorityDiff !== 0) {
+    return priorityDiff;
+  }
+
+  const leftSeverity = severityRank[left.severity ?? "info"] ?? 0;
+  const rightSeverity = severityRank[right.severity ?? "info"] ?? 0;
+  if (leftSeverity !== rightSeverity) {
+    return leftSeverity - rightSeverity;
+  }
+
+  const leftObserved = Date.parse(left.observedAt);
+  const rightObserved = Date.parse(right.observedAt);
+  return leftObserved - rightObserved;
+};
 
 export class ExternalOverlayService {
   constructor(
@@ -149,31 +254,61 @@ export class ExternalOverlayService {
         throw new MissionExternalOverlayMissionNotFoundError(missionId);
       }
 
-      const overlays: ExternalOverlay[] = [];
+      const dedupedRecords = new Map<
+        string,
+        {
+          winner: NormalizeAreaOverlaySourcesInput["records"][number];
+          sourceTrace: NonNullable<AreaConflictOverlayMetadata["sourceTrace"]>;
+        }
+      >();
+
       for (const record of validated.records) {
+        const dedupeKey = buildAreaDedupeKey(record);
+        const traceEntry = normalizedAreaMetadata(record).sourceTrace ?? [];
+        const existing = dedupedRecords.get(dedupeKey);
+
+        if (!existing) {
+          dedupedRecords.set(dedupeKey, {
+            winner: record,
+            sourceTrace: traceEntry,
+          });
+          continue;
+        }
+
+        const nextTrace = [...existing.sourceTrace, ...traceEntry];
+        if (compareAreaNormalizationPriority(record, existing.winner) > 0) {
+          dedupedRecords.set(dedupeKey, {
+            winner: record,
+            sourceTrace: nextTrace,
+          });
+          continue;
+        }
+
+        dedupedRecords.set(dedupeKey, {
+          winner: existing.winner,
+          sourceTrace: nextTrace,
+        });
+      }
+
+      const overlays: ExternalOverlay[] = [];
+      for (const { winner, sourceTrace } of dedupedRecords.values()) {
         overlays.push(
           await this.externalOverlayRepository.insertAreaConflictOverlay(
             client,
             missionId,
             {
               kind: "area_conflict",
-              source: record.source,
-              observedAt: record.observedAt,
-              validFrom: record.validFrom,
-              validTo: record.validTo,
-              geometry: record.geometry,
-              severity: record.severity,
-              confidence: record.confidence,
-              freshnessSeconds: record.freshnessSeconds,
-              metadata: {
-                areaId: record.area.areaId,
-                label: record.area.label,
-                areaType: record.area.areaType,
-                description: record.area.description ?? null,
-                authorityName: record.area.authorityName ?? null,
-                notamNumber: record.area.notamNumber ?? null,
-                sourceReference: record.area.sourceReference ?? null,
-              },
+              source: winner.source,
+              observedAt: winner.observedAt,
+              validFrom: winner.validFrom,
+              validTo: winner.validTo,
+              geometry: winner.geometry,
+              severity: winner.severity,
+              confidence: winner.confidence,
+              freshnessSeconds: winner.freshnessSeconds,
+              metadata: normalizedAreaMetadata(winner, {
+                sourceTrace,
+              }),
             },
           ),
         );

--- a/src/external-overlays/external-overlay.types.ts
+++ b/src/external-overlays/external-overlay.types.ts
@@ -82,6 +82,18 @@ export interface AreaConflictOverlayMetadata {
   authorityName?: string | null;
   notamNumber?: string | null;
   sourceReference?: string | null;
+  normalizedSourcePriority?: number | null;
+  dedupeKey?: string | null;
+  sourceTrace?: Array<{
+    provider: string;
+    sourceType: string;
+    sourceRecordId: string | null;
+    authorityName?: string | null;
+    notamNumber?: string | null;
+    sourceReference?: string | null;
+    areaId: string;
+    label: string;
+  }>;
 }
 
 export interface ExternalOverlay {

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -561,6 +561,106 @@ describe("mission external overlays integration", () => {
     );
   });
 
+  it("deduplicates overlapping authoritative area sources and preserves source traceability", async () => {
+    const missionId = await createMission();
+
+    const normalizeResponse = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-400",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-400",
+              label: "Danger Area EGD-400",
+              areaType: "danger_area",
+              description: "Permanent danger area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B4000/26",
+            },
+            observedAt: "2026-04-21T10:08:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B4000-26",
+              label: "Danger Area EGD-400 Active NOTAM",
+              areaType: "notam_restriction",
+              description: "NOTAM overlay for the same area",
+              authorityName: "NATS",
+              notamNumber: "B4000/26",
+              sourceReference: "NOTAM B4000/26",
+            },
+          },
+        ],
+      });
+
+    expect(normalizeResponse.status).toBe(201);
+    expect(normalizeResponse.body.overlays).toHaveLength(1);
+    expect(normalizeResponse.body.overlays[0]).toMatchObject({
+      kind: "area_conflict",
+      source: {
+        provider: "uk-ais",
+        sourceType: "notam_restriction",
+        sourceRecordId: "B4000/26",
+      },
+      severity: "critical",
+      metadata: expect.objectContaining({
+        areaType: "notam_restriction",
+        normalizedSourcePriority: 3,
+        dedupeKey: expect.any(String),
+        sourceTrace: [
+          expect.objectContaining({
+            sourceType: "danger_area",
+            sourceRecordId: "EGD-400",
+          }),
+          expect.objectContaining({
+            sourceType: "notam_restriction",
+            sourceRecordId: "B4000/26",
+          }),
+        ],
+      }),
+    });
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays?kind=area_conflict`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.overlays).toHaveLength(1);
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 

--- a/src/tests/traffic-conflict-assessment.test.ts
+++ b/src/tests/traffic-conflict-assessment.test.ts
@@ -551,6 +551,91 @@ describe("traffic conflict assessment integration", () => {
     );
   });
 
+  it("does not create redundant interpreted conflicts for deduplicated overlapping area sources", async () => {
+    const missionId = await createMission();
+    await recordTelemetry(missionId);
+
+    const normalizeResponse = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-900",
+            },
+            observedAt: "2026-04-21T12:00:10.000Z",
+            validFrom: "2026-04-21T12:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5075,
+              centerLng: -0.1277,
+              radiusMeters: 150,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            area: {
+              areaId: "EGD-900",
+              label: "Danger Area EGD-900",
+              areaType: "danger_area",
+              description: "Base area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B9000/26",
+            },
+            observedAt: "2026-04-21T12:00:20.000Z",
+            validFrom: "2026-04-21T12:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5075,
+              centerLng: -0.1277,
+              radiusMeters: 150,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B9000-26",
+              label: "Danger Area EGD-900 Active NOTAM",
+              areaType: "notam_restriction",
+              description: "Higher-priority duplicate",
+              authorityName: "NATS",
+              notamNumber: "B9000/26",
+              sourceReference: "NOTAM B9000/26",
+            },
+          },
+        ],
+      });
+
+    expect(normalizeResponse.status).toBe(201);
+    expect(normalizeResponse.body.overlays).toHaveLength(1);
+
+    const response = await request(app).get(
+      `/missions/${missionId}/conflict-assessment`,
+    );
+
+    expect(response.status).toBe(200);
+    const areaConflicts = response.body.assessment.conflicts.filter(
+      (item: { overlayKind: string }) => item.overlayKind === "area_conflict",
+    );
+    expect(areaConflicts).toHaveLength(1);
+    expect(areaConflicts[0]).toMatchObject({
+      overlayLabel: "Danger Area EGD-900 Active NOTAM",
+      relatedSource: {
+        sourceType: "notam_restriction",
+      },
+    });
+  });
+
   it("preserves mission isolation for conflict assessment reads", async () => {
     const firstMissionId = await createMission();
     const secondMissionId = await createMission();


### PR DESCRIPTION
## Summary

Implements GitHub issue #181 by adding source-priority and deduplication rules to normalized area overlay ingestion so overlapping danger areas and NOTAM-derived restrictions do not create redundant interpreted conflicts.

## What changed

- Added source-priority and deduplication rules to normalized area overlay ingestion.
- Kept the implementation inside the normalized area overlay ingestion boundary.
- Added deterministic source priority for overlapping authoritative area inputs:
  - `notam_restriction`
  - `temporary_danger_area`
  - `danger_area`
- Added normalization-time dedupe using a normalized area signature based on:
  - geometry
  - altitude band
  - validity window
- Overlapping normalized area inputs with the same normalized signature now collapse to a single `area_conflict` overlay before insert.
- Preserved source traceability on deduplicated overlays through metadata fields including:
  - `normalizedSourcePriority`
  - `dedupeKey`
  - `sourceTrace`
- Higher-priority sources now determine the surviving normalized overlay identity, while lower-priority overlapping inputs remain represented in trace metadata.
- Preserved the conflict assessment layer’s source-agnostic behavior by continuing to feed it normalized area overlays only.
- Verified that deduplicated authoritative inputs do not create redundant interpreted area conflicts.
- Updated the save point to the next backend refinement step:
  - supersession updates across repeated normalization runs

## Verification

- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 10 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 9 tests.
- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 339 tests.

## Notes

This issue refines normalization behavior only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #181.
