### PR TITLE
Add area overlay transition artifact chronology filtering

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add transition artifact chronology filtering support to normalized area overlay chronology queries so specific ordered transition review payloads can be selected directly.",
+  "nextBuildStep": "Add transition artifact chronology pagination support to normalized area overlay chronology queries so ordered transition review payloads can be retrieved in bounded windows.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -15,6 +15,7 @@ type RefreshRunQuery = {
   transitionArtifact?: string;
   transitionArtifactId?: string;
   transitionArtifactChronology?: string;
+  transitionArtifactIds?: string;
   chronology?: string;
 };
 
@@ -152,6 +153,14 @@ export class ExternalOverlayController {
         ["1", "true", "yes"].includes(
           req.query.transitionArtifactChronology.trim().toLowerCase(),
         );
+      const transitionArtifactIds =
+        typeof req.query.transitionArtifactIds === "string" &&
+        req.query.transitionArtifactIds.trim().length > 0
+          ? req.query.transitionArtifactIds
+              .split(",")
+              .map((value) => value.trim())
+              .filter((value) => value.length > 0)
+          : undefined;
 
       if (transitionArtifactChronology) {
         const result =
@@ -166,6 +175,7 @@ export class ExternalOverlayController {
               transitionFromRefreshRunId,
               transitionToRefreshRunId,
               transitionArtifactId,
+              transitionArtifactIds,
             },
           );
 

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -1312,6 +1312,7 @@ export class ExternalOverlayService {
       transitionFromRefreshRunId?: string;
       transitionToRefreshRunId?: string;
       transitionArtifactId?: string;
+      transitionArtifactIds?: string[];
     },
   ): Promise<{
     missionId: string;
@@ -1335,14 +1336,45 @@ export class ExternalOverlayService {
     const chronologyResult = await this.listAreaOverlayRefreshRunChronology(
       missionId,
     );
+    const artifacts = chronologyResult.chronology.transitions.map((transition) =>
+      buildAreaOverlayRefreshRunTransitionArtifact(missionId, transition),
+    );
+
+    if (filters.transitionArtifactIds && filters.transitionArtifactIds.length > 0) {
+      for (const artifactId of filters.transitionArtifactIds) {
+        const parsedArtifactId = parseAreaOverlayRefreshRunTransitionArtifactId(
+          artifactId,
+        );
+        if (!parsedArtifactId) {
+          throw new MissionExternalOverlayRefreshRunTransitionArtifactChronologyQueryInvalidError(
+            "transitionArtifactIds entries must use the refresh_run_transition:<missionId>:<fromRefreshRunId>:<toRefreshRunId> format",
+          );
+        }
+
+        if (parsedArtifactId.missionId !== missionId) {
+          throw new MissionExternalOverlayRefreshRunTransitionArtifactChronologyQueryInvalidError(
+            "transitionArtifactIds entries must match the requested mission",
+          );
+        }
+      }
+
+      const selectedArtifactIds = new Set(filters.transitionArtifactIds);
+      return {
+        missionId,
+        chronology: {
+          missionId,
+          artifacts: artifacts.filter((artifact) =>
+            selectedArtifactIds.has(artifact.artifactId),
+          ),
+        },
+      };
+    }
 
     return {
       missionId,
       chronology: {
         missionId,
-        artifacts: chronologyResult.chronology.transitions.map((transition) =>
-          buildAreaOverlayRefreshRunTransitionArtifact(missionId, transition),
-        ),
+        artifacts,
       },
     };
   }

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -2415,6 +2415,194 @@ describe("mission external overlays integration", () => {
     });
   });
 
+  it("filters ordered transition artifacts directly from chronology", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-1900",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-1900",
+              label: "Danger Area EGD-1900",
+              areaType: "danger_area",
+              description: "Base area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+        ],
+      });
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1900/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1900-26",
+              label: "Danger Area EGD-1900 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B1900/26",
+              sourceReference: "NOTAM B1900/26",
+            },
+          },
+        ],
+      });
+
+    const thirdRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1900/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B1900-26",
+              label: "Danger Area EGD-1900 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B1900/26",
+              sourceReference: "NOTAM B1900/26",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-1902",
+            },
+            observedAt: "2026-04-21T10:10:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5102,
+              centerLng: -0.1251,
+              radiusMeters: 250,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1100,
+            },
+            severity: "caution",
+            area: {
+              areaId: "TDA-1902",
+              label: "Temporary Danger Area 1902",
+              areaType: "temporary_danger_area",
+              description: "New area in later run",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(secondRun.status).toBe(201);
+    expect(thirdRun.status).toBe(201);
+
+    const fullArtifactChronologyResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true`,
+    );
+
+    const selectedArtifactId = `refresh_run_transition:${missionId}:${secondRun.body.refreshRunId}:${thirdRun.body.refreshRunId}`;
+    const filteredArtifactChronologyResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactIds=${selectedArtifactId}`,
+    );
+
+    expect(filteredArtifactChronologyResponse.status).toBe(200);
+    expect(filteredArtifactChronologyResponse.body).toMatchObject({
+      missionId,
+      chronology: {
+        missionId,
+        artifacts: [
+          expect.objectContaining({
+            artifactId: selectedArtifactId,
+            fromRefreshRunId: secondRun.body.refreshRunId,
+            toRefreshRunId: thirdRun.body.refreshRunId,
+          }),
+        ],
+      },
+    });
+    expect(filteredArtifactChronologyResponse.body.chronology.artifacts).toEqual([
+      fullArtifactChronologyResponse.body.chronology.artifacts[1],
+    ]);
+
+    const invalidArtifactIdsResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactIds=bad-format`,
+    );
+
+    expect(invalidArtifactIdsResponse.status).toBe(400);
+    expect(invalidArtifactIdsResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_transition_artifact_chronology_query_invalid",
+      },
+    });
+
+    const mismatchedMissionResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactIds=refresh_run_transition:${randomUUID()}:${secondRun.body.refreshRunId}:${thirdRun.body.refreshRunId}`,
+    );
+
+    expect(mismatchedMissionResponse.status).toBe(400);
+    expect(mismatchedMissionResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_transition_artifact_chronology_query_invalid",
+      },
+    });
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #206 by adding transition artifact chronology filtering support to normalized area overlay chronology queries so specific ordered transition review payloads can be selected directly.

## What changed

- Extended the mission-linked refresh-run summary read path so transition artifact chronology queries can be filtered directly:
  - `GET /missions/:missionId/external-overlays/refresh-runs`
  - chronology artifact query parameters:
    - `transitionArtifactChronology=true`
    - `transitionArtifactIds`
- Kept the implementation inside the normalized area overlay ingestion / auditability boundary.
- Reused the existing chronology, artifact, artifact-filter, and artifact-chronology model rather than introducing a separate filtered listing surface.
- Added ordered transition artifact chronology filtering by stable artifact id:
  - `refresh_run_transition:<missionId>:<fromRefreshRunId>:<toRefreshRunId>`
- Preserved chronology order in filtered results so selected transition artifacts remain in the same relative order as the full ordered artifact chronology.
- Added clear validation for invalid chronology filter queries:
  - malformed `transitionArtifactIds` entries
  - `transitionArtifactIds` mission mismatch
- Preserved existing invalid-combination handling for transition artifact chronology mode.
- Verified that filtered chronology artifacts match the corresponding entries from the full transition artifact chronology.
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling
  - source traceability
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
  - single-run filtering
  - direct two-run diff queries
  - chronology ordering
  - direct transition drilldown
  - transition artifact query support
  - transition artifact filtering support
  - transition artifact chronology listing support
- Kept conflict assessment source-agnostic and unchanged.
- Updated the save point to the next read-path refinement step:
  - transition artifact chronology pagination support

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 21 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 352 tests.

## Notes

This issue is an ingestion-layer auditability read-path refinement only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #206.
