### PR TITLE
Add area overlay refresh summary query

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add refresh-run summary query support to normalized area overlay ingestion so authoritative snapshots can be reviewed across repeated normalization cycles.",
+  "nextBuildStep": "Add refresh-run detail filtering support to normalized area overlay summary queries so a single authoritative snapshot can be reviewed directly.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -69,6 +69,22 @@ export class ExternalOverlayController {
     }
   };
 
+  listAreaOverlayRefreshRuns = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const result = await this.externalOverlayService.listAreaOverlayRefreshRuns(
+        req.params.missionId,
+      );
+
+      res.status(200).json(result);
+    } catch (error) {
+      next(error);
+    }
+  };
+
   listExternalOverlays = async (
     req: Request<MissionIdParams>,
     res: Response,

--- a/src/external-overlays/external-overlay.routes.ts
+++ b/src/external-overlays/external-overlay.routes.ts
@@ -10,6 +10,10 @@ export function createExternalOverlayRouter(
     "/:missionId/external-overlays/normalize-area-sources",
     controller.normalizeAreaOverlaySources,
   );
+  router.get(
+    "/:missionId/external-overlays/refresh-runs",
+    controller.listAreaOverlayRefreshRuns,
+  );
   router.post("/:missionId/external-overlays", controller.createExternalOverlay);
   router.get("/:missionId/external-overlays", controller.listExternalOverlays);
 

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -201,6 +201,38 @@ const isNormalizedAreaOverlay = (overlay: ExternalOverlay): boolean => {
   return typeof metadata.dedupeKey === "string" && metadata.dedupeKey.length > 0;
 };
 
+type AreaRefreshRunOverlaySummary = {
+  overlayId: string;
+  areaId: string;
+  label: string;
+  sourceType: string;
+  sourceRecordId: string | null;
+  retired: boolean;
+};
+
+type AreaRefreshRunSummary = {
+  refreshRunId: string;
+  created: AreaRefreshRunOverlaySummary[];
+  updated: AreaRefreshRunOverlaySummary[];
+  superseded: AreaRefreshRunOverlaySummary[];
+  retired: AreaRefreshRunOverlaySummary[];
+  active: AreaRefreshRunOverlaySummary[];
+};
+
+const toRefreshRunOverlaySummary = (
+  overlay: ExternalOverlay,
+): AreaRefreshRunOverlaySummary => {
+  const metadata = areaMetadataFromOverlay(overlay);
+  return {
+    overlayId: overlay.id,
+    areaId: metadata.areaId,
+    label: metadata.label,
+    sourceType: overlay.source.sourceType,
+    sourceRecordId: overlay.source.sourceRecordId,
+    retired: metadata.retirement?.retired === true,
+  };
+};
+
 const compareIncomingToExistingAreaPriority = (
   incoming: NormalizeAreaOverlaySourcesInput["records"][number],
   existing: ExternalOverlay,
@@ -642,6 +674,91 @@ export class ExternalOverlayService {
       return {
         missionId,
         overlays,
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  async listAreaOverlayRefreshRuns(
+    missionId: string,
+  ): Promise<{ missionId: string; refreshRuns: AreaRefreshRunSummary[] }> {
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.externalOverlayRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new MissionExternalOverlayMissionNotFoundError(missionId);
+      }
+
+      const overlays = await this.externalOverlayRepository.listForMission(
+        client,
+        missionId,
+        { kind: "area_conflict", includeRetired: true },
+      );
+
+      const runs = new Map<string, AreaRefreshRunSummary>();
+      const ensureRun = (refreshRunId: string): AreaRefreshRunSummary => {
+        const existingRun = runs.get(refreshRunId);
+        if (existingRun) {
+          return existingRun;
+        }
+
+        const createdRun: AreaRefreshRunSummary = {
+          refreshRunId,
+          created: [],
+          updated: [],
+          superseded: [],
+          retired: [],
+          active: [],
+        };
+        runs.set(refreshRunId, createdRun);
+        return createdRun;
+      };
+
+      for (const overlay of overlays) {
+        if (!isNormalizedAreaOverlay(overlay)) {
+          continue;
+        }
+
+        const metadata = areaMetadataFromOverlay(overlay);
+        const provenance = metadata.refreshProvenance;
+        if (!provenance?.createdByRunId || !provenance.lastUpdatedByRunId) {
+          continue;
+        }
+
+        const summary = toRefreshRunOverlaySummary(overlay);
+
+        ensureRun(provenance.createdByRunId).created.push(summary);
+
+        if (provenance.lastUpdatedByRunId !== provenance.createdByRunId) {
+          ensureRun(provenance.lastUpdatedByRunId).updated.push(summary);
+        }
+
+        if (provenance.supersededByRunId) {
+          ensureRun(provenance.supersededByRunId).superseded.push(summary);
+        }
+
+        if (provenance.retiredByRunId) {
+          ensureRun(provenance.retiredByRunId).retired.push(summary);
+        }
+
+        if (!summary.retired) {
+          ensureRun(provenance.lastUpdatedByRunId).active.push(summary);
+        }
+      }
+
+      const refreshRuns = [...runs.values()].sort((left, right) =>
+        right.refreshRunId.localeCompare(left.refreshRunId),
+      );
+
+      return {
+        missionId,
+        refreshRuns,
       };
     } finally {
       client.release();

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -996,6 +996,164 @@ describe("mission external overlays integration", () => {
     });
   });
 
+  it("returns refresh-run summaries for repeated normalized area overlay cycles", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-995",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-995",
+              label: "Danger Area EGD-995",
+              areaType: "danger_area",
+              description: "Base area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-995",
+            },
+            observedAt: "2026-04-21T10:08:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5091,
+              centerLng: -0.1261,
+              radiusMeters: 280,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            severity: "critical",
+            area: {
+              areaId: "TDA-995",
+              label: "Temporary Danger Area 995",
+              areaType: "temporary_danger_area",
+              description: "Stays active",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B9950/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B9950-26",
+              label: "Danger Area EGD-995 Active NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B9950/26",
+              sourceReference: "NOTAM B9950/26",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(secondRun.status).toBe(201);
+
+    const summaryResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs`,
+    );
+
+    expect(summaryResponse.status).toBe(200);
+    expect(summaryResponse.body.missionId).toBe(missionId);
+    expect(summaryResponse.body.refreshRuns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          refreshRunId: firstRun.body.refreshRunId,
+          created: expect.arrayContaining([
+            expect.objectContaining({
+              areaId: "NOTAM-B9950-26",
+              retired: false,
+            }),
+            expect.objectContaining({
+              areaId: "TDA-995",
+              retired: true,
+            }),
+          ]),
+        }),
+        expect.objectContaining({
+          refreshRunId: secondRun.body.refreshRunId,
+          updated: expect.arrayContaining([
+            expect.objectContaining({
+              areaId: "NOTAM-B9950-26",
+              retired: false,
+            }),
+            expect.objectContaining({
+              areaId: "TDA-995",
+              retired: true,
+            }),
+          ]),
+          superseded: expect.arrayContaining([
+            expect.objectContaining({
+              areaId: "NOTAM-B9950-26",
+              retired: false,
+            }),
+          ]),
+          retired: expect.arrayContaining([
+            expect.objectContaining({
+              areaId: "TDA-995",
+              retired: true,
+            }),
+          ]),
+          active: expect.arrayContaining([
+            expect.objectContaining({
+              areaId: "NOTAM-B9950-26",
+              retired: false,
+            }),
+          ]),
+        }),
+      ]),
+    );
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #190 by adding refresh-run summary query support to normalized area overlay ingestion so authoritative snapshots can be reviewed across repeated normalization cycles.

## What changed

- Added a mission-linked refresh-run summary read path:
  - `GET /missions/:missionId/external-overlays/refresh-runs`
- Kept the implementation inside the normalized area overlay ingestion / auditability boundary.
- Added service-side aggregation over normalized `area_conflict` overlay provenance metadata so refresh cycles can be reviewed without changing conflict-engine behavior.
- Refresh-run summaries now group overlays by `refreshRunId` and expose:
  - overlays created by that run
  - overlays updated by that run
  - overlays superseded by that run
  - overlays retired by that run
  - overlays left active after that run
- Reused the existing provenance metadata from `#188` rather than adding a new persistence model.
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling
  - source traceability
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
- Kept conflict assessment source-agnostic and unchanged.
- Updated the save point to the next read-path refinement step:
  - refresh-run detail filtering support for a single authoritative snapshot

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 14 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 345 tests.

## Notes

This issue is an ingestion-layer auditability read-path refinement only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #190.
