### PR TITLE
Add area overlay supersession updates

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add supersession updates to normalized area overlay ingestion so higher-priority NOTAM-derived restrictions can replace existing lower-priority area overlays across repeated normalization runs.",
+  "nextBuildStep": "Add normalized area overlay retirement handling so previously-ingested restrictions that disappear from later authoritative refreshes can be marked inactive without losing traceability.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.repository.ts
+++ b/src/external-overlays/external-overlay.repository.ts
@@ -312,6 +312,24 @@ export class ExternalOverlayRepository {
     missionId: string,
     input: CreateAreaConflictExternalOverlayInput,
   ): Promise<ExternalOverlay> {
+    return this.upsertAreaConflictOverlay(tx, null, missionId, input);
+  }
+
+  async updateAreaConflictOverlay(
+    tx: PoolClient,
+    overlayId: string,
+    missionId: string,
+    input: CreateAreaConflictExternalOverlayInput,
+  ): Promise<ExternalOverlay> {
+    return this.upsertAreaConflictOverlay(tx, overlayId, missionId, input);
+  }
+
+  private async upsertAreaConflictOverlay(
+    tx: PoolClient,
+    overlayId: string | null,
+    missionId: string,
+    input: CreateAreaConflictExternalOverlayInput,
+  ): Promise<ExternalOverlay> {
     const geometryType = input.geometry.type;
     const center =
       geometryType === "circle"
@@ -330,54 +348,80 @@ export class ExternalOverlayRepository {
             altitudeCeilingFt: input.geometry.altitudeCeilingFt ?? null,
           };
 
+    const parameters = [
+      overlayId ?? randomUUID(),
+      missionId,
+      input.source.provider,
+      input.source.sourceType,
+      input.source.sourceRecordId,
+      input.observedAt,
+      input.validFrom,
+      input.validTo,
+      geometryType,
+      center.lat,
+      center.lng,
+      input.severity,
+      input.confidence,
+      input.freshnessSeconds,
+      JSON.stringify({
+        ...input.metadata,
+        ...geometryMetadata,
+      }),
+    ];
+
     const result = await tx.query<ExternalOverlayRow>(
-      `
-      insert into mission_external_overlays (
-        id,
-        mission_id,
-        overlay_kind,
-        source_provider,
-        source_type,
-        source_record_id,
-        observed_at,
-        valid_from,
-        valid_to,
-        geometry_type,
-        latitude,
-        longitude,
-        altitude_msl_ft,
-        heading_degrees,
-        speed_knots,
-        severity,
-        confidence,
-        freshness_seconds,
-        metadata
-      )
-      values (
-        $1, $2, 'area_conflict', $3, $4, $5, $6, $7, $8, $9, $10, $11, null, null, null, $12, $13, $14, $15::jsonb
-      )
-      returning *
-      `,
-      [
-        randomUUID(),
-        missionId,
-        input.source.provider,
-        input.source.sourceType,
-        input.source.sourceRecordId,
-        input.observedAt,
-        input.validFrom,
-        input.validTo,
-        geometryType,
-        center.lat,
-        center.lng,
-        input.severity,
-        input.confidence,
-        input.freshnessSeconds,
-        JSON.stringify({
-          ...input.metadata,
-          ...geometryMetadata,
-        }),
-      ],
+      overlayId
+        ? `
+          update mission_external_overlays
+          set source_provider = $3,
+              source_type = $4,
+              source_record_id = $5,
+              observed_at = $6,
+              valid_from = $7,
+              valid_to = $8,
+              geometry_type = $9,
+              latitude = $10,
+              longitude = $11,
+              altitude_msl_ft = null,
+              heading_degrees = null,
+              speed_knots = null,
+              severity = $12,
+              confidence = $13,
+              freshness_seconds = $14,
+              metadata = $15::jsonb,
+              updated_at = now()
+          where id = $1
+            and mission_id = $2
+          returning *
+        `
+        : `
+          insert into mission_external_overlays (
+            id,
+            mission_id,
+            overlay_kind,
+            source_provider,
+            source_type,
+            source_record_id,
+            observed_at,
+            valid_from,
+            valid_to,
+            geometry_type,
+            latitude,
+            longitude,
+            altitude_msl_ft,
+            heading_degrees,
+            speed_knots,
+            severity,
+            confidence,
+            freshness_seconds,
+            metadata
+          )
+          values (
+            $1, $2, 'area_conflict', $3, $4, $5, $6, $7, $8, $9, $10, $11, null, null, null, $12, $13, $14, $15::jsonb
+          )
+          returning *
+        `,
+      parameters,
     );
 
     return toExternalOverlay(result.rows[0]);

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -8,7 +8,9 @@ import type {
   CreateDroneTrafficExternalOverlayInput,
   CreateWeatherExternalOverlayInput,
   ExternalOverlay,
+  ExternalOverlayCircleGeometry,
   ExternalOverlayKind,
+  ExternalOverlayPolygonGeometry,
   NormalizeAreaOverlaySourcesInput,
 } from "./external-overlay.types";
 import {
@@ -101,6 +103,102 @@ const normalizedAreaMetadata = (
   ],
   ...extras,
 });
+
+const sourceTraceEntryKey = (
+  entry: NonNullable<AreaConflictOverlayMetadata["sourceTrace"]>[number],
+): string =>
+  [
+    entry.provider,
+    entry.sourceType,
+    entry.sourceRecordId ?? "",
+    entry.areaId,
+  ].join("|");
+
+const mergeSourceTrace = (
+  ...traces: Array<NonNullable<AreaConflictOverlayMetadata["sourceTrace"]> | undefined>
+): NonNullable<AreaConflictOverlayMetadata["sourceTrace"]> => {
+  const merged = new Map<
+    string,
+    NonNullable<AreaConflictOverlayMetadata["sourceTrace"]>[number]
+  >();
+
+  for (const trace of traces) {
+    for (const entry of trace ?? []) {
+      merged.set(sourceTraceEntryKey(entry), entry);
+    }
+  }
+
+  return [...merged.values()];
+};
+
+const areaMetadataFromOverlay = (
+  overlay: ExternalOverlay,
+): AreaConflictOverlayMetadata => overlay.metadata as unknown as AreaConflictOverlayMetadata;
+
+const isAreaConflictGeometry = (
+  geometry: ExternalOverlay["geometry"],
+): geometry is ExternalOverlayCircleGeometry | ExternalOverlayPolygonGeometry =>
+  geometry.type === "circle" || geometry.type === "polygon";
+
+const sourceTraceFromOverlay = (
+  overlay: ExternalOverlay,
+): NonNullable<AreaConflictOverlayMetadata["sourceTrace"]> => {
+  const metadata = areaMetadataFromOverlay(overlay);
+  if (Array.isArray(metadata.sourceTrace) && metadata.sourceTrace.length > 0) {
+    return metadata.sourceTrace;
+  }
+
+  return [
+    {
+      provider: overlay.source.provider,
+      sourceType: overlay.source.sourceType,
+      sourceRecordId: overlay.source.sourceRecordId ?? null,
+      authorityName: metadata.authorityName ?? null,
+      notamNumber: metadata.notamNumber ?? null,
+      sourceReference: metadata.sourceReference ?? null,
+      areaId: metadata.areaId,
+      label: metadata.label,
+    },
+  ];
+};
+
+const dedupeKeyFromOverlay = (overlay: ExternalOverlay): string | null => {
+  const metadata = areaMetadataFromOverlay(overlay);
+  if (typeof metadata.dedupeKey === "string" && metadata.dedupeKey.length > 0) {
+    return metadata.dedupeKey;
+  }
+
+  if (overlay.kind !== "area_conflict" || !isAreaConflictGeometry(overlay.geometry)) {
+    return null;
+  }
+
+  return [
+    dedupeGeometryKey(overlay.geometry),
+    dedupeWindowKey(overlay.validFrom, overlay.validTo),
+  ].join("|");
+};
+
+const compareIncomingToExistingAreaPriority = (
+  incoming: NormalizeAreaOverlaySourcesInput["records"][number],
+  existing: ExternalOverlay,
+): number => {
+  const priorityDiff =
+    areaSourcePriority(incoming.source.sourceType) -
+    areaSourcePriority(existing.source.sourceType);
+  if (priorityDiff !== 0) {
+    return priorityDiff;
+  }
+
+  const incomingSeverity = severityRank[incoming.severity ?? "info"] ?? 0;
+  const existingSeverity = severityRank[existing.severity ?? "info"] ?? 0;
+  if (incomingSeverity !== existingSeverity) {
+    return incomingSeverity - existingSeverity;
+  }
+
+  const incomingObserved = Date.parse(incoming.observedAt);
+  const existingObserved = Date.parse(existing.observedAt);
+  return incomingObserved - existingObserved;
+};
 
 const compareAreaNormalizationPriority = (
   left: NormalizeAreaOverlaySourcesInput["records"][number],
@@ -254,6 +352,19 @@ export class ExternalOverlayService {
         throw new MissionExternalOverlayMissionNotFoundError(missionId);
       }
 
+      const existingAreaOverlays = await this.externalOverlayRepository.listForMission(
+        client,
+        missionId,
+        { kind: "area_conflict" },
+      );
+      const existingByDedupeKey = new Map<string, ExternalOverlay>();
+      for (const overlay of existingAreaOverlays) {
+        const dedupeKey = dedupeKeyFromOverlay(overlay);
+        if (dedupeKey) {
+          existingByDedupeKey.set(dedupeKey, overlay);
+        }
+      }
+
       const dedupedRecords = new Map<
         string,
         {
@@ -291,24 +402,118 @@ export class ExternalOverlayService {
       }
 
       const overlays: ExternalOverlay[] = [];
-      for (const { winner, sourceTrace } of dedupedRecords.values()) {
+      for (const [dedupeKey, { winner, sourceTrace }] of dedupedRecords.entries()) {
+        const existing = existingByDedupeKey.get(dedupeKey);
+
+        if (!existing) {
+          overlays.push(
+            await this.externalOverlayRepository.insertAreaConflictOverlay(
+              client,
+              missionId,
+              {
+                kind: "area_conflict",
+                source: winner.source,
+                observedAt: winner.observedAt,
+                validFrom: winner.validFrom,
+                validTo: winner.validTo,
+                geometry: winner.geometry,
+                severity: winner.severity,
+                confidence: winner.confidence,
+                freshnessSeconds: winner.freshnessSeconds,
+                metadata: normalizedAreaMetadata(winner, {
+                  dedupeKey,
+                  sourceTrace,
+                  supersession: {
+                    supersededExisting: false,
+                    replacedSourceType: null,
+                    replacedSourceRecordId: null,
+                  },
+                }),
+              },
+            ),
+          );
+          continue;
+        }
+
+        const existingMetadata = areaMetadataFromOverlay(existing);
+        const mergedTrace = mergeSourceTrace(
+          sourceTraceFromOverlay(existing),
+          sourceTrace,
+        );
+        const incomingWins =
+          compareIncomingToExistingAreaPriority(winner, existing) > 0;
+
+        if (incomingWins) {
+          overlays.push(
+            await this.externalOverlayRepository.updateAreaConflictOverlay(
+              client,
+              existing.id,
+              missionId,
+              {
+                kind: "area_conflict",
+                source: winner.source,
+                observedAt: winner.observedAt,
+                validFrom: winner.validFrom,
+                validTo: winner.validTo,
+                geometry: winner.geometry,
+                severity: winner.severity,
+                confidence: winner.confidence,
+                freshnessSeconds: winner.freshnessSeconds,
+                metadata: normalizedAreaMetadata(winner, {
+                  dedupeKey,
+                  sourceTrace: mergedTrace,
+                  supersession: {
+                    supersededExisting: true,
+                    replacedSourceType: existing.source.sourceType,
+                    replacedSourceRecordId: existing.source.sourceRecordId,
+                  },
+                }),
+              },
+            ),
+          );
+          continue;
+        }
+
         overlays.push(
-          await this.externalOverlayRepository.insertAreaConflictOverlay(
+          await this.externalOverlayRepository.updateAreaConflictOverlay(
             client,
+            existing.id,
             missionId,
             {
               kind: "area_conflict",
-              source: winner.source,
-              observedAt: winner.observedAt,
-              validFrom: winner.validFrom,
-              validTo: winner.validTo,
-              geometry: winner.geometry,
-              severity: winner.severity,
-              confidence: winner.confidence,
-              freshnessSeconds: winner.freshnessSeconds,
-              metadata: normalizedAreaMetadata(winner, {
-                sourceTrace,
-              }),
+              source: {
+                provider: existing.source.provider,
+                sourceType: existing.source.sourceType,
+                sourceRecordId: existing.source.sourceRecordId,
+              },
+              observedAt: existing.observedAt,
+              validFrom: existing.validFrom,
+              validTo: existing.validTo,
+              geometry: isAreaConflictGeometry(existing.geometry)
+                ? existing.geometry
+                : winner.geometry,
+              severity: existing.severity,
+              confidence: existing.confidence,
+              freshnessSeconds: existing.freshnessSeconds,
+              metadata: {
+                areaId: existingMetadata.areaId,
+                label: existingMetadata.label,
+                areaType: existingMetadata.areaType,
+                description: existingMetadata.description ?? null,
+                authorityName: existingMetadata.authorityName ?? null,
+                notamNumber: existingMetadata.notamNumber ?? null,
+                sourceReference: existingMetadata.sourceReference ?? null,
+                normalizedSourcePriority:
+                  existingMetadata.normalizedSourcePriority ??
+                  areaSourcePriority(existing.source.sourceType),
+                dedupeKey,
+                sourceTrace: mergedTrace,
+                supersession: {
+                  supersededExisting: false,
+                  replacedSourceType: null,
+                  replacedSourceRecordId: null,
+                },
+              },
             },
           ),
         );

--- a/src/external-overlays/external-overlay.types.ts
+++ b/src/external-overlays/external-overlay.types.ts
@@ -94,6 +94,11 @@ export interface AreaConflictOverlayMetadata {
     areaId: string;
     label: string;
   }>;
+  supersession?: {
+    supersededExisting: boolean;
+    replacedSourceType: string | null;
+    replacedSourceRecordId: string | null;
+  } | null;
 }
 
 export interface ExternalOverlay {

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -661,6 +661,174 @@ describe("mission external overlays integration", () => {
     expect(listResponse.body.overlays).toHaveLength(1);
   });
 
+  it("supersedes an existing lower-priority normalized area overlay on a later normalization run", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-700",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-700",
+              label: "Danger Area EGD-700",
+              areaType: "danger_area",
+              description: "Base danger area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(firstRun.body.overlays).toHaveLength(1);
+    const originalOverlayId = firstRun.body.overlays[0].id;
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B7000/26",
+            },
+            observedAt: "2026-04-21T10:08:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B7000-26",
+              label: "Danger Area EGD-700 Active NOTAM",
+              areaType: "notam_restriction",
+              description: "Higher-priority update",
+              authorityName: "NATS",
+              notamNumber: "B7000/26",
+              sourceReference: "NOTAM B7000/26",
+            },
+          },
+        ],
+      });
+
+    expect(secondRun.status).toBe(201);
+    expect(secondRun.body.overlays).toHaveLength(1);
+    expect(secondRun.body.overlays[0]).toMatchObject({
+      id: originalOverlayId,
+      source: {
+        sourceType: "notam_restriction",
+        sourceRecordId: "B7000/26",
+      },
+      severity: "critical",
+      metadata: expect.objectContaining({
+        supersession: {
+          supersededExisting: true,
+          replacedSourceType: "danger_area",
+          replacedSourceRecordId: "EGD-700",
+        },
+        sourceTrace: [
+          expect.objectContaining({
+            sourceType: "danger_area",
+            sourceRecordId: "EGD-700",
+          }),
+          expect.objectContaining({
+            sourceType: "notam_restriction",
+            sourceRecordId: "B7000/26",
+          }),
+        ],
+      }),
+    });
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays?kind=area_conflict`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.overlays).toHaveLength(1);
+    expect(listResponse.body.overlays[0].id).toBe(originalOverlayId);
+  });
+
+  it("re-sees equivalent normalized area overlays across runs without creating duplicates", async () => {
+    const missionId = await createMission();
+
+    const requestBody = {
+      records: [
+        {
+          source: {
+            provider: "uk-ais",
+            sourceType: "temporary_danger_area",
+            sourceRecordId: "TDA-808",
+          },
+          observedAt: "2026-04-21T10:07:00.000Z",
+          validFrom: "2026-04-21T10:00:00.000Z",
+          validTo: "2026-04-21T14:00:00.000Z",
+          geometry: {
+            type: "circle",
+            centerLat: 51.5078,
+            centerLng: -0.1269,
+            radiusMeters: 350,
+            altitudeFloorFt: 0,
+            altitudeCeilingFt: 900,
+          },
+          severity: "caution",
+          area: {
+            areaId: "TDA-808",
+            label: "Temporary Danger Area 808",
+            areaType: "temporary_danger_area",
+            description: "Repeated authoritative input",
+            authorityName: "CAA",
+            sourceReference: "Temporary activation notice",
+          },
+        },
+      ],
+    };
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send(requestBody);
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send(requestBody);
+
+    expect(firstRun.status).toBe(201);
+    expect(secondRun.status).toBe(201);
+    expect(secondRun.body.overlays).toHaveLength(1);
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays?kind=area_conflict`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.overlays).toHaveLength(1);
+    expect(listResponse.body.overlays[0].metadata.sourceTrace).toHaveLength(1);
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 

--- a/src/tests/traffic-conflict-assessment.test.ts
+++ b/src/tests/traffic-conflict-assessment.test.ts
@@ -636,6 +636,95 @@ describe("traffic conflict assessment integration", () => {
     });
   });
 
+  it("uses the superseded higher-priority overlay on later normalization runs without creating parallel area conflicts", async () => {
+    const missionId = await createMission();
+    await recordTelemetry(missionId);
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-901",
+            },
+            observedAt: "2026-04-21T12:00:10.000Z",
+            validFrom: "2026-04-21T12:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5075,
+              centerLng: -0.1277,
+              radiusMeters: 150,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            area: {
+              areaId: "EGD-901",
+              label: "Danger Area EGD-901",
+              areaType: "danger_area",
+              description: "Base area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+        ],
+      });
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B9010/26",
+            },
+            observedAt: "2026-04-21T12:00:20.000Z",
+            validFrom: "2026-04-21T12:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5075,
+              centerLng: -0.1277,
+              radiusMeters: 150,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B9010-26",
+              label: "Danger Area EGD-901 Active NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding NOTAM",
+              authorityName: "NATS",
+              notamNumber: "B9010/26",
+              sourceReference: "NOTAM B9010/26",
+            },
+          },
+        ],
+      });
+
+    const response = await request(app).get(
+      `/missions/${missionId}/conflict-assessment`,
+    );
+
+    expect(response.status).toBe(200);
+    const areaConflicts = response.body.assessment.conflicts.filter(
+      (item: { overlayKind: string }) => item.overlayKind === "area_conflict",
+    );
+    expect(areaConflicts).toHaveLength(1);
+    expect(areaConflicts[0]).toMatchObject({
+      overlayLabel: "Danger Area EGD-901 Active NOTAM",
+      relatedSource: {
+        sourceType: "notam_restriction",
+      },
+    });
+  });
+
   it("preserves mission isolation for conflict assessment reads", async () => {
     const firstMissionId = await createMission();
     const secondMissionId = await createMission();


### PR DESCRIPTION
## Summary

Implements GitHub issue #183 by adding supersession updates to normalized area overlay ingestion so higher-priority NOTAM-derived restrictions can replace existing lower-priority area overlays across repeated normalization runs.

## What changed

- Added supersession behavior to normalized area overlay ingestion.
- Kept the implementation inside the normalized area overlay ingestion boundary.
- Added update/upsert support for mission-linked `area_conflict` overlays so repeated normalization runs can reuse an existing normalized overlay row instead of creating a parallel duplicate.
- Preserved the existing same-run source-priority and deduplication behavior from `#181`.
- Added repeated-run supersession behavior so:
  - a later higher-priority `notam_restriction` can replace an existing lower-priority `danger_area` or `temporary_danger_area`
  - equivalent later runs do not create unnecessary duplicate overlays
- Preserved source traceability during supersession through merged metadata fields including:
  - `sourceTrace`
  - `dedupeKey`
  - `normalizedSourcePriority`
  - `supersession`
- Higher-priority later inputs now replace the active normalized overlay representation in place while preserving the existing overlay row id for the dedupe signature.
- Verified that conflict assessment continues to consume normalized area overlays without source-specific branching and without creating redundant parallel area conflicts after repeated normalization runs.
- Updated the save point to the next ingestion refinement step:
  - retirement handling for previously-ingested restrictions missing from later authoritative refreshes

## Verification

- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 12 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 10 tests.
- `npm.cmd run build` passed.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 342 tests.

## Notes

This issue refines normalization behavior across repeated runs only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #183.
