### PR TITLE
Add area overlay retirement handling

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add normalized area overlay retirement handling so previously-ingested restrictions that disappear from later authoritative refreshes can be marked inactive without losing traceability.",
+  "nextBuildStep": "Add refresh-run provenance metadata to normalized area overlay ingestion so authoritative snapshots can be audited across repeated normalization cycles.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.repository.ts
+++ b/src/external-overlays/external-overlay.repository.ts
@@ -324,6 +324,28 @@ export class ExternalOverlayRepository {
     return this.upsertAreaConflictOverlay(tx, overlayId, missionId, input);
   }
 
+  async retireAreaConflictOverlay(
+    tx: PoolClient,
+    overlayId: string,
+    missionId: string,
+    metadata: Record<string, unknown>,
+  ): Promise<ExternalOverlay> {
+    const result = await tx.query<ExternalOverlayRow>(
+      `
+      update mission_external_overlays
+      set metadata = $3::jsonb,
+          updated_at = now()
+      where id = $1
+        and mission_id = $2
+        and overlay_kind = 'area_conflict'
+      returning *
+      `,
+      [overlayId, missionId, JSON.stringify(metadata)],
+    );
+
+    return toExternalOverlay(result.rows[0]);
+  }
+
   private async upsertAreaConflictOverlay(
     tx: PoolClient,
     overlayId: string | null,
@@ -438,9 +460,14 @@ export class ExternalOverlayRepository {
       from mission_external_overlays
       where mission_id = $1
         and ($2::text is null or overlay_kind = $2)
+        and (
+          $3::boolean = true
+          or overlay_kind <> 'area_conflict'
+          or coalesce(metadata->'retirement'->>'retired', 'false') <> 'true'
+        )
       order by observed_at desc, id desc
       `,
-      [missionId, filters.kind ?? null],
+      [missionId, filters.kind ?? null, filters.includeRetired ?? false],
     );
 
     return result.rows.map(toExternalOverlay);

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -101,6 +101,11 @@ const normalizedAreaMetadata = (
       label: record.area.label,
     },
   ],
+  retirement: {
+    retired: false,
+    retiredAt: null,
+    reason: null,
+  },
   ...extras,
 });
 
@@ -176,6 +181,16 @@ const dedupeKeyFromOverlay = (overlay: ExternalOverlay): string | null => {
     dedupeGeometryKey(overlay.geometry),
     dedupeWindowKey(overlay.validFrom, overlay.validTo),
   ].join("|");
+};
+
+const isRetiredAreaOverlay = (overlay: ExternalOverlay): boolean => {
+  const metadata = areaMetadataFromOverlay(overlay);
+  return metadata.retirement?.retired === true;
+};
+
+const isNormalizedAreaOverlay = (overlay: ExternalOverlay): boolean => {
+  const metadata = areaMetadataFromOverlay(overlay);
+  return typeof metadata.dedupeKey === "string" && metadata.dedupeKey.length > 0;
 };
 
 const compareIncomingToExistingAreaPriority = (
@@ -355,10 +370,13 @@ export class ExternalOverlayService {
       const existingAreaOverlays = await this.externalOverlayRepository.listForMission(
         client,
         missionId,
-        { kind: "area_conflict" },
+        { kind: "area_conflict", includeRetired: true },
       );
       const existingByDedupeKey = new Map<string, ExternalOverlay>();
       for (const overlay of existingAreaOverlays) {
+        if (isRetiredAreaOverlay(overlay)) {
+          continue;
+        }
         const dedupeKey = dedupeKeyFromOverlay(overlay);
         if (dedupeKey) {
           existingByDedupeKey.set(dedupeKey, overlay);
@@ -402,7 +420,9 @@ export class ExternalOverlayService {
       }
 
       const overlays: ExternalOverlay[] = [];
+      const processedDedupeKeys = new Set<string>();
       for (const [dedupeKey, { winner, sourceTrace }] of dedupedRecords.entries()) {
+        processedDedupeKeys.add(dedupeKey);
         const existing = existingByDedupeKey.get(dedupeKey);
 
         if (!existing) {
@@ -516,6 +536,37 @@ export class ExternalOverlayService {
               },
             },
           ),
+        );
+      }
+
+      const retirementTimestamp = new Date().toISOString();
+      for (const overlay of existingAreaOverlays) {
+        if (isRetiredAreaOverlay(overlay)) {
+          continue;
+        }
+
+        const dedupeKey = dedupeKeyFromOverlay(overlay);
+        if (
+          !dedupeKey ||
+          processedDedupeKeys.has(dedupeKey) ||
+          !isNormalizedAreaOverlay(overlay)
+        ) {
+          continue;
+        }
+
+        const metadata = areaMetadataFromOverlay(overlay);
+        await this.externalOverlayRepository.retireAreaConflictOverlay(
+          client,
+          overlay.id,
+          missionId,
+          {
+            ...metadata,
+            retirement: {
+              retired: true,
+              retiredAt: retirementTimestamp,
+              reason: "missing_from_refresh",
+            },
+          },
         );
       }
 

--- a/src/external-overlays/external-overlay.types.ts
+++ b/src/external-overlays/external-overlay.types.ts
@@ -99,6 +99,11 @@ export interface AreaConflictOverlayMetadata {
     replacedSourceType: string | null;
     replacedSourceRecordId: string | null;
   } | null;
+  retirement?: {
+    retired: boolean;
+    retiredAt: string | null;
+    reason: "missing_from_refresh" | null;
+  } | null;
 }
 
 export interface ExternalOverlay {
@@ -277,4 +282,5 @@ export interface NormalizeAreaOverlaySourcesInput {
 
 export interface ListExternalOverlaysFilters {
   kind?: ExternalOverlayKind;
+  includeRetired?: boolean;
 }

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -829,6 +829,145 @@ describe("mission external overlays integration", () => {
     expect(listResponse.body.overlays[0].metadata.sourceTrace).toHaveLength(1);
   });
 
+  it("retires previously-normalized area overlays when later authoritative refreshes omit them", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-990",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-990",
+              label: "Danger Area EGD-990",
+              areaType: "danger_area",
+              description: "First refresh only",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-991",
+            },
+            observedAt: "2026-04-21T10:08:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5091,
+              centerLng: -0.1261,
+              radiusMeters: 280,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            severity: "critical",
+            area: {
+              areaId: "TDA-991",
+              label: "Temporary Danger Area 991",
+              areaType: "temporary_danger_area",
+              description: "Survives later refresh",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(firstRun.body.overlays).toHaveLength(2);
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-991",
+            },
+            observedAt: "2026-04-21T10:08:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5091,
+              centerLng: -0.1261,
+              radiusMeters: 280,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            severity: "critical",
+            area: {
+              areaId: "TDA-991",
+              label: "Temporary Danger Area 991",
+              areaType: "temporary_danger_area",
+              description: "Survives later refresh",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    expect(secondRun.status).toBe(201);
+    expect(secondRun.body.overlays).toHaveLength(1);
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays?kind=area_conflict`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.overlays).toHaveLength(1);
+    expect(listResponse.body.overlays[0].metadata.areaId).toBe("TDA-991");
+
+    const retiredOverlay = await pool.query<{
+      metadata: {
+        areaId: string;
+        retirement: {
+          retired: boolean;
+          retiredAt: string | null;
+          reason: string | null;
+        } | null;
+      };
+    }>(
+      `
+      select metadata
+      from mission_external_overlays
+      where mission_id = $1
+        and metadata->>'areaId' = 'EGD-990'
+      `,
+      [missionId],
+    );
+
+    expect(retiredOverlay.rowCount).toBe(1);
+    expect(retiredOverlay.rows[0].metadata.retirement).toMatchObject({
+      retired: true,
+      retiredAt: expect.any(String),
+      reason: "missing_from_refresh",
+    });
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 

--- a/src/tests/traffic-conflict-assessment.test.ts
+++ b/src/tests/traffic-conflict-assessment.test.ts
@@ -725,6 +725,124 @@ describe("traffic conflict assessment integration", () => {
     });
   });
 
+  it("does not assess retired normalized area overlays after a later authoritative refresh omits them", async () => {
+    const missionId = await createMission();
+    await recordTelemetry(missionId);
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-902",
+            },
+            observedAt: "2026-04-21T12:00:10.000Z",
+            validFrom: "2026-04-21T12:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5075,
+              centerLng: -0.1277,
+              radiusMeters: 150,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            area: {
+              areaId: "EGD-902",
+              label: "Danger Area EGD-902",
+              areaType: "danger_area",
+              description: "Should retire on later refresh",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-902",
+            },
+            observedAt: "2026-04-21T12:00:20.000Z",
+            validFrom: "2026-04-21T12:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5095,
+              centerLng: -0.1267,
+              radiusMeters: 150,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            area: {
+              areaId: "TDA-902",
+              label: "Temporary Danger Area 902",
+              areaType: "temporary_danger_area",
+              description: "Remains active",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-902",
+            },
+            observedAt: "2026-04-21T12:00:20.000Z",
+            validFrom: "2026-04-21T12:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5095,
+              centerLng: -0.1267,
+              radiusMeters: 150,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            area: {
+              areaId: "TDA-902",
+              label: "Temporary Danger Area 902",
+              areaType: "temporary_danger_area",
+              description: "Remains active",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    const response = await request(app).get(
+      `/missions/${missionId}/conflict-assessment`,
+    );
+
+    expect(response.status).toBe(200);
+    const areaConflicts = response.body.assessment.conflicts.filter(
+      (item: { overlayKind: string }) => item.overlayKind === "area_conflict",
+    );
+    expect(areaConflicts).toHaveLength(1);
+    expect(areaConflicts[0]).toMatchObject({
+      overlayLabel: "Temporary Danger Area 902",
+      relatedSource: {
+        sourceType: "temporary_danger_area",
+      },
+    });
+    expect(
+      areaConflicts.some(
+        (item: { overlayLabel: string }) => item.overlayLabel === "Danger Area EGD-902",
+      ),
+    ).toBe(false);
+  });
+
   it("preserves mission isolation for conflict assessment reads", async () => {
     const firstMissionId = await createMission();
     const secondMissionId = await createMission();


### PR DESCRIPTION
## Summary

Implements GitHub issue #185 by adding normalized area overlay retirement handling so previously-ingested restrictions that disappear from later authoritative refreshes can be marked inactive without losing traceability.

## What changed

- Added retirement handling to normalized area overlay ingestion.
- Kept the implementation inside the normalized area overlay ingestion boundary.
- Extended normalized `area_conflict` metadata with explicit retirement state:
  - `retirement.retired`
  - `retirement.retiredAt`
  - `retirement.reason`
- Added repository support to retire existing normalized area overlays in place while preserving the original overlay row and metadata history.
- Updated default mission overlay reads so retired normalized area overlays are excluded from active reads, while still remaining stored for traceability.
- Updated repeated normalization-run behavior so:
  - overlays present in the current authoritative refresh remain active
  - previously-normalized area overlays missing from the later refresh are marked retired with reason `missing_from_refresh`
  - retired overlays no longer feed interpreted area conflict assessment
- Preserved existing:
  - same-run deduplication
  - repeated-run supersession
  - source traceability
  - geometry-aware range/bearing behavior
  - altitude-band gating
  - validity-window gating
- Verified that conflict assessment continues to consume only active normalized area overlays and does not surface retired restrictions as active interpreted conflicts.
- Updated the save point to the next ingestion refinement step:
  - refresh-run provenance metadata across repeated normalization cycles

## Verification

- `npm.cmd run build` passed.
- `node scripts\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 13 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 344 tests.

## Notes

This issue refines normalized area overlay lifecycle handling only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #185.
