### PR TITLE
Add area overlay transition drilldown

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add refresh-run transition drilldown support to normalized area overlay chronology queries so individual snapshot transitions can be reviewed directly.",
+  "nextBuildStep": "Add refresh-run transition artifact query support to normalized area overlay chronology queries so transition-level review payloads can be retrieved directly.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -10,6 +10,8 @@ type RefreshRunQuery = {
   refreshRunId?: string;
   fromRefreshRunId?: string;
   toRefreshRunId?: string;
+  transitionFromRefreshRunId?: string;
+  transitionToRefreshRunId?: string;
   chronology?: string;
 };
 
@@ -119,9 +121,37 @@ export class ExternalOverlayController {
         req.query.toRefreshRunId.trim().length > 0
           ? req.query.toRefreshRunId.trim()
           : undefined;
+      const transitionFromRefreshRunId =
+        typeof req.query.transitionFromRefreshRunId === "string" &&
+        req.query.transitionFromRefreshRunId.trim().length > 0
+          ? req.query.transitionFromRefreshRunId.trim()
+          : undefined;
+      const transitionToRefreshRunId =
+        typeof req.query.transitionToRefreshRunId === "string" &&
+        req.query.transitionToRefreshRunId.trim().length > 0
+          ? req.query.transitionToRefreshRunId.trim()
+          : undefined;
       const chronology =
         typeof req.query.chronology === "string" &&
         ["1", "true", "yes"].includes(req.query.chronology.trim().toLowerCase());
+
+      if (transitionFromRefreshRunId || transitionToRefreshRunId) {
+        const result =
+          await this.externalOverlayService.getAreaOverlayRefreshRunTransition(
+            req.params.missionId,
+            {
+              refreshRunId,
+              fromRefreshRunId,
+              toRefreshRunId,
+              chronology,
+              transitionFromRefreshRunId,
+              transitionToRefreshRunId,
+            },
+          );
+
+        res.status(200).json(result);
+        return;
+      }
 
       if (chronology) {
         const result =

--- a/src/external-overlays/external-overlay.errors.ts
+++ b/src/external-overlays/external-overlay.errors.ts
@@ -33,3 +33,12 @@ export class MissionExternalOverlayRefreshRunChronologyQueryInvalidError extends
     super(message);
   }
 }
+
+export class MissionExternalOverlayRefreshRunTransitionDrilldownQueryInvalidError extends Error {
+  readonly statusCode = 400;
+  readonly type = "refresh_run_transition_drilldown_query_invalid";
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -6,6 +6,7 @@ import {
   MissionExternalOverlayMissionNotFoundError,
   MissionExternalOverlayRefreshRunDiffQueryInvalidError,
   MissionExternalOverlayRefreshRunNotFoundError,
+  MissionExternalOverlayRefreshRunTransitionDrilldownQueryInvalidError,
 } from "./external-overlay.errors";
 import type {
   AreaConflictOverlayMetadata,
@@ -286,6 +287,11 @@ type AreaOverlayRefreshRunChronology = {
   missionId: string;
   refreshRuns: AreaOverlayRefreshRunSummary[];
   transitions: AreaOverlayRefreshRunDiff[];
+};
+
+type AreaOverlayRefreshRunTransitionDrilldown = {
+  missionId: string;
+  transition: AreaOverlayRefreshRunDiff;
 };
 
 const areaOverlayRefreshSummaryItemFromOverlay = (
@@ -1064,6 +1070,81 @@ export class ExternalOverlayService {
           refreshRunOrder,
           filters.fromRefreshRunId,
           filters.toRefreshRunId,
+        ),
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  async getAreaOverlayRefreshRunTransition(
+    missionId: string,
+    filters: {
+      refreshRunId?: string;
+      fromRefreshRunId?: string;
+      toRefreshRunId?: string;
+      chronology?: boolean;
+      transitionFromRefreshRunId?: string;
+      transitionToRefreshRunId?: string;
+    },
+  ): Promise<AreaOverlayRefreshRunTransitionDrilldown> {
+    if (
+      !filters.transitionFromRefreshRunId ||
+      !filters.transitionToRefreshRunId
+    ) {
+      throw new MissionExternalOverlayRefreshRunTransitionDrilldownQueryInvalidError(
+        "Both transitionFromRefreshRunId and transitionToRefreshRunId are required for refresh-run transition drilldown queries",
+      );
+    }
+
+    if (
+      filters.transitionFromRefreshRunId === filters.transitionToRefreshRunId
+    ) {
+      throw new MissionExternalOverlayRefreshRunTransitionDrilldownQueryInvalidError(
+        "transitionFromRefreshRunId and transitionToRefreshRunId must be different",
+      );
+    }
+
+    if (
+      filters.refreshRunId ||
+      filters.fromRefreshRunId ||
+      filters.toRefreshRunId ||
+      filters.chronology
+    ) {
+      throw new MissionExternalOverlayRefreshRunTransitionDrilldownQueryInvalidError(
+        "transition drilldown queries cannot be combined with refreshRunId, fromRefreshRunId, toRefreshRunId, or chronology",
+      );
+    }
+
+    const client = await this.pool.connect();
+
+    try {
+      const exists = await this.externalOverlayRepository.missionExists(
+        client,
+        missionId,
+      );
+
+      if (!exists) {
+        throw new MissionExternalOverlayMissionNotFoundError(missionId);
+      }
+
+      const overlays = await this.externalOverlayRepository.listForMission(
+        client,
+        missionId,
+        { kind: "area_conflict", includeRetired: true },
+      );
+      const refreshRuns = buildAreaOverlayRefreshRunSummaries(missionId, overlays);
+      const refreshRunOrder = buildRefreshRunOrder(overlays);
+
+      return {
+        missionId,
+        transition: buildAreaOverlayRefreshRunDiff(
+          missionId,
+          overlays,
+          refreshRuns,
+          refreshRunOrder,
+          filters.transitionFromRefreshRunId,
+          filters.transitionToRefreshRunId,
         ),
       };
     } finally {

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -1630,6 +1630,218 @@ describe("mission external overlays integration", () => {
     });
   });
 
+  it("returns direct transition drilldown for one chronology transition", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-1500",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-1500",
+              label: "Danger Area EGD-1500",
+              areaType: "danger_area",
+              description: "Base area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-1501",
+            },
+            observedAt: "2026-04-21T10:08:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5091,
+              centerLng: -0.1261,
+              radiusMeters: 280,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            severity: "critical",
+            area: {
+              areaId: "TDA-1501",
+              label: "Temporary Danger Area 1501",
+              areaType: "temporary_danger_area",
+              description: "Will be retired later",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1500/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1500-26",
+              label: "Danger Area EGD-1500 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B1500/26",
+              sourceReference: "NOTAM B1500/26",
+            },
+          },
+        ],
+      });
+
+    const thirdRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1500/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1500-26",
+              label: "Danger Area EGD-1500 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B1500/26",
+              sourceReference: "NOTAM B1500/26",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-1502",
+            },
+            observedAt: "2026-04-21T10:10:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5102,
+              centerLng: -0.1251,
+              radiusMeters: 250,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1100,
+            },
+            severity: "caution",
+            area: {
+              areaId: "TDA-1502",
+              label: "Temporary Danger Area 1502",
+              areaType: "temporary_danger_area",
+              description: "New area in later run",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(secondRun.status).toBe(201);
+    expect(thirdRun.status).toBe(201);
+
+    const chronologyResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?chronology=true`,
+    );
+
+    expect(chronologyResponse.status).toBe(200);
+
+    const drilldownResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionFromRefreshRunId=${secondRun.body.refreshRunId}&transitionToRefreshRunId=${thirdRun.body.refreshRunId}`,
+    );
+
+    expect(drilldownResponse.status).toBe(200);
+    expect(drilldownResponse.body).toMatchObject({
+      missionId,
+      transition: {
+        missionId,
+        fromRefreshRunId: secondRun.body.refreshRunId,
+        toRefreshRunId: thirdRun.body.refreshRunId,
+        added: [
+          expect.objectContaining({
+            areaId: "TDA-1502",
+            sourceType: "temporary_danger_area",
+          }),
+        ],
+        persisted: [
+          expect.objectContaining({
+            areaId: "NOTAM-B1500-26",
+            sourceType: "notam_restriction",
+          }),
+        ],
+      },
+    });
+    expect(drilldownResponse.body.transition).toEqual(
+      chronologyResponse.body.chronology.transitions[1],
+    );
+
+    const invalidDrilldownResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionFromRefreshRunId=${secondRun.body.refreshRunId}&transitionToRefreshRunId=${thirdRun.body.refreshRunId}&chronology=true`,
+    );
+
+    expect(invalidDrilldownResponse.status).toBe(400);
+    expect(invalidDrilldownResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_transition_drilldown_query_invalid",
+      },
+    });
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #198 by adding refresh-run transition drilldown support to normalized area overlay chronology queries so individual snapshot transitions can be reviewed directly.

## What changed

- Extended the mission-linked refresh-run summary read path with direct transition drilldown support:
  - `GET /missions/:missionId/external-overlays/refresh-runs`
  - drilldown query parameters:
    - `transitionFromRefreshRunId`
    - `transitionToRefreshRunId`
- Kept the implementation inside the normalized area overlay ingestion / auditability boundary.
- Reused the existing provenance, summary, diff, and chronology model rather than introducing a separate transition store.
- Added direct transition drilldown output for one specific adjacent chronology transition, including:
  - earlier run id
  - later run id
  - `added`
  - `removed`
  - `persisted`
  - `changed.updated`
  - `changed.superseded`
  - `changed.retired`
- Added explicit validation for invalid drilldown queries:
  - both transition run ids are required
  - the two transition run ids must be different
  - drilldown mode cannot be combined with `refreshRunId`
  - drilldown mode cannot be combined with `fromRefreshRunId`
  - drilldown mode cannot be combined with `toRefreshRunId`
  - drilldown mode cannot be combined with `chronology`
  - invalid requests return `refresh_run_transition_drilldown_query_invalid`
- Verified that the direct drilldown response matches the corresponding adjacent transition in the chronology response.
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling
  - source traceability
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
  - single-run filtering
  - direct two-run diff queries
  - chronology ordering
- Kept conflict assessment source-agnostic and unchanged.
- Updated the save point to the next read-path refinement step:
  - refresh-run transition artifact query support

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 17 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 348 tests.

## Notes

This issue is an ingestion-layer auditability read-path refinement only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #198.
