### PR TITLE
Add area overlay refresh-run chronology

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add refresh-run chronology query support to normalized area overlay summaries so authoritative snapshot changes can be reviewed in chronological order.",
+  "nextBuildStep": "Add refresh-run transition drilldown support to normalized area overlay chronology queries so individual snapshot transitions can be reviewed directly.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -10,6 +10,7 @@ type RefreshRunQuery = {
   refreshRunId?: string;
   fromRefreshRunId?: string;
   toRefreshRunId?: string;
+  chronology?: string;
 };
 
 export class ExternalOverlayController {
@@ -118,6 +119,24 @@ export class ExternalOverlayController {
         req.query.toRefreshRunId.trim().length > 0
           ? req.query.toRefreshRunId.trim()
           : undefined;
+      const chronology =
+        typeof req.query.chronology === "string" &&
+        ["1", "true", "yes"].includes(req.query.chronology.trim().toLowerCase());
+
+      if (chronology) {
+        const result =
+          await this.externalOverlayService.listAreaOverlayRefreshRunChronology(
+            req.params.missionId,
+            {
+              refreshRunId,
+              fromRefreshRunId,
+              toRefreshRunId,
+            },
+          );
+
+        res.status(200).json(result);
+        return;
+      }
 
       if (fromRefreshRunId || toRefreshRunId) {
         const result =

--- a/src/external-overlays/external-overlay.errors.ts
+++ b/src/external-overlays/external-overlay.errors.ts
@@ -24,3 +24,12 @@ export class MissionExternalOverlayRefreshRunDiffQueryInvalidError extends Error
     super(message);
   }
 }
+
+export class MissionExternalOverlayRefreshRunChronologyQueryInvalidError extends Error {
+  readonly statusCode = 400;
+  readonly type = "refresh_run_chronology_query_invalid";
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import type { Pool } from "pg";
 import { ExternalOverlayRepository } from "./external-overlay.repository";
 import {
+  MissionExternalOverlayRefreshRunChronologyQueryInvalidError,
   MissionExternalOverlayMissionNotFoundError,
   MissionExternalOverlayRefreshRunDiffQueryInvalidError,
   MissionExternalOverlayRefreshRunNotFoundError,
@@ -281,6 +282,12 @@ type AreaOverlayRefreshRunDiff = {
   };
 };
 
+type AreaOverlayRefreshRunChronology = {
+  missionId: string;
+  refreshRuns: AreaOverlayRefreshRunSummary[];
+  transitions: AreaOverlayRefreshRunDiff[];
+};
+
 const areaOverlayRefreshSummaryItemFromOverlay = (
   overlay: ExternalOverlay,
 ): AreaOverlayRefreshRunSummaryItem => {
@@ -486,6 +493,73 @@ const buildAreaOverlaySnapshotForRun = (
       return retiredIndex === undefined || retiredIndex > snapshotIndex;
     })
     .map(({ overlay }) => areaOverlayRefreshSummaryItemFromOverlay(overlay));
+};
+
+const buildAreaOverlayRefreshRunDiff = (
+  missionId: string,
+  overlays: ExternalOverlay[],
+  refreshRuns: AreaOverlayRefreshRunSummary[],
+  refreshRunOrder: Map<string, number>,
+  fromRefreshRunId: string,
+  toRefreshRunId: string,
+): AreaOverlayRefreshRunDiff => {
+  const fromRun = refreshRuns.find(
+    (refreshRun) => refreshRun.refreshRunId === fromRefreshRunId,
+  );
+  if (!fromRun) {
+    throw new MissionExternalOverlayRefreshRunNotFoundError(
+      missionId,
+      fromRefreshRunId,
+    );
+  }
+
+  const toRun = refreshRuns.find(
+    (refreshRun) => refreshRun.refreshRunId === toRefreshRunId,
+  );
+  if (!toRun) {
+    throw new MissionExternalOverlayRefreshRunNotFoundError(
+      missionId,
+      toRefreshRunId,
+    );
+  }
+
+  const fromSnapshot = buildAreaOverlaySnapshotForRun(
+    overlays,
+    refreshRunOrder,
+    fromRefreshRunId,
+  );
+  const toSnapshot = buildAreaOverlaySnapshotForRun(
+    overlays,
+    refreshRunOrder,
+    toRefreshRunId,
+  );
+
+  const fromActiveById = new Map(
+    fromSnapshot.map((item) => [item.overlayId, item] as const),
+  );
+  const toActiveById = new Map(
+    toSnapshot.map((item) => [item.overlayId, item] as const),
+  );
+
+  const added = toSnapshot.filter((item) => !fromActiveById.has(item.overlayId));
+  const removed = fromSnapshot.filter((item) => !toActiveById.has(item.overlayId));
+  const persisted = toSnapshot.filter((item) => fromActiveById.has(item.overlayId));
+  const persistedIds = new Set(persisted.map((item) => item.overlayId));
+  const removedIds = new Set(removed.map((item) => item.overlayId));
+
+  return {
+    missionId,
+    fromRefreshRunId,
+    toRefreshRunId,
+    added,
+    removed,
+    persisted,
+    changed: {
+      updated: toRun.updated.filter((item) => persistedIds.has(item.overlayId)),
+      superseded: toRun.superseded.filter((item) => persistedIds.has(item.overlayId)),
+      retired: toRun.retired.filter((item) => removedIds.has(item.overlayId)),
+    },
+  };
 };
 
 export class ExternalOverlayService {
@@ -981,66 +1055,81 @@ export class ExternalOverlayService {
       const refreshRuns = buildAreaOverlayRefreshRunSummaries(missionId, overlays);
       const refreshRunOrder = buildRefreshRunOrder(overlays);
 
-      const fromRun = refreshRuns.find(
-        (refreshRun) => refreshRun.refreshRunId === filters.fromRefreshRunId,
-      );
-      if (!fromRun) {
-        throw new MissionExternalOverlayRefreshRunNotFoundError(
+      return {
+        missionId,
+        diff: buildAreaOverlayRefreshRunDiff(
           missionId,
+          overlays,
+          refreshRuns,
+          refreshRunOrder,
           filters.fromRefreshRunId,
-        );
-      }
-
-      const toRun = refreshRuns.find(
-        (refreshRun) => refreshRun.refreshRunId === filters.toRefreshRunId,
-      );
-      if (!toRun) {
-        throw new MissionExternalOverlayRefreshRunNotFoundError(
-          missionId,
           filters.toRefreshRunId,
-        );
+        ),
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  async listAreaOverlayRefreshRunChronology(
+    missionId: string,
+    filters: {
+      refreshRunId?: string;
+      fromRefreshRunId?: string;
+      toRefreshRunId?: string;
+    } = {},
+  ): Promise<{ missionId: string; chronology: AreaOverlayRefreshRunChronology }> {
+    if (filters.refreshRunId || filters.fromRefreshRunId || filters.toRefreshRunId) {
+      throw new MissionExternalOverlayRefreshRunChronologyQueryInvalidError(
+        "chronology queries cannot be combined with refreshRunId, fromRefreshRunId, or toRefreshRunId",
+      );
+    }
+
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.externalOverlayRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new MissionExternalOverlayMissionNotFoundError(missionId);
       }
 
-      const fromSnapshot = buildAreaOverlaySnapshotForRun(
-        overlays,
-        refreshRunOrder,
-        filters.fromRefreshRunId,
+      const overlays = await this.externalOverlayRepository.listForMission(
+        client,
+        missionId,
+        { kind: "area_conflict", includeRetired: true },
       );
-      const toSnapshot = buildAreaOverlaySnapshotForRun(
-        overlays,
-        refreshRunOrder,
-        filters.toRefreshRunId,
-      );
-
-      const fromActiveById = new Map(
-        fromSnapshot.map((item) => [item.overlayId, item] as const),
-      );
-      const toActiveById = new Map(
-        toSnapshot.map((item) => [item.overlayId, item] as const),
+      const refreshRuns = buildAreaOverlayRefreshRunSummaries(missionId, overlays);
+      const refreshRunOrder = buildRefreshRunOrder(overlays);
+      const orderedRefreshRuns = [...refreshRuns].sort(
+        (left, right) =>
+          (refreshRunOrder.get(left.refreshRunId) ?? Number.MAX_SAFE_INTEGER) -
+          (refreshRunOrder.get(right.refreshRunId) ?? Number.MAX_SAFE_INTEGER),
       );
 
-      const added = toSnapshot.filter((item) => !fromActiveById.has(item.overlayId));
-      const removed = fromSnapshot.filter((item) => !toActiveById.has(item.overlayId));
-      const persisted = toSnapshot.filter((item) => fromActiveById.has(item.overlayId));
-      const persistedIds = new Set(persisted.map((item) => item.overlayId));
-      const removedIds = new Set(removed.map((item) => item.overlayId));
+      const transitions: AreaOverlayRefreshRunDiff[] = [];
+      for (let index = 1; index < orderedRefreshRuns.length; index += 1) {
+        transitions.push(
+          buildAreaOverlayRefreshRunDiff(
+            missionId,
+            overlays,
+            refreshRuns,
+            refreshRunOrder,
+            orderedRefreshRuns[index - 1].refreshRunId,
+            orderedRefreshRuns[index].refreshRunId,
+          ),
+        );
+      }
 
       return {
         missionId,
-        diff: {
+        chronology: {
           missionId,
-          fromRefreshRunId: filters.fromRefreshRunId,
-          toRefreshRunId: filters.toRefreshRunId,
-          added,
-          removed,
-          persisted,
-          changed: {
-            updated: toRun.updated.filter((item) => persistedIds.has(item.overlayId)),
-            superseded: toRun.superseded.filter((item) =>
-              persistedIds.has(item.overlayId),
-            ),
-            retired: toRun.retired.filter((item) => removedIds.has(item.overlayId)),
-          },
+          refreshRuns: orderedRefreshRuns,
+          transitions,
         },
       };
     } finally {

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -1416,6 +1416,220 @@ describe("mission external overlays integration", () => {
     });
   });
 
+  it("returns refresh-run chronology in inferred chronological order with adjacent transitions", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-1400",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-1400",
+              label: "Danger Area EGD-1400",
+              areaType: "danger_area",
+              description: "Base area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-1401",
+            },
+            observedAt: "2026-04-21T10:08:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5091,
+              centerLng: -0.1261,
+              radiusMeters: 280,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            severity: "critical",
+            area: {
+              areaId: "TDA-1401",
+              label: "Temporary Danger Area 1401",
+              areaType: "temporary_danger_area",
+              description: "Will be retired later",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1400/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1400-26",
+              label: "Danger Area EGD-1400 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B1400/26",
+              sourceReference: "NOTAM B1400/26",
+            },
+          },
+        ],
+      });
+
+    const thirdRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1400/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1400-26",
+              label: "Danger Area EGD-1400 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B1400/26",
+              sourceReference: "NOTAM B1400/26",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-1402",
+            },
+            observedAt: "2026-04-21T10:10:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5102,
+              centerLng: -0.1251,
+              radiusMeters: 250,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1100,
+            },
+            severity: "caution",
+            area: {
+              areaId: "TDA-1402",
+              label: "Temporary Danger Area 1402",
+              areaType: "temporary_danger_area",
+              description: "New area in later run",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(secondRun.status).toBe(201);
+    expect(thirdRun.status).toBe(201);
+
+    const chronologyResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?chronology=true`,
+    );
+
+    expect(chronologyResponse.status).toBe(200);
+    expect(chronologyResponse.body).toMatchObject({
+      missionId,
+      chronology: {
+        missionId,
+        refreshRuns: [
+          expect.objectContaining({ refreshRunId: firstRun.body.refreshRunId }),
+          expect.objectContaining({ refreshRunId: secondRun.body.refreshRunId }),
+          expect.objectContaining({ refreshRunId: thirdRun.body.refreshRunId }),
+        ],
+        transitions: [
+          expect.objectContaining({
+            fromRefreshRunId: firstRun.body.refreshRunId,
+            toRefreshRunId: secondRun.body.refreshRunId,
+            persisted: [
+              expect.objectContaining({
+                areaId: "NOTAM-B1400-26",
+              }),
+            ],
+          }),
+          expect.objectContaining({
+            fromRefreshRunId: secondRun.body.refreshRunId,
+            toRefreshRunId: thirdRun.body.refreshRunId,
+            added: [
+              expect.objectContaining({
+                areaId: "TDA-1402",
+              }),
+            ],
+          }),
+        ],
+      },
+    });
+
+    const invalidChronologyResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?chronology=true&refreshRunId=${firstRun.body.refreshRunId}`,
+    );
+
+    expect(invalidChronologyResponse.status).toBe(400);
+    expect(invalidChronologyResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_chronology_query_invalid",
+      },
+    });
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #196 by adding refresh-run chronology query support to normalized area overlay summaries so authoritative snapshot changes can be reviewed in chronological order.

## What changed

- Extended the mission-linked refresh-run summary read path with chronology query support:
  - `GET /missions/:missionId/external-overlays/refresh-runs`
  - chronology query parameter:
    - `chronology=true`
- Kept the implementation inside the normalized area overlay ingestion / auditability boundary.
- Added chronology mode so refresh runs can be reviewed in inferred chronological order rather than only by single-run lookup or pairwise diff.
- Chronology responses now return:
  - ordered `refreshRuns`
  - ordered adjacent `transitions`
- Reused the existing provenance, summary, and diff model rather than introducing a separate chronology persistence model.
- Refactored shared refresh-run diff computation so:
  - direct diff queries
  - chronology transitions
  stay consistent
- Added explicit validation for chronology mode:
  - chronology queries cannot be combined with `refreshRunId`
  - chronology queries cannot be combined with `fromRefreshRunId`
  - chronology queries cannot be combined with `toRefreshRunId`
  - invalid chronology requests return `refresh_run_chronology_query_invalid`
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling
  - source traceability
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
  - single-run filtering
  - direct two-run diff queries
- Kept conflict assessment source-agnostic and unchanged.
- Updated the save point to the next read-path refinement step:
  - refresh-run transition drilldown support

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 16 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 347 tests.

## Notes

This issue is an ingestion-layer auditability read-path refinement only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #196.
