### PR TITLE
Add area overlay transition artifact query

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add refresh-run transition artifact query support to normalized area overlay chronology queries so transition-level review payloads can be retrieved directly.",
+  "nextBuildStep": "Add refresh-run transition artifact filtering support to normalized area overlay chronology queries so specific transition review payloads can be selected directly.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -12,6 +12,7 @@ type RefreshRunQuery = {
   toRefreshRunId?: string;
   transitionFromRefreshRunId?: string;
   transitionToRefreshRunId?: string;
+  transitionArtifact?: string;
   chronology?: string;
 };
 
@@ -134,6 +135,29 @@ export class ExternalOverlayController {
       const chronology =
         typeof req.query.chronology === "string" &&
         ["1", "true", "yes"].includes(req.query.chronology.trim().toLowerCase());
+      const transitionArtifact =
+        typeof req.query.transitionArtifact === "string" &&
+        ["1", "true", "yes"].includes(
+          req.query.transitionArtifact.trim().toLowerCase(),
+        );
+
+      if (transitionArtifact) {
+        const result =
+          await this.externalOverlayService.getAreaOverlayRefreshRunTransitionArtifact(
+            req.params.missionId,
+            {
+              refreshRunId,
+              fromRefreshRunId,
+              toRefreshRunId,
+              chronology,
+              transitionFromRefreshRunId,
+              transitionToRefreshRunId,
+            },
+          );
+
+        res.status(200).json(result);
+        return;
+      }
 
       if (transitionFromRefreshRunId || transitionToRefreshRunId) {
         const result =

--- a/src/external-overlays/external-overlay.errors.ts
+++ b/src/external-overlays/external-overlay.errors.ts
@@ -42,3 +42,12 @@ export class MissionExternalOverlayRefreshRunTransitionDrilldownQueryInvalidErro
     super(message);
   }
 }
+
+export class MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError extends Error {
+  readonly statusCode = 400;
+  readonly type = "refresh_run_transition_artifact_query_invalid";
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -6,6 +6,7 @@ import {
   MissionExternalOverlayMissionNotFoundError,
   MissionExternalOverlayRefreshRunDiffQueryInvalidError,
   MissionExternalOverlayRefreshRunNotFoundError,
+  MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError,
   MissionExternalOverlayRefreshRunTransitionDrilldownQueryInvalidError,
 } from "./external-overlay.errors";
 import type {
@@ -293,6 +294,27 @@ type AreaOverlayRefreshRunTransitionDrilldown = {
   missionId: string;
   transition: AreaOverlayRefreshRunDiff;
 };
+
+type AreaOverlayRefreshRunTransitionArtifact = {
+  artifactId: string;
+  missionId: string;
+  artifactType: "refresh_run_transition";
+  fromRefreshRunId: string;
+  toRefreshRunId: string;
+  transition: AreaOverlayRefreshRunDiff;
+};
+
+const buildAreaOverlayRefreshRunTransitionArtifactId = (
+  missionId: string,
+  fromRefreshRunId: string,
+  toRefreshRunId: string,
+): string =>
+  [
+    "refresh_run_transition",
+    missionId,
+    fromRefreshRunId,
+    toRefreshRunId,
+  ].join(":");
 
 const areaOverlayRefreshSummaryItemFromOverlay = (
   overlay: ExternalOverlay,
@@ -1150,6 +1172,70 @@ export class ExternalOverlayService {
     } finally {
       client.release();
     }
+  }
+
+  async getAreaOverlayRefreshRunTransitionArtifact(
+    missionId: string,
+    filters: {
+      refreshRunId?: string;
+      fromRefreshRunId?: string;
+      toRefreshRunId?: string;
+      chronology?: boolean;
+      transitionFromRefreshRunId?: string;
+      transitionToRefreshRunId?: string;
+    },
+  ): Promise<{ missionId: string; artifact: AreaOverlayRefreshRunTransitionArtifact }> {
+    if (
+      !filters.transitionFromRefreshRunId ||
+      !filters.transitionToRefreshRunId
+    ) {
+      throw new MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError(
+        "Both transitionFromRefreshRunId and transitionToRefreshRunId are required for refresh-run transition artifact queries",
+      );
+    }
+
+    if (
+      filters.transitionFromRefreshRunId === filters.transitionToRefreshRunId
+    ) {
+      throw new MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError(
+        "transitionFromRefreshRunId and transitionToRefreshRunId must be different",
+      );
+    }
+
+    if (
+      filters.refreshRunId ||
+      filters.fromRefreshRunId ||
+      filters.toRefreshRunId ||
+      filters.chronology
+    ) {
+      throw new MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError(
+        "transition artifact queries cannot be combined with refreshRunId, fromRefreshRunId, toRefreshRunId, or chronology",
+      );
+    }
+
+    const transitionResult = await this.getAreaOverlayRefreshRunTransition(
+      missionId,
+      {
+        transitionFromRefreshRunId: filters.transitionFromRefreshRunId,
+        transitionToRefreshRunId: filters.transitionToRefreshRunId,
+      },
+    );
+
+    return {
+      missionId,
+      artifact: {
+        artifactId: buildAreaOverlayRefreshRunTransitionArtifactId(
+          missionId,
+          filters.transitionFromRefreshRunId,
+          filters.transitionToRefreshRunId,
+        ),
+        missionId,
+        artifactType: "refresh_run_transition",
+        fromRefreshRunId: filters.transitionFromRefreshRunId,
+        toRefreshRunId: filters.transitionToRefreshRunId,
+        transition: transitionResult.transition,
+      },
+    };
   }
 
   async listAreaOverlayRefreshRunChronology(

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -1842,6 +1842,194 @@ describe("mission external overlays integration", () => {
     });
   });
 
+  it("returns a direct transition artifact payload for one chronology transition", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-1600",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-1600",
+              label: "Danger Area EGD-1600",
+              areaType: "danger_area",
+              description: "Base area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+        ],
+      });
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1600/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1600-26",
+              label: "Danger Area EGD-1600 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B1600/26",
+              sourceReference: "NOTAM B1600/26",
+            },
+          },
+        ],
+      });
+
+    const thirdRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1600/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1600-26",
+              label: "Danger Area EGD-1600 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B1600/26",
+              sourceReference: "NOTAM B1600/26",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-1602",
+            },
+            observedAt: "2026-04-21T10:10:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5102,
+              centerLng: -0.1251,
+              radiusMeters: 250,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1100,
+            },
+            severity: "caution",
+            area: {
+              areaId: "TDA-1602",
+              label: "Temporary Danger Area 1602",
+              areaType: "temporary_danger_area",
+              description: "New area in later run",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(secondRun.status).toBe(201);
+    expect(thirdRun.status).toBe(201);
+
+    const drilldownResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionFromRefreshRunId=${secondRun.body.refreshRunId}&transitionToRefreshRunId=${thirdRun.body.refreshRunId}`,
+    );
+
+    const artifactResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifact=true&transitionFromRefreshRunId=${secondRun.body.refreshRunId}&transitionToRefreshRunId=${thirdRun.body.refreshRunId}`,
+    );
+
+    expect(artifactResponse.status).toBe(200);
+    expect(artifactResponse.body).toMatchObject({
+      missionId,
+      artifact: {
+        artifactId: `refresh_run_transition:${missionId}:${secondRun.body.refreshRunId}:${thirdRun.body.refreshRunId}`,
+        missionId,
+        artifactType: "refresh_run_transition",
+        fromRefreshRunId: secondRun.body.refreshRunId,
+        toRefreshRunId: thirdRun.body.refreshRunId,
+        transition: {
+          missionId,
+          fromRefreshRunId: secondRun.body.refreshRunId,
+          toRefreshRunId: thirdRun.body.refreshRunId,
+          added: [
+            expect.objectContaining({
+              areaId: "TDA-1602",
+            }),
+          ],
+          persisted: [
+            expect.objectContaining({
+              areaId: "NOTAM-B1600-26",
+            }),
+          ],
+        },
+      },
+    });
+    expect(artifactResponse.body.artifact.transition).toEqual(
+      drilldownResponse.body.transition,
+    );
+
+    const invalidArtifactResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifact=true&transitionFromRefreshRunId=${secondRun.body.refreshRunId}&transitionToRefreshRunId=${thirdRun.body.refreshRunId}&chronology=true`,
+    );
+
+    expect(invalidArtifactResponse.status).toBe(400);
+    expect(invalidArtifactResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_transition_artifact_query_invalid",
+      },
+    });
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #200 by adding refresh-run transition artifact query support to normalized area overlay chronology queries so transition-level review payloads can be retrieved directly.

## What changed

- Extended the mission-linked refresh-run summary read path with transition artifact query support:
  - `GET /missions/:missionId/external-overlays/refresh-runs`
  - artifact query parameters:
    - `transitionArtifact=true`
    - `transitionFromRefreshRunId`
    - `transitionToRefreshRunId`
- Kept the implementation inside the normalized area overlay ingestion / auditability boundary.
- Reused the existing provenance, diff, chronology, and transition drilldown model rather than introducing a separate artifact store.
- Added a bounded transition artifact payload that exposes:
  - `artifactId`
  - `artifactType`
  - `missionId`
  - `fromRefreshRunId`
  - `toRefreshRunId`
  - the transition payload itself
- Added a stable transition artifact identity using the mission id plus the transition run ids.
- Kept the transition artifact payload consistent with the direct transition drilldown response.
- Added explicit validation for invalid transition artifact queries:
  - both transition run ids are required
  - the two transition run ids must be different
  - artifact mode cannot be combined with `refreshRunId`
  - artifact mode cannot be combined with `fromRefreshRunId`
  - artifact mode cannot be combined with `toRefreshRunId`
  - artifact mode cannot be combined with `chronology`
  - invalid requests return `refresh_run_transition_artifact_query_invalid`
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling
  - source traceability
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
  - single-run filtering
  - direct two-run diff queries
  - chronology ordering
  - direct transition drilldown
- Kept conflict assessment source-agnostic and unchanged.
- Updated the save point to the next read-path refinement step:
  - transition artifact filtering support

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 18 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 349 tests.

## Notes

This issue is an ingestion-layer auditability read-path refinement only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #200.
