### PR TITLE
Add area overlay refresh provenance

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add refresh-run provenance metadata to normalized area overlay ingestion so authoritative snapshots can be audited across repeated normalization cycles.",
+  "nextBuildStep": "Add refresh-run summary query support to normalized area overlay ingestion so authoritative snapshots can be reviewed across repeated normalization cycles.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import type { Pool } from "pg";
 import { ExternalOverlayRepository } from "./external-overlay.repository";
 import { MissionExternalOverlayMissionNotFoundError } from "./external-overlay.errors";
@@ -78,6 +79,7 @@ const areaSourcePriority = (sourceType: string): number =>
 
 const normalizedAreaMetadata = (
   record: NormalizeAreaOverlaySourcesInput["records"][number],
+  refreshRunId: string,
   extras: Partial<AreaConflictOverlayMetadata> = {},
 ): AreaConflictOverlayMetadata => ({
   areaId: record.area.areaId,
@@ -105,6 +107,12 @@ const normalizedAreaMetadata = (
     retired: false,
     retiredAt: null,
     reason: null,
+  },
+  refreshProvenance: {
+    createdByRunId: refreshRunId,
+    lastUpdatedByRunId: refreshRunId,
+    supersededByRunId: null,
+    retiredByRunId: null,
   },
   ...extras,
 });
@@ -353,8 +361,9 @@ export class ExternalOverlayService {
   async normalizeAreaOverlaySources(
     missionId: string,
     input: unknown,
-  ): Promise<{ missionId: string; overlays: ExternalOverlay[] }> {
+  ): Promise<{ missionId: string; refreshRunId: string; overlays: ExternalOverlay[] }> {
     const validated = validateNormalizeAreaOverlaySourcesInput(input);
+    const refreshRunId = randomUUID();
     const client = await this.pool.connect();
 
     try {
@@ -393,7 +402,7 @@ export class ExternalOverlayService {
 
       for (const record of validated.records) {
         const dedupeKey = buildAreaDedupeKey(record);
-        const traceEntry = normalizedAreaMetadata(record).sourceTrace ?? [];
+        const traceEntry = normalizedAreaMetadata(record, refreshRunId).sourceTrace ?? [];
         const existing = dedupedRecords.get(dedupeKey);
 
         if (!existing) {
@@ -440,7 +449,7 @@ export class ExternalOverlayService {
                 severity: winner.severity,
                 confidence: winner.confidence,
                 freshnessSeconds: winner.freshnessSeconds,
-                metadata: normalizedAreaMetadata(winner, {
+                metadata: normalizedAreaMetadata(winner, refreshRunId, {
                   dedupeKey,
                   sourceTrace,
                   supersession: {
@@ -479,13 +488,20 @@ export class ExternalOverlayService {
                 severity: winner.severity,
                 confidence: winner.confidence,
                 freshnessSeconds: winner.freshnessSeconds,
-                metadata: normalizedAreaMetadata(winner, {
+                metadata: normalizedAreaMetadata(winner, refreshRunId, {
                   dedupeKey,
                   sourceTrace: mergedTrace,
                   supersession: {
                     supersededExisting: true,
                     replacedSourceType: existing.source.sourceType,
                     replacedSourceRecordId: existing.source.sourceRecordId,
+                  },
+                  refreshProvenance: {
+                    createdByRunId:
+                      existingMetadata.refreshProvenance?.createdByRunId ?? refreshRunId,
+                    lastUpdatedByRunId: refreshRunId,
+                    supersededByRunId: refreshRunId,
+                    retiredByRunId: null,
                   },
                 }),
               },
@@ -533,6 +549,19 @@ export class ExternalOverlayService {
                   replacedSourceType: null,
                   replacedSourceRecordId: null,
                 },
+                retirement: {
+                  retired: false,
+                  retiredAt: null,
+                  reason: null,
+                },
+                refreshProvenance: {
+                  createdByRunId:
+                    existingMetadata.refreshProvenance?.createdByRunId ?? refreshRunId,
+                  lastUpdatedByRunId: refreshRunId,
+                  supersededByRunId:
+                    existingMetadata.refreshProvenance?.supersededByRunId ?? null,
+                  retiredByRunId: null,
+                },
               },
             },
           ),
@@ -566,12 +595,21 @@ export class ExternalOverlayService {
               retiredAt: retirementTimestamp,
               reason: "missing_from_refresh",
             },
+            refreshProvenance: {
+              createdByRunId:
+                metadata.refreshProvenance?.createdByRunId ?? refreshRunId,
+              lastUpdatedByRunId: refreshRunId,
+              supersededByRunId:
+                metadata.refreshProvenance?.supersededByRunId ?? null,
+              retiredByRunId: refreshRunId,
+            },
           },
         );
       }
 
       return {
         missionId,
+        refreshRunId,
         overlays,
       };
     } finally {

--- a/src/external-overlays/external-overlay.types.ts
+++ b/src/external-overlays/external-overlay.types.ts
@@ -104,6 +104,12 @@ export interface AreaConflictOverlayMetadata {
     retiredAt: string | null;
     reason: "missing_from_refresh" | null;
   } | null;
+  refreshProvenance?: {
+    createdByRunId: string;
+    lastUpdatedByRunId: string;
+    supersededByRunId: string | null;
+    retiredByRunId: string | null;
+  } | null;
 }
 
 export interface ExternalOverlay {

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -510,6 +510,7 @@ describe("mission external overlays integration", () => {
       });
 
     expect(normalizeResponse.status).toBe(201);
+    expect(normalizeResponse.body.refreshRunId).toEqual(expect.any(String));
     expect(normalizeResponse.body).toMatchObject({
       missionId,
       overlays: [
@@ -525,6 +526,12 @@ describe("mission external overlays integration", () => {
             areaType: "danger_area",
             authorityName: "CAA",
             sourceReference: "ENR 5.1",
+            refreshProvenance: expect.objectContaining({
+              createdByRunId: normalizeResponse.body.refreshRunId,
+              lastUpdatedByRunId: normalizeResponse.body.refreshRunId,
+              supersededByRunId: null,
+              retiredByRunId: null,
+            }),
           }),
         }),
         expect.objectContaining({
@@ -539,6 +546,12 @@ describe("mission external overlays integration", () => {
             areaType: "notam_restriction",
             notamNumber: "B1234/26",
             sourceReference: "NOTAM B1234/26",
+            refreshProvenance: expect.objectContaining({
+              createdByRunId: normalizeResponse.body.refreshRunId,
+              lastUpdatedByRunId: normalizeResponse.body.refreshRunId,
+              supersededByRunId: null,
+              retiredByRunId: null,
+            }),
           }),
         }),
       ],
@@ -701,6 +714,7 @@ describe("mission external overlays integration", () => {
     expect(firstRun.status).toBe(201);
     expect(firstRun.body.overlays).toHaveLength(1);
     const originalOverlayId = firstRun.body.overlays[0].id;
+    const firstRunId = firstRun.body.refreshRunId as string;
 
     const secondRun = await request(app)
       .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
@@ -739,6 +753,7 @@ describe("mission external overlays integration", () => {
 
     expect(secondRun.status).toBe(201);
     expect(secondRun.body.overlays).toHaveLength(1);
+    expect(secondRun.body.refreshRunId).toEqual(expect.any(String));
     expect(secondRun.body.overlays[0]).toMatchObject({
       id: originalOverlayId,
       source: {
@@ -762,6 +777,12 @@ describe("mission external overlays integration", () => {
             sourceRecordId: "B7000/26",
           }),
         ],
+        refreshProvenance: {
+          createdByRunId: firstRunId,
+          lastUpdatedByRunId: secondRun.body.refreshRunId,
+          supersededByRunId: secondRun.body.refreshRunId,
+          retiredByRunId: null,
+        },
       }),
     });
 
@@ -895,6 +916,7 @@ describe("mission external overlays integration", () => {
 
     expect(firstRun.status).toBe(201);
     expect(firstRun.body.overlays).toHaveLength(2);
+    const firstRunId = firstRun.body.refreshRunId as string;
 
     const secondRun = await request(app)
       .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
@@ -932,6 +954,7 @@ describe("mission external overlays integration", () => {
 
     expect(secondRun.status).toBe(201);
     expect(secondRun.body.overlays).toHaveLength(1);
+    expect(secondRun.body.refreshRunId).toEqual(expect.any(String));
 
     const listResponse = await request(app).get(
       `/missions/${missionId}/external-overlays?kind=area_conflict`,
@@ -965,6 +988,11 @@ describe("mission external overlays integration", () => {
       retired: true,
       retiredAt: expect.any(String),
       reason: "missing_from_refresh",
+    });
+    expect(retiredOverlay.rows[0].metadata.refreshProvenance).toMatchObject({
+      createdByRunId: firstRunId,
+      lastUpdatedByRunId: secondRun.body.refreshRunId,
+      retiredByRunId: secondRun.body.refreshRunId,
     });
   });
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #188 by adding refresh-run provenance metadata to normalized area overlay ingestion so authoritative snapshots can be audited across repeated normalization cycles.

## What changed

- Added refresh-run provenance metadata to normalized `area_conflict` overlay metadata.
- Kept the implementation inside the normalized area overlay ingestion boundary.
- Each normalization run now generates a stable `refreshRunId`.
- Normalized area overlay metadata now records:
  - `createdByRunId`
  - `lastUpdatedByRunId`
  - `supersededByRunId`
  - `retiredByRunId`
- Updated normalization behavior so refresh provenance is attached consistently when overlays are:
  - created
  - re-seen and updated
  - superseded by higher-priority inputs
  - retired after disappearing from a later authoritative refresh
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling
  - source traceability
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
- Kept conflict assessment source-agnostic and unchanged in behavior.
- Updated the save point to the next provenance-read refinement step:
  - refresh-run summary query support across repeated normalization cycles

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 13 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 344 tests.

## Notes

This issue is an ingestion-layer auditability refinement only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #188.
