### PR TITLE
Add area overlay transition artifact chronology

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add transition artifact chronology listing support to normalized area overlay chronology queries so ordered transition review payloads can be retrieved together.",
+  "nextBuildStep": "Add transition artifact chronology filtering support to normalized area overlay chronology queries so specific ordered transition review payloads can be selected directly.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -14,6 +14,7 @@ type RefreshRunQuery = {
   transitionToRefreshRunId?: string;
   transitionArtifact?: string;
   transitionArtifactId?: string;
+  transitionArtifactChronology?: string;
   chronology?: string;
 };
 
@@ -146,6 +147,31 @@ export class ExternalOverlayController {
         req.query.transitionArtifactId.trim().length > 0
           ? req.query.transitionArtifactId.trim()
           : undefined;
+      const transitionArtifactChronology =
+        typeof req.query.transitionArtifactChronology === "string" &&
+        ["1", "true", "yes"].includes(
+          req.query.transitionArtifactChronology.trim().toLowerCase(),
+        );
+
+      if (transitionArtifactChronology) {
+        const result =
+          await this.externalOverlayService.listAreaOverlayRefreshRunTransitionArtifacts(
+            req.params.missionId,
+            {
+              refreshRunId,
+              fromRefreshRunId,
+              toRefreshRunId,
+              chronology,
+              transitionArtifact,
+              transitionFromRefreshRunId,
+              transitionToRefreshRunId,
+              transitionArtifactId,
+            },
+          );
+
+        res.status(200).json(result);
+        return;
+      }
 
       if (transitionArtifact) {
         const result =

--- a/src/external-overlays/external-overlay.errors.ts
+++ b/src/external-overlays/external-overlay.errors.ts
@@ -51,3 +51,12 @@ export class MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError
     super(message);
   }
 }
+
+export class MissionExternalOverlayRefreshRunTransitionArtifactChronologyQueryInvalidError extends Error {
+  readonly statusCode = 400;
+  readonly type = "refresh_run_transition_artifact_chronology_query_invalid";
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -6,6 +6,7 @@ import {
   MissionExternalOverlayMissionNotFoundError,
   MissionExternalOverlayRefreshRunDiffQueryInvalidError,
   MissionExternalOverlayRefreshRunNotFoundError,
+  MissionExternalOverlayRefreshRunTransitionArtifactChronologyQueryInvalidError,
   MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError,
   MissionExternalOverlayRefreshRunTransitionDrilldownQueryInvalidError,
 } from "./external-overlay.errors";
@@ -304,6 +305,11 @@ type AreaOverlayRefreshRunTransitionArtifact = {
   transition: AreaOverlayRefreshRunDiff;
 };
 
+type AreaOverlayRefreshRunTransitionArtifactChronology = {
+  missionId: string;
+  artifacts: AreaOverlayRefreshRunTransitionArtifact[];
+};
+
 const buildAreaOverlayRefreshRunTransitionArtifactId = (
   missionId: string,
   fromRefreshRunId: string,
@@ -339,6 +345,22 @@ const parseAreaOverlayRefreshRunTransitionArtifactId = (
     toRefreshRunId,
   };
 };
+
+const buildAreaOverlayRefreshRunTransitionArtifact = (
+  missionId: string,
+  transition: AreaOverlayRefreshRunDiff,
+): AreaOverlayRefreshRunTransitionArtifact => ({
+  artifactId: buildAreaOverlayRefreshRunTransitionArtifactId(
+    missionId,
+    transition.fromRefreshRunId,
+    transition.toRefreshRunId,
+  ),
+  missionId,
+  artifactType: "refresh_run_transition",
+  fromRefreshRunId: transition.fromRefreshRunId,
+  toRefreshRunId: transition.toRefreshRunId,
+  transition,
+});
 
 const areaOverlayRefreshSummaryItemFromOverlay = (
   overlay: ExternalOverlay,
@@ -1272,17 +1294,55 @@ export class ExternalOverlayService {
 
     return {
       missionId,
-      artifact: {
-        artifactId: buildAreaOverlayRefreshRunTransitionArtifactId(
-          missionId,
-          transitionFromRefreshRunId,
-          transitionToRefreshRunId,
-        ),
+      artifact: buildAreaOverlayRefreshRunTransitionArtifact(
         missionId,
-        artifactType: "refresh_run_transition",
-        fromRefreshRunId: transitionFromRefreshRunId,
-        toRefreshRunId: transitionToRefreshRunId,
-        transition: transitionResult.transition,
+        transitionResult.transition,
+      ),
+    };
+  }
+
+  async listAreaOverlayRefreshRunTransitionArtifacts(
+    missionId: string,
+    filters: {
+      refreshRunId?: string;
+      fromRefreshRunId?: string;
+      toRefreshRunId?: string;
+      chronology?: boolean;
+      transitionArtifact?: boolean;
+      transitionFromRefreshRunId?: string;
+      transitionToRefreshRunId?: string;
+      transitionArtifactId?: string;
+    },
+  ): Promise<{
+    missionId: string;
+    chronology: AreaOverlayRefreshRunTransitionArtifactChronology;
+  }> {
+    if (
+      filters.refreshRunId ||
+      filters.fromRefreshRunId ||
+      filters.toRefreshRunId ||
+      filters.chronology ||
+      filters.transitionArtifact ||
+      filters.transitionFromRefreshRunId ||
+      filters.transitionToRefreshRunId ||
+      filters.transitionArtifactId
+    ) {
+      throw new MissionExternalOverlayRefreshRunTransitionArtifactChronologyQueryInvalidError(
+        "transition artifact chronology queries cannot be combined with other refresh-run or transition artifact filters",
+      );
+    }
+
+    const chronologyResult = await this.listAreaOverlayRefreshRunChronology(
+      missionId,
+    );
+
+    return {
+      missionId,
+      chronology: {
+        missionId,
+        artifacts: chronologyResult.chronology.transitions.map((transition) =>
+          buildAreaOverlayRefreshRunTransitionArtifact(missionId, transition),
+        ),
       },
     };
   }

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -2204,6 +2204,217 @@ describe("mission external overlays integration", () => {
     });
   });
 
+  it("lists ordered transition artifacts directly from chronology", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-1800",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-1800",
+              label: "Danger Area EGD-1800",
+              areaType: "danger_area",
+              description: "Base area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-1801",
+            },
+            observedAt: "2026-04-21T10:08:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5091,
+              centerLng: -0.1261,
+              radiusMeters: 280,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            severity: "critical",
+            area: {
+              areaId: "TDA-1801",
+              label: "Temporary Danger Area 1801",
+              areaType: "temporary_danger_area",
+              description: "Will be retired later",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1800/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1800-26",
+              label: "Danger Area EGD-1800 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B1800/26",
+              sourceReference: "NOTAM B1800/26",
+            },
+          },
+        ],
+      });
+
+    const thirdRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1800/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1800-26",
+              label: "Danger Area EGD-1800 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B1800/26",
+              sourceReference: "NOTAM B1800/26",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-1802",
+            },
+            observedAt: "2026-04-21T10:10:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5102,
+              centerLng: -0.1251,
+              radiusMeters: 250,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1100,
+            },
+            severity: "caution",
+            area: {
+              areaId: "TDA-1802",
+              label: "Temporary Danger Area 1802",
+              areaType: "temporary_danger_area",
+              description: "New area in later run",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(secondRun.status).toBe(201);
+    expect(thirdRun.status).toBe(201);
+
+    const chronologyResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?chronology=true`,
+    );
+
+    const artifactChronologyResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true`,
+    );
+
+    expect(artifactChronologyResponse.status).toBe(200);
+    expect(artifactChronologyResponse.body).toMatchObject({
+      missionId,
+      chronology: {
+        missionId,
+        artifacts: [
+          expect.objectContaining({
+            artifactId: `refresh_run_transition:${missionId}:${firstRun.body.refreshRunId}:${secondRun.body.refreshRunId}`,
+            fromRefreshRunId: firstRun.body.refreshRunId,
+            toRefreshRunId: secondRun.body.refreshRunId,
+          }),
+          expect.objectContaining({
+            artifactId: `refresh_run_transition:${missionId}:${secondRun.body.refreshRunId}:${thirdRun.body.refreshRunId}`,
+            fromRefreshRunId: secondRun.body.refreshRunId,
+            toRefreshRunId: thirdRun.body.refreshRunId,
+          }),
+        ],
+      },
+    });
+
+    expect(
+      artifactChronologyResponse.body.chronology.artifacts.map(
+        (artifact: { transition: unknown }) => artifact.transition,
+      ),
+    ).toEqual(chronologyResponse.body.chronology.transitions);
+
+    const invalidArtifactChronologyResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifact=true`,
+    );
+
+    expect(invalidArtifactChronologyResponse.status).toBe(400);
+    expect(invalidArtifactChronologyResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_transition_artifact_chronology_query_invalid",
+      },
+    });
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #204 by adding transition artifact chronology listing support to normalized area overlay chronology queries so ordered transition review payloads can be retrieved together.

## What changed

- Extended the mission-linked refresh-run summary read path with transition artifact chronology listing support:
  - `GET /missions/:missionId/external-overlays/refresh-runs`
  - chronology artifact query parameter:
    - `transitionArtifactChronology=true`
- Kept the implementation inside the normalized area overlay ingestion / auditability boundary.
- Reused the existing chronology, transition drilldown, transition artifact, and transition artifact filtering model rather than introducing another listing surface.
- Added a bounded chronology listing response for ordered transition artifacts, including:
  - ordered transition artifact ids
  - `fromRefreshRunId`
  - `toRefreshRunId`
  - the underlying transition payload for each ordered transition
- Reused the existing chronology transition ordering so artifact chronology stays consistent with the ordered refresh-run chronology response.
- Refactored transition artifact construction into shared service logic so:
  - direct transition artifact queries
  - filtered transition artifact queries
  - transition artifact chronology listing
  all stay consistent
- Added explicit validation for invalid transition artifact chronology queries:
  - transition artifact chronology mode cannot be combined with `refreshRunId`
  - transition artifact chronology mode cannot be combined with `fromRefreshRunId`
  - transition artifact chronology mode cannot be combined with `toRefreshRunId`
  - transition artifact chronology mode cannot be combined with `chronology`
  - transition artifact chronology mode cannot be combined with `transitionArtifact`
  - transition artifact chronology mode cannot be combined with `transitionFromRefreshRunId`
  - transition artifact chronology mode cannot be combined with `transitionToRefreshRunId`
  - transition artifact chronology mode cannot be combined with `transitionArtifactId`
  - invalid requests return `refresh_run_transition_artifact_chronology_query_invalid`
- Verified that the ordered listed transition artifacts match the corresponding ordered chronology transitions.
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling
  - source traceability
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
  - single-run filtering
  - direct two-run diff queries
  - chronology ordering
  - direct transition drilldown
  - transition artifact query support
  - transition artifact filtering support
- Kept conflict assessment source-agnostic and unchanged.
- Updated the save point to the next read-path refinement step:
  - transition artifact chronology filtering support

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 20 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 351 tests.

## Notes

This issue is an ingestion-layer auditability read-path refinement only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #204.
