### PR TITLE
Add area overlay refresh-run diff query

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add refresh-run detail filtering support to normalized area overlay summary queries so a single authoritative snapshot can be reviewed directly.",
+  "nextBuildStep": "Add refresh-run chronology query support to normalized area overlay summaries so authoritative snapshot changes can be reviewed in chronological order.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -8,6 +8,8 @@ type MissionIdParams = {
 
 type RefreshRunQuery = {
   refreshRunId?: string;
+  fromRefreshRunId?: string;
+  toRefreshRunId?: string;
 };
 
 export class ExternalOverlayController {
@@ -106,6 +108,30 @@ export class ExternalOverlayController {
         req.query.refreshRunId.trim().length > 0
           ? req.query.refreshRunId.trim()
           : undefined;
+      const fromRefreshRunId =
+        typeof req.query.fromRefreshRunId === "string" &&
+        req.query.fromRefreshRunId.trim().length > 0
+          ? req.query.fromRefreshRunId.trim()
+          : undefined;
+      const toRefreshRunId =
+        typeof req.query.toRefreshRunId === "string" &&
+        req.query.toRefreshRunId.trim().length > 0
+          ? req.query.toRefreshRunId.trim()
+          : undefined;
+
+      if (fromRefreshRunId || toRefreshRunId) {
+        const result =
+          await this.externalOverlayService.diffAreaOverlayRefreshRuns(
+            req.params.missionId,
+            {
+              fromRefreshRunId,
+              toRefreshRunId,
+            },
+          );
+
+        res.status(200).json(result);
+        return;
+      }
 
       const result =
         await this.externalOverlayService.listAreaOverlayRefreshRuns(

--- a/src/external-overlays/external-overlay.errors.ts
+++ b/src/external-overlays/external-overlay.errors.ts
@@ -15,3 +15,12 @@ export class MissionExternalOverlayRefreshRunNotFoundError extends Error {
     super(`Refresh run ${refreshRunId} not found for mission ${missionId}`);
   }
 }
+
+export class MissionExternalOverlayRefreshRunDiffQueryInvalidError extends Error {
+  readonly statusCode = 400;
+  readonly type = "refresh_run_diff_query_invalid";
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -3,6 +3,7 @@ import type { Pool } from "pg";
 import { ExternalOverlayRepository } from "./external-overlay.repository";
 import {
   MissionExternalOverlayMissionNotFoundError,
+  MissionExternalOverlayRefreshRunDiffQueryInvalidError,
   MissionExternalOverlayRefreshRunNotFoundError,
 } from "./external-overlay.errors";
 import type {
@@ -266,6 +267,20 @@ type AreaOverlayRefreshRunSummary = {
   active: AreaOverlayRefreshRunSummaryItem[];
 };
 
+type AreaOverlayRefreshRunDiff = {
+  missionId: string;
+  fromRefreshRunId: string;
+  toRefreshRunId: string;
+  added: AreaOverlayRefreshRunSummaryItem[];
+  removed: AreaOverlayRefreshRunSummaryItem[];
+  persisted: AreaOverlayRefreshRunSummaryItem[];
+  changed: {
+    updated: AreaOverlayRefreshRunSummaryItem[];
+    superseded: AreaOverlayRefreshRunSummaryItem[];
+    retired: AreaOverlayRefreshRunSummaryItem[];
+  };
+};
+
 const areaOverlayRefreshSummaryItemFromOverlay = (
   overlay: ExternalOverlay,
 ): AreaOverlayRefreshRunSummaryItem => {
@@ -279,6 +294,198 @@ const areaOverlayRefreshSummaryItemFromOverlay = (
     sourceRecordId: overlay.source.sourceRecordId ?? null,
     retired: isRetiredAreaOverlay(overlay),
   };
+};
+
+const buildAreaOverlayRefreshRunSummaries = (
+  missionId: string,
+  overlays: ExternalOverlay[],
+): AreaOverlayRefreshRunSummary[] => {
+  const refreshRunMap = new Map<string, AreaOverlayRefreshRunSummary>();
+
+  const ensureSummary = (refreshRunId: string): AreaOverlayRefreshRunSummary => {
+    const existingSummary = refreshRunMap.get(refreshRunId);
+    if (existingSummary) {
+      return existingSummary;
+    }
+
+    const createdSummary: AreaOverlayRefreshRunSummary = {
+      refreshRunId,
+      missionId,
+      created: [],
+      updated: [],
+      superseded: [],
+      retired: [],
+      active: [],
+    };
+    refreshRunMap.set(refreshRunId, createdSummary);
+    return createdSummary;
+  };
+
+  for (const overlay of overlays) {
+    if (!isNormalizedAreaOverlay(overlay)) {
+      continue;
+    }
+
+    const provenance = areaMetadataFromOverlay(overlay).refreshProvenance;
+    if (!provenance) {
+      continue;
+    }
+
+    const summaryItem = areaOverlayRefreshSummaryItemFromOverlay(overlay);
+    ensureSummary(provenance.createdByRunId).created.push(summaryItem);
+    ensureSummary(provenance.lastUpdatedByRunId).updated.push(summaryItem);
+
+    if (provenance.supersededByRunId) {
+      ensureSummary(provenance.supersededByRunId).superseded.push(summaryItem);
+    }
+
+    if (provenance.retiredByRunId) {
+      ensureSummary(provenance.retiredByRunId).retired.push(summaryItem);
+    }
+
+    if (!summaryItem.retired) {
+      ensureSummary(provenance.lastUpdatedByRunId).active.push(summaryItem);
+    }
+  }
+
+  return [...refreshRunMap.values()].sort((left, right) =>
+    right.refreshRunId.localeCompare(left.refreshRunId),
+  );
+};
+
+const buildRefreshRunOrder = (overlays: ExternalOverlay[]): Map<string, number> => {
+  const nodes = new Set<string>();
+  const outgoing = new Map<string, Set<string>>();
+  const indegree = new Map<string, number>();
+
+  const ensureNode = (runId: string): void => {
+    nodes.add(runId);
+    if (!outgoing.has(runId)) {
+      outgoing.set(runId, new Set());
+    }
+    if (!indegree.has(runId)) {
+      indegree.set(runId, 0);
+    }
+  };
+
+  const addEdge = (fromRunId: string, toRunId: string): void => {
+    if (fromRunId === toRunId) {
+      ensureNode(fromRunId);
+      return;
+    }
+
+    ensureNode(fromRunId);
+    ensureNode(toRunId);
+
+    const edges = outgoing.get(fromRunId);
+    if (!edges || edges.has(toRunId)) {
+      return;
+    }
+
+    edges.add(toRunId);
+    indegree.set(toRunId, (indegree.get(toRunId) ?? 0) + 1);
+  };
+
+  for (const overlay of overlays) {
+    if (!isNormalizedAreaOverlay(overlay)) {
+      continue;
+    }
+
+    const provenance = areaMetadataFromOverlay(overlay).refreshProvenance;
+    if (!provenance) {
+      continue;
+    }
+
+    ensureNode(provenance.createdByRunId);
+    ensureNode(provenance.lastUpdatedByRunId);
+
+    addEdge(provenance.createdByRunId, provenance.lastUpdatedByRunId);
+
+    if (provenance.supersededByRunId) {
+      ensureNode(provenance.supersededByRunId);
+      addEdge(provenance.createdByRunId, provenance.supersededByRunId);
+      addEdge(provenance.supersededByRunId, provenance.lastUpdatedByRunId);
+    }
+
+    if (provenance.retiredByRunId) {
+      ensureNode(provenance.retiredByRunId);
+      addEdge(provenance.createdByRunId, provenance.retiredByRunId);
+      addEdge(provenance.lastUpdatedByRunId, provenance.retiredByRunId);
+      if (provenance.supersededByRunId) {
+        addEdge(provenance.supersededByRunId, provenance.retiredByRunId);
+      }
+    }
+  }
+
+  const queue = [...nodes]
+    .filter((runId) => (indegree.get(runId) ?? 0) === 0)
+    .sort((left, right) => left.localeCompare(right));
+  const orderedRunIds: string[] = [];
+
+  while (queue.length > 0) {
+    const nextRunId = queue.shift();
+    if (!nextRunId) {
+      break;
+    }
+
+    orderedRunIds.push(nextRunId);
+
+    for (const adjacentRunId of outgoing.get(nextRunId) ?? []) {
+      const nextIndegree = (indegree.get(adjacentRunId) ?? 0) - 1;
+      indegree.set(adjacentRunId, nextIndegree);
+      if (nextIndegree === 0) {
+        queue.push(adjacentRunId);
+        queue.sort((left, right) => left.localeCompare(right));
+      }
+    }
+  }
+
+  const unresolvedRunIds = [...nodes]
+    .filter((runId) => !orderedRunIds.includes(runId))
+    .sort((left, right) => left.localeCompare(right));
+  orderedRunIds.push(...unresolvedRunIds);
+
+  return new Map(orderedRunIds.map((runId, index) => [runId, index] as const));
+};
+
+const buildAreaOverlaySnapshotForRun = (
+  overlays: ExternalOverlay[],
+  refreshRunOrder: Map<string, number>,
+  refreshRunId: string,
+): AreaOverlayRefreshRunSummaryItem[] => {
+  const snapshotIndex = refreshRunOrder.get(refreshRunId);
+  if (snapshotIndex === undefined) {
+    return [];
+  }
+
+  return overlays
+    .filter((overlay) => isNormalizedAreaOverlay(overlay))
+    .map((overlay) => ({
+      overlay,
+      provenance: areaMetadataFromOverlay(overlay).refreshProvenance,
+    }))
+    .filter(
+      (
+        candidate,
+      ): candidate is {
+        overlay: ExternalOverlay;
+        provenance: NonNullable<AreaConflictOverlayMetadata["refreshProvenance"]>;
+      } => candidate.provenance !== null,
+    )
+    .filter(({ provenance }) => {
+      const createdIndex = refreshRunOrder.get(provenance.createdByRunId);
+      if (createdIndex === undefined || createdIndex > snapshotIndex) {
+        return false;
+      }
+
+      if (!provenance.retiredByRunId) {
+        return true;
+      }
+
+      const retiredIndex = refreshRunOrder.get(provenance.retiredByRunId);
+      return retiredIndex === undefined || retiredIndex > snapshotIndex;
+    })
+    .map(({ overlay }) => areaOverlayRefreshSummaryItemFromOverlay(overlay));
 };
 
 export class ExternalOverlayService {
@@ -706,58 +913,7 @@ export class ExternalOverlayService {
         missionId,
         { kind: "area_conflict", includeRetired: true },
       );
-
-      const refreshRunMap = new Map<string, AreaOverlayRefreshRunSummary>();
-
-      const ensureSummary = (refreshRunId: string): AreaOverlayRefreshRunSummary => {
-        const existingSummary = refreshRunMap.get(refreshRunId);
-        if (existingSummary) {
-          return existingSummary;
-        }
-
-        const createdSummary: AreaOverlayRefreshRunSummary = {
-          refreshRunId,
-          missionId,
-          created: [],
-          updated: [],
-          superseded: [],
-          retired: [],
-          active: [],
-        };
-        refreshRunMap.set(refreshRunId, createdSummary);
-        return createdSummary;
-      };
-
-      for (const overlay of overlays) {
-        if (!isNormalizedAreaOverlay(overlay)) {
-          continue;
-        }
-
-        const provenance = areaMetadataFromOverlay(overlay).refreshProvenance;
-        if (!provenance) {
-          continue;
-        }
-
-        const summaryItem = areaOverlayRefreshSummaryItemFromOverlay(overlay);
-        ensureSummary(provenance.createdByRunId).created.push(summaryItem);
-        ensureSummary(provenance.lastUpdatedByRunId).updated.push(summaryItem);
-
-        if (provenance.supersededByRunId) {
-          ensureSummary(provenance.supersededByRunId).superseded.push(summaryItem);
-        }
-
-        if (provenance.retiredByRunId) {
-          ensureSummary(provenance.retiredByRunId).retired.push(summaryItem);
-        }
-
-        if (!summaryItem.retired) {
-          ensureSummary(provenance.lastUpdatedByRunId).active.push(summaryItem);
-        }
-      }
-
-      const refreshRuns = [...refreshRunMap.values()].sort((left, right) =>
-        right.refreshRunId.localeCompare(left.refreshRunId),
-      );
+      const refreshRuns = buildAreaOverlayRefreshRunSummaries(missionId, overlays);
 
       if (filters.refreshRunId) {
         const matchingRun = refreshRuns.find(
@@ -780,6 +936,112 @@ export class ExternalOverlayService {
       return {
         missionId,
         refreshRuns,
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  async diffAreaOverlayRefreshRuns(
+    missionId: string,
+    filters: {
+      fromRefreshRunId?: string;
+      toRefreshRunId?: string;
+    },
+  ): Promise<{ missionId: string; diff: AreaOverlayRefreshRunDiff }> {
+    if (!filters.fromRefreshRunId || !filters.toRefreshRunId) {
+      throw new MissionExternalOverlayRefreshRunDiffQueryInvalidError(
+        "Both fromRefreshRunId and toRefreshRunId are required for refresh-run diff queries",
+      );
+    }
+
+    if (filters.fromRefreshRunId === filters.toRefreshRunId) {
+      throw new MissionExternalOverlayRefreshRunDiffQueryInvalidError(
+        "fromRefreshRunId and toRefreshRunId must be different",
+      );
+    }
+
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.externalOverlayRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new MissionExternalOverlayMissionNotFoundError(missionId);
+      }
+
+      const overlays = await this.externalOverlayRepository.listForMission(
+        client,
+        missionId,
+        { kind: "area_conflict", includeRetired: true },
+      );
+      const refreshRuns = buildAreaOverlayRefreshRunSummaries(missionId, overlays);
+      const refreshRunOrder = buildRefreshRunOrder(overlays);
+
+      const fromRun = refreshRuns.find(
+        (refreshRun) => refreshRun.refreshRunId === filters.fromRefreshRunId,
+      );
+      if (!fromRun) {
+        throw new MissionExternalOverlayRefreshRunNotFoundError(
+          missionId,
+          filters.fromRefreshRunId,
+        );
+      }
+
+      const toRun = refreshRuns.find(
+        (refreshRun) => refreshRun.refreshRunId === filters.toRefreshRunId,
+      );
+      if (!toRun) {
+        throw new MissionExternalOverlayRefreshRunNotFoundError(
+          missionId,
+          filters.toRefreshRunId,
+        );
+      }
+
+      const fromSnapshot = buildAreaOverlaySnapshotForRun(
+        overlays,
+        refreshRunOrder,
+        filters.fromRefreshRunId,
+      );
+      const toSnapshot = buildAreaOverlaySnapshotForRun(
+        overlays,
+        refreshRunOrder,
+        filters.toRefreshRunId,
+      );
+
+      const fromActiveById = new Map(
+        fromSnapshot.map((item) => [item.overlayId, item] as const),
+      );
+      const toActiveById = new Map(
+        toSnapshot.map((item) => [item.overlayId, item] as const),
+      );
+
+      const added = toSnapshot.filter((item) => !fromActiveById.has(item.overlayId));
+      const removed = fromSnapshot.filter((item) => !toActiveById.has(item.overlayId));
+      const persisted = toSnapshot.filter((item) => fromActiveById.has(item.overlayId));
+      const persistedIds = new Set(persisted.map((item) => item.overlayId));
+      const removedIds = new Set(removed.map((item) => item.overlayId));
+
+      return {
+        missionId,
+        diff: {
+          missionId,
+          fromRefreshRunId: filters.fromRefreshRunId,
+          toRefreshRunId: filters.toRefreshRunId,
+          added,
+          removed,
+          persisted,
+          changed: {
+            updated: toRun.updated.filter((item) => persistedIds.has(item.overlayId)),
+            superseded: toRun.superseded.filter((item) =>
+              persistedIds.has(item.overlayId),
+            ),
+            retired: toRun.retired.filter((item) => removedIds.has(item.overlayId)),
+          },
+        },
       };
     } finally {
       client.release();

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -1154,6 +1154,268 @@ describe("mission external overlays integration", () => {
     });
   });
 
+  it("returns refresh-run diffs between two authoritative snapshots", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-1300",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-1300",
+              label: "Danger Area EGD-1300",
+              areaType: "danger_area",
+              description: "Base area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-1301",
+            },
+            observedAt: "2026-04-21T10:08:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5091,
+              centerLng: -0.1261,
+              radiusMeters: 280,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            severity: "critical",
+            area: {
+              areaId: "TDA-1301",
+              label: "Temporary Danger Area 1301",
+              areaType: "temporary_danger_area",
+              description: "Will be retired later",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1300/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1300-26",
+              label: "Danger Area EGD-1300 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B1300/26",
+              sourceReference: "NOTAM B1300/26",
+            },
+          },
+        ],
+      });
+
+    expect(secondRun.status).toBe(201);
+
+    const diffSecondResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?fromRefreshRunId=${firstRun.body.refreshRunId}&toRefreshRunId=${secondRun.body.refreshRunId}`,
+    );
+
+    expect(diffSecondResponse.status).toBe(200);
+    expect(diffSecondResponse.body).toMatchObject({
+      missionId,
+      diff: {
+        missionId,
+        fromRefreshRunId: firstRun.body.refreshRunId,
+        toRefreshRunId: secondRun.body.refreshRunId,
+        added: [],
+        removed: [
+          expect.objectContaining({
+            areaId: "TDA-1301",
+            retired: true,
+          }),
+        ],
+        persisted: [
+          expect.objectContaining({
+            areaId: "NOTAM-B1300-26",
+            sourceType: "notam_restriction",
+          }),
+        ],
+        changed: {
+          updated: [
+            expect.objectContaining({
+              areaId: "NOTAM-B1300-26",
+            }),
+          ],
+          superseded: [
+            expect.objectContaining({
+              areaId: "NOTAM-B1300-26",
+            }),
+          ],
+          retired: [
+            expect.objectContaining({
+              areaId: "TDA-1301",
+              retired: true,
+            }),
+          ],
+        },
+      },
+    });
+
+    const thirdRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1300/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1300-26",
+              label: "Danger Area EGD-1300 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B1300/26",
+              sourceReference: "NOTAM B1300/26",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-1302",
+            },
+            observedAt: "2026-04-21T10:10:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5102,
+              centerLng: -0.1251,
+              radiusMeters: 250,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1100,
+            },
+            severity: "caution",
+            area: {
+              areaId: "TDA-1302",
+              label: "Temporary Danger Area 1302",
+              areaType: "temporary_danger_area",
+              description: "New area in later run",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    expect(thirdRun.status).toBe(201);
+
+    const diffThirdResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?fromRefreshRunId=${secondRun.body.refreshRunId}&toRefreshRunId=${thirdRun.body.refreshRunId}`,
+    );
+
+    expect(diffThirdResponse.status).toBe(200);
+    expect(diffThirdResponse.body).toMatchObject({
+      missionId,
+      diff: {
+        missionId,
+        fromRefreshRunId: secondRun.body.refreshRunId,
+        toRefreshRunId: thirdRun.body.refreshRunId,
+        added: [
+          expect.objectContaining({
+            areaId: "TDA-1302",
+            sourceType: "temporary_danger_area",
+          }),
+        ],
+        removed: [],
+        persisted: [
+          expect.objectContaining({
+            areaId: "NOTAM-B1300-26",
+            sourceType: "notam_restriction",
+          }),
+        ],
+      },
+    });
+
+    const missingParamResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?fromRefreshRunId=${firstRun.body.refreshRunId}`,
+    );
+
+    expect(missingParamResponse.status).toBe(400);
+    expect(missingParamResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_diff_query_invalid",
+      },
+    });
+
+    const sameRunResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?fromRefreshRunId=${firstRun.body.refreshRunId}&toRefreshRunId=${firstRun.body.refreshRunId}`,
+    );
+
+    expect(sameRunResponse.status).toBe(400);
+    expect(sameRunResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_diff_query_invalid",
+      },
+    });
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #194 by adding refresh-run diff query support to normalized area overlay summary queries so changes between two authoritative snapshots can be reviewed directly.

## What changed

- Extended the mission-linked refresh-run summary read path with diff query support:
  - `GET /missions/:missionId/external-overlays/refresh-runs`
  - diff query parameters:
    - `fromRefreshRunId`
    - `toRefreshRunId`
- Kept the implementation inside the normalized area overlay ingestion / auditability boundary.
- Added explicit validation for refresh-run diff requests:
  - both `fromRefreshRunId` and `toRefreshRunId` are required for diff mode
  - the two run ids must be different
  - invalid diff requests return `refresh_run_diff_query_invalid`
- Reused the existing normalized area overlay provenance model and refresh-run summaries instead of introducing a new persistence model.
- Added provenance-based refresh-run chronology reconstruction so snapshot activity can be compared directly between two runs.
- Added direct diff output for:
  - `added`
  - `removed`
  - `persisted`
  - `changed.updated`
  - `changed.superseded`
  - `changed.retired`
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling
  - source traceability
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
  - single-run filtering with `refreshRunId`
- Kept conflict assessment source-agnostic and unchanged.
- Updated the save point to the next read-path refinement step:
  - refresh-run chronology query support for ordered snapshot review

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 15 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 346 tests.

## Notes

This issue is an ingestion-layer auditability read-path refinement only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #194.
