### PR TITLE
Add area overlay refresh-run filtering

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add refresh-run summary query support to normalized area overlay ingestion so authoritative snapshots can be reviewed across repeated normalization cycles.",
+  "nextBuildStep": "Add refresh-run detail filtering support to normalized area overlay summary queries so a single authoritative snapshot can be reviewed directly.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -6,6 +6,10 @@ type MissionIdParams = {
   missionId: string;
 };
 
+type RefreshRunQuery = {
+  refreshRunId?: string;
+};
+
 export class ExternalOverlayController {
   constructor(
     private readonly externalOverlayService: ExternalOverlayService,
@@ -84,6 +88,30 @@ export class ExternalOverlayController {
         req.params.missionId,
         { kind },
       );
+
+      res.status(200).json(result);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listAreaOverlayRefreshRuns = async (
+    req: Request<MissionIdParams, unknown, unknown, RefreshRunQuery>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const refreshRunId =
+        typeof req.query.refreshRunId === "string" &&
+        req.query.refreshRunId.trim().length > 0
+          ? req.query.refreshRunId.trim()
+          : undefined;
+
+      const result =
+        await this.externalOverlayService.listAreaOverlayRefreshRuns(
+          req.params.missionId,
+          { refreshRunId },
+        );
 
       res.status(200).json(result);
     } catch (error) {

--- a/src/external-overlays/external-overlay.errors.ts
+++ b/src/external-overlays/external-overlay.errors.ts
@@ -6,3 +6,12 @@ export class MissionExternalOverlayMissionNotFoundError extends Error {
     super(`Mission ${missionId} not found`);
   }
 }
+
+export class MissionExternalOverlayRefreshRunNotFoundError extends Error {
+  readonly statusCode = 404;
+  readonly type = "refresh_run_not_found";
+
+  constructor(missionId: string, refreshRunId: string) {
+    super(`Refresh run ${refreshRunId} not found for mission ${missionId}`);
+  }
+}

--- a/src/external-overlays/external-overlay.routes.ts
+++ b/src/external-overlays/external-overlay.routes.ts
@@ -10,6 +10,10 @@ export function createExternalOverlayRouter(
     "/:missionId/external-overlays/normalize-area-sources",
     controller.normalizeAreaOverlaySources,
   );
+  router.get(
+    "/:missionId/external-overlays/refresh-runs",
+    controller.listAreaOverlayRefreshRuns,
+  );
   router.post("/:missionId/external-overlays", controller.createExternalOverlay);
   router.get("/:missionId/external-overlays", controller.listExternalOverlays);
 

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "crypto";
 import type { Pool } from "pg";
 import { ExternalOverlayRepository } from "./external-overlay.repository";
-import { MissionExternalOverlayMissionNotFoundError } from "./external-overlay.errors";
+import {
+  MissionExternalOverlayMissionNotFoundError,
+  MissionExternalOverlayRefreshRunNotFoundError,
+} from "./external-overlay.errors";
 import type {
   AreaConflictOverlayMetadata,
   CreateAreaConflictExternalOverlayInput,
@@ -242,6 +245,40 @@ const compareAreaNormalizationPriority = (
   const leftObserved = Date.parse(left.observedAt);
   const rightObserved = Date.parse(right.observedAt);
   return leftObserved - rightObserved;
+};
+
+type AreaOverlayRefreshRunSummaryItem = {
+  overlayId: string;
+  areaId: string;
+  label: string;
+  sourceType: string;
+  sourceRecordId: string | null;
+  retired: boolean;
+};
+
+type AreaOverlayRefreshRunSummary = {
+  refreshRunId: string;
+  missionId: string;
+  created: AreaOverlayRefreshRunSummaryItem[];
+  updated: AreaOverlayRefreshRunSummaryItem[];
+  superseded: AreaOverlayRefreshRunSummaryItem[];
+  retired: AreaOverlayRefreshRunSummaryItem[];
+  active: AreaOverlayRefreshRunSummaryItem[];
+};
+
+const areaOverlayRefreshSummaryItemFromOverlay = (
+  overlay: ExternalOverlay,
+): AreaOverlayRefreshRunSummaryItem => {
+  const metadata = areaMetadataFromOverlay(overlay);
+
+  return {
+    overlayId: overlay.id,
+    areaId: metadata.areaId,
+    label: metadata.label,
+    sourceType: overlay.source.sourceType,
+    sourceRecordId: overlay.source.sourceRecordId ?? null,
+    retired: isRetiredAreaOverlay(overlay),
+  };
 };
 
 export class ExternalOverlayService {
@@ -642,6 +679,107 @@ export class ExternalOverlayService {
       return {
         missionId,
         overlays,
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  async listAreaOverlayRefreshRuns(
+    missionId: string,
+    filters: { refreshRunId?: string } = {},
+  ): Promise<{ missionId: string; refreshRuns: AreaOverlayRefreshRunSummary[] }> {
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.externalOverlayRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new MissionExternalOverlayMissionNotFoundError(missionId);
+      }
+
+      const overlays = await this.externalOverlayRepository.listForMission(
+        client,
+        missionId,
+        { kind: "area_conflict", includeRetired: true },
+      );
+
+      const refreshRunMap = new Map<string, AreaOverlayRefreshRunSummary>();
+
+      const ensureSummary = (refreshRunId: string): AreaOverlayRefreshRunSummary => {
+        const existingSummary = refreshRunMap.get(refreshRunId);
+        if (existingSummary) {
+          return existingSummary;
+        }
+
+        const createdSummary: AreaOverlayRefreshRunSummary = {
+          refreshRunId,
+          missionId,
+          created: [],
+          updated: [],
+          superseded: [],
+          retired: [],
+          active: [],
+        };
+        refreshRunMap.set(refreshRunId, createdSummary);
+        return createdSummary;
+      };
+
+      for (const overlay of overlays) {
+        if (!isNormalizedAreaOverlay(overlay)) {
+          continue;
+        }
+
+        const provenance = areaMetadataFromOverlay(overlay).refreshProvenance;
+        if (!provenance) {
+          continue;
+        }
+
+        const summaryItem = areaOverlayRefreshSummaryItemFromOverlay(overlay);
+        ensureSummary(provenance.createdByRunId).created.push(summaryItem);
+        ensureSummary(provenance.lastUpdatedByRunId).updated.push(summaryItem);
+
+        if (provenance.supersededByRunId) {
+          ensureSummary(provenance.supersededByRunId).superseded.push(summaryItem);
+        }
+
+        if (provenance.retiredByRunId) {
+          ensureSummary(provenance.retiredByRunId).retired.push(summaryItem);
+        }
+
+        if (!summaryItem.retired) {
+          ensureSummary(provenance.lastUpdatedByRunId).active.push(summaryItem);
+        }
+      }
+
+      const refreshRuns = [...refreshRunMap.values()].sort((left, right) =>
+        right.refreshRunId.localeCompare(left.refreshRunId),
+      );
+
+      if (filters.refreshRunId) {
+        const matchingRun = refreshRuns.find(
+          (refreshRun) => refreshRun.refreshRunId === filters.refreshRunId,
+        );
+
+        if (!matchingRun) {
+          throw new MissionExternalOverlayRefreshRunNotFoundError(
+            missionId,
+            filters.refreshRunId,
+          );
+        }
+
+        return {
+          missionId,
+          refreshRuns: [matchingRun],
+        };
+      }
+
+      return {
+        missionId,
+        refreshRuns,
       };
     } finally {
       client.release();

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -996,6 +996,164 @@ describe("mission external overlays integration", () => {
     });
   });
 
+  it("returns refresh-run summaries and supports filtering a single authoritative snapshot", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-1200",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-1200",
+              label: "Danger Area EGD-1200",
+              areaType: "danger_area",
+              description: "First snapshot",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    const firstRunId = firstRun.body.refreshRunId as string;
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1200/26",
+            },
+            observedAt: "2026-04-21T10:08:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1200-26",
+              label: "Danger Area EGD-1200 NOTAM",
+              areaType: "notam_restriction",
+              description: "Higher priority snapshot",
+              authorityName: "NATS",
+              notamNumber: "B1200/26",
+              sourceReference: "NOTAM B1200/26",
+            },
+          },
+        ],
+      });
+
+    expect(secondRun.status).toBe(201);
+    const secondRunId = secondRun.body.refreshRunId as string;
+
+    const summaryResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs`,
+    );
+
+    expect(summaryResponse.status).toBe(200);
+    expect(summaryResponse.body.missionId).toBe(missionId);
+    expect(summaryResponse.body.refreshRuns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          refreshRunId: firstRunId,
+          missionId,
+          created: [
+            expect.objectContaining({
+              areaId: "NOTAM-B1200-26",
+              sourceType: "notam_restriction",
+              retired: false,
+            }),
+          ],
+          updated: [],
+          superseded: [],
+          retired: [],
+          active: [],
+        }),
+        expect.objectContaining({
+          refreshRunId: secondRunId,
+          missionId,
+          created: [],
+          updated: [
+            expect.objectContaining({
+              areaId: "NOTAM-B1200-26",
+              sourceType: "notam_restriction",
+              retired: false,
+            }),
+          ],
+          superseded: [
+            expect.objectContaining({
+              areaId: "NOTAM-B1200-26",
+              sourceType: "notam_restriction",
+              retired: false,
+            }),
+          ],
+          retired: [],
+          active: [
+            expect.objectContaining({
+              areaId: "NOTAM-B1200-26",
+              sourceType: "notam_restriction",
+              retired: false,
+            }),
+          ],
+        }),
+      ]),
+    );
+
+    const filteredSummaryResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?refreshRunId=${firstRunId}`,
+    );
+
+    expect(filteredSummaryResponse.status).toBe(200);
+    expect(filteredSummaryResponse.body).toMatchObject({
+      missionId,
+      refreshRuns: [
+        expect.objectContaining({
+          refreshRunId: firstRunId,
+        }),
+      ],
+    });
+    expect(filteredSummaryResponse.body.refreshRuns).toHaveLength(1);
+
+    const missingRunResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?refreshRunId=${randomUUID()}`,
+    );
+
+    expect(missingRunResponse.status).toBe(404);
+    expect(missingRunResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_not_found",
+      },
+    });
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #192 by adding refresh-run detail filtering support to normalized area overlay summary queries so a single authoritative snapshot can be reviewed directly.

## What changed

- Extended the normalized area overlay refresh-run summary read path with direct filtering support for a single refresh run:
  - `GET /missions/:missionId/external-overlays/refresh-runs`
  - optional query parameter: `refreshRunId`
- Kept the implementation inside the normalized area overlay ingestion / auditability boundary.
- Added service-side refresh-run summary aggregation over normalized `area_conflict` overlay provenance metadata.
- Refresh-run summaries now expose, per run:
  - overlays created by that run
  - overlays updated by that run
  - overlays superseded by that run
  - overlays retired by that run
  - overlays left active after that run
- Added direct run-id filtering so one authoritative snapshot can be reviewed without client-side filtering.
- Added clear 404 handling for invalid or missing refresh run ids:
  - `refresh_run_not_found`
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling
  - source traceability
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
- Kept conflict assessment source-agnostic and unchanged.
- Updated the save point to the next read-path refinement step.

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 14 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 345 tests.

## Notes

This issue is an ingestion-layer auditability read-path refinement only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #192.
