### PR TITLE
Add area overlay transition artifact filtering

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add refresh-run transition artifact filtering support to normalized area overlay chronology queries so specific transition review payloads can be selected directly.",
+  "nextBuildStep": "Add transition artifact chronology listing support to normalized area overlay chronology queries so ordered transition review payloads can be retrieved together.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -13,6 +13,7 @@ type RefreshRunQuery = {
   transitionFromRefreshRunId?: string;
   transitionToRefreshRunId?: string;
   transitionArtifact?: string;
+  transitionArtifactId?: string;
   chronology?: string;
 };
 
@@ -140,6 +141,11 @@ export class ExternalOverlayController {
         ["1", "true", "yes"].includes(
           req.query.transitionArtifact.trim().toLowerCase(),
         );
+      const transitionArtifactId =
+        typeof req.query.transitionArtifactId === "string" &&
+        req.query.transitionArtifactId.trim().length > 0
+          ? req.query.transitionArtifactId.trim()
+          : undefined;
 
       if (transitionArtifact) {
         const result =
@@ -152,6 +158,7 @@ export class ExternalOverlayController {
               chronology,
               transitionFromRefreshRunId,
               transitionToRefreshRunId,
+              transitionArtifactId,
             },
           );
 

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -316,6 +316,30 @@ const buildAreaOverlayRefreshRunTransitionArtifactId = (
     toRefreshRunId,
   ].join(":");
 
+const parseAreaOverlayRefreshRunTransitionArtifactId = (
+  artifactId: string,
+): {
+  missionId: string;
+  fromRefreshRunId: string;
+  toRefreshRunId: string;
+} | null => {
+  const parts = artifactId.split(":");
+  if (parts.length !== 4 || parts[0] !== "refresh_run_transition") {
+    return null;
+  }
+
+  const [, missionId, fromRefreshRunId, toRefreshRunId] = parts;
+  if (!missionId || !fromRefreshRunId || !toRefreshRunId) {
+    return null;
+  }
+
+  return {
+    missionId,
+    fromRefreshRunId,
+    toRefreshRunId,
+  };
+};
+
 const areaOverlayRefreshSummaryItemFromOverlay = (
   overlay: ExternalOverlay,
 ): AreaOverlayRefreshRunSummaryItem => {
@@ -1183,25 +1207,9 @@ export class ExternalOverlayService {
       chronology?: boolean;
       transitionFromRefreshRunId?: string;
       transitionToRefreshRunId?: string;
+      transitionArtifactId?: string;
     },
   ): Promise<{ missionId: string; artifact: AreaOverlayRefreshRunTransitionArtifact }> {
-    if (
-      !filters.transitionFromRefreshRunId ||
-      !filters.transitionToRefreshRunId
-    ) {
-      throw new MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError(
-        "Both transitionFromRefreshRunId and transitionToRefreshRunId are required for refresh-run transition artifact queries",
-      );
-    }
-
-    if (
-      filters.transitionFromRefreshRunId === filters.transitionToRefreshRunId
-    ) {
-      throw new MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError(
-        "transitionFromRefreshRunId and transitionToRefreshRunId must be different",
-      );
-    }
-
     if (
       filters.refreshRunId ||
       filters.fromRefreshRunId ||
@@ -1213,11 +1221,52 @@ export class ExternalOverlayService {
       );
     }
 
+    let transitionFromRefreshRunId = filters.transitionFromRefreshRunId;
+    let transitionToRefreshRunId = filters.transitionToRefreshRunId;
+
+    if (filters.transitionArtifactId) {
+      if (transitionFromRefreshRunId || transitionToRefreshRunId) {
+        throw new MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError(
+          "transitionArtifactId cannot be combined with transitionFromRefreshRunId or transitionToRefreshRunId",
+        );
+      }
+
+      const parsedArtifactId = parseAreaOverlayRefreshRunTransitionArtifactId(
+        filters.transitionArtifactId,
+      );
+      if (!parsedArtifactId) {
+        throw new MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError(
+          "transitionArtifactId must use the refresh_run_transition:<missionId>:<fromRefreshRunId>:<toRefreshRunId> format",
+        );
+      }
+
+      if (parsedArtifactId.missionId !== missionId) {
+        throw new MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError(
+          "transitionArtifactId mission id does not match the requested mission",
+        );
+      }
+
+      transitionFromRefreshRunId = parsedArtifactId.fromRefreshRunId;
+      transitionToRefreshRunId = parsedArtifactId.toRefreshRunId;
+    }
+
+    if (!transitionFromRefreshRunId || !transitionToRefreshRunId) {
+      throw new MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError(
+        "Either transitionArtifactId or both transitionFromRefreshRunId and transitionToRefreshRunId are required for refresh-run transition artifact queries",
+      );
+    }
+
+    if (transitionFromRefreshRunId === transitionToRefreshRunId) {
+      throw new MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError(
+        "transitionFromRefreshRunId and transitionToRefreshRunId must be different",
+      );
+    }
+
     const transitionResult = await this.getAreaOverlayRefreshRunTransition(
       missionId,
       {
-        transitionFromRefreshRunId: filters.transitionFromRefreshRunId,
-        transitionToRefreshRunId: filters.transitionToRefreshRunId,
+        transitionFromRefreshRunId,
+        transitionToRefreshRunId,
       },
     );
 
@@ -1226,13 +1275,13 @@ export class ExternalOverlayService {
       artifact: {
         artifactId: buildAreaOverlayRefreshRunTransitionArtifactId(
           missionId,
-          filters.transitionFromRefreshRunId,
-          filters.transitionToRefreshRunId,
+          transitionFromRefreshRunId,
+          transitionToRefreshRunId,
         ),
         missionId,
         artifactType: "refresh_run_transition",
-        fromRefreshRunId: filters.transitionFromRefreshRunId,
-        toRefreshRunId: filters.transitionToRefreshRunId,
+        fromRefreshRunId: transitionFromRefreshRunId,
+        toRefreshRunId: transitionToRefreshRunId,
         transition: transitionResult.transition,
       },
     };

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -2030,6 +2030,180 @@ describe("mission external overlays integration", () => {
     });
   });
 
+  it("filters a transition artifact directly by artifact id", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-1700",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-1700",
+              label: "Danger Area EGD-1700",
+              areaType: "danger_area",
+              description: "Base area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+        ],
+      });
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1700/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1700-26",
+              label: "Danger Area EGD-1700 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B1700/26",
+              sourceReference: "NOTAM B1700/26",
+            },
+          },
+        ],
+      });
+
+    const thirdRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1700/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1700-26",
+              label: "Danger Area EGD-1700 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B1700/26",
+              sourceReference: "NOTAM B1700/26",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-1702",
+            },
+            observedAt: "2026-04-21T10:10:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5102,
+              centerLng: -0.1251,
+              radiusMeters: 250,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1100,
+            },
+            severity: "caution",
+            area: {
+              areaId: "TDA-1702",
+              label: "Temporary Danger Area 1702",
+              areaType: "temporary_danger_area",
+              description: "New area in later run",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(secondRun.status).toBe(201);
+    expect(thirdRun.status).toBe(201);
+
+    const unfilteredArtifactResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifact=true&transitionFromRefreshRunId=${secondRun.body.refreshRunId}&transitionToRefreshRunId=${thirdRun.body.refreshRunId}`,
+    );
+
+    const filteredArtifactResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifact=true&transitionArtifactId=refresh_run_transition:${missionId}:${secondRun.body.refreshRunId}:${thirdRun.body.refreshRunId}`,
+    );
+
+    expect(filteredArtifactResponse.status).toBe(200);
+    expect(filteredArtifactResponse.body).toEqual(
+      unfilteredArtifactResponse.body,
+    );
+
+    const invalidArtifactIdResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifact=true&transitionArtifactId=bad-format`,
+    );
+
+    expect(invalidArtifactIdResponse.status).toBe(400);
+    expect(invalidArtifactIdResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_transition_artifact_query_invalid",
+      },
+    });
+
+    const mismatchedMissionResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifact=true&transitionArtifactId=refresh_run_transition:${randomUUID()}:${secondRun.body.refreshRunId}:${thirdRun.body.refreshRunId}`,
+    );
+
+    expect(mismatchedMissionResponse.status).toBe(400);
+    expect(mismatchedMissionResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_transition_artifact_query_invalid",
+      },
+    });
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #202 by adding transition artifact filtering support to normalized area overlay chronology queries so specific transition review payloads can be selected directly.

## What changed

- Extended the mission-linked refresh-run summary read path so transition artifact queries can select a specific artifact directly:
  - `GET /missions/:missionId/external-overlays/refresh-runs`
  - artifact query parameters:
    - `transitionArtifact=true`
    - `transitionArtifactId`
- Kept the implementation inside the normalized area overlay ingestion / auditability boundary.
- Reused the existing provenance, chronology, transition drilldown, and transition artifact model rather than introducing another read model.
- Added direct transition artifact id parsing for the stable artifact id format:
  - `refresh_run_transition:<missionId>:<fromRefreshRunId>:<toRefreshRunId>`
- Added artifact selection by `transitionArtifactId`, so one specific transition review payload can be requested without separately supplying `transitionFromRefreshRunId` and `transitionToRefreshRunId`.
- Preserved the existing artifact query mode using explicit transition run ids.
- Added clear validation for invalid artifact filter queries:
  - malformed `transitionArtifactId`
  - `transitionArtifactId` mission mismatch
  - combining `transitionArtifactId` with `transitionFromRefreshRunId`
  - combining artifact mode with `refreshRunId`
  - combining artifact mode with `fromRefreshRunId`
  - combining artifact mode with `toRefreshRunId`
  - combining artifact mode with `chronology`
  - invalid requests return `refresh_run_transition_artifact_query_invalid`
- Verified that a filtered artifact response matches the corresponding unfiltered transition artifact payload.
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling
  - source traceability
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
  - single-run filtering
  - direct two-run diff queries
  - chronology ordering
  - direct transition drilldown
  - transition artifact query support
- Kept conflict assessment source-agnostic and unchanged.
- Updated the save point to the next read-path refinement step:
  - transition artifact chronology listing support

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 19 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 350 tests.

## Notes

This issue is an ingestion-layer auditability read-path refinement only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #202.
