### PR TITLE
Add area overlay transition artifact chronology pagination

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add transition artifact chronology pagination support to normalized area overlay chronology queries so ordered transition review payloads can be retrieved in bounded windows.",
+  "nextBuildStep": "Add transition artifact chronology cursor support to normalized area overlay chronology queries so bounded ordered transition review payload windows can be resumed directly.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -16,6 +16,8 @@ type RefreshRunQuery = {
   transitionArtifactId?: string;
   transitionArtifactChronology?: string;
   transitionArtifactIds?: string;
+  transitionArtifactOffset?: string;
+  transitionArtifactLimit?: string;
   chronology?: string;
 };
 
@@ -161,6 +163,16 @@ export class ExternalOverlayController {
               .map((value) => value.trim())
               .filter((value) => value.length > 0)
           : undefined;
+      const transitionArtifactOffset =
+        typeof req.query.transitionArtifactOffset === "string" &&
+        req.query.transitionArtifactOffset.trim().length > 0
+          ? req.query.transitionArtifactOffset.trim()
+          : undefined;
+      const transitionArtifactLimit =
+        typeof req.query.transitionArtifactLimit === "string" &&
+        req.query.transitionArtifactLimit.trim().length > 0
+          ? req.query.transitionArtifactLimit.trim()
+          : undefined;
 
       if (transitionArtifactChronology) {
         const result =
@@ -176,6 +188,8 @@ export class ExternalOverlayController {
               transitionToRefreshRunId,
               transitionArtifactId,
               transitionArtifactIds,
+              transitionArtifactOffset,
+              transitionArtifactLimit,
             },
           );
 

--- a/src/external-overlays/external-overlay.errors.ts
+++ b/src/external-overlays/external-overlay.errors.ts
@@ -60,3 +60,12 @@ export class MissionExternalOverlayRefreshRunTransitionArtifactChronologyQueryIn
     super(message);
   }
 }
+
+export class MissionExternalOverlayRefreshRunTransitionArtifactChronologyPaginationQueryInvalidError extends Error {
+  readonly statusCode = 400;
+  readonly type = "refresh_run_transition_artifact_chronology_pagination_query_invalid";
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -7,6 +7,7 @@ import {
   MissionExternalOverlayRefreshRunDiffQueryInvalidError,
   MissionExternalOverlayRefreshRunNotFoundError,
   MissionExternalOverlayRefreshRunTransitionArtifactChronologyQueryInvalidError,
+  MissionExternalOverlayRefreshRunTransitionArtifactChronologyPaginationQueryInvalidError,
   MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError,
   MissionExternalOverlayRefreshRunTransitionDrilldownQueryInvalidError,
 } from "./external-overlay.errors";
@@ -308,6 +309,13 @@ type AreaOverlayRefreshRunTransitionArtifact = {
 type AreaOverlayRefreshRunTransitionArtifactChronology = {
   missionId: string;
   artifacts: AreaOverlayRefreshRunTransitionArtifact[];
+  pagination: {
+    totalCount: number;
+    offset: number;
+    limit: number;
+    nextOffset: number | null;
+    previousOffset: number | null;
+  };
 };
 
 const buildAreaOverlayRefreshRunTransitionArtifactId = (
@@ -1313,6 +1321,8 @@ export class ExternalOverlayService {
       transitionToRefreshRunId?: string;
       transitionArtifactId?: string;
       transitionArtifactIds?: string[];
+      transitionArtifactOffset?: string;
+      transitionArtifactLimit?: string;
     },
   ): Promise<{
     missionId: string;
@@ -1339,7 +1349,29 @@ export class ExternalOverlayService {
     const artifacts = chronologyResult.chronology.transitions.map((transition) =>
       buildAreaOverlayRefreshRunTransitionArtifact(missionId, transition),
     );
+    const paginationOffset = filters.transitionArtifactOffset
+      ? Number(filters.transitionArtifactOffset)
+      : 0;
+    const paginationLimit = filters.transitionArtifactLimit
+      ? Number(filters.transitionArtifactLimit)
+      : Math.max(artifacts.length, 1);
 
+    if (
+      !Number.isInteger(paginationOffset) ||
+      paginationOffset < 0
+    ) {
+      throw new MissionExternalOverlayRefreshRunTransitionArtifactChronologyPaginationQueryInvalidError(
+        "transitionArtifactOffset must be a non-negative integer",
+      );
+    }
+
+    if (!Number.isInteger(paginationLimit) || paginationLimit < 1) {
+      throw new MissionExternalOverlayRefreshRunTransitionArtifactChronologyPaginationQueryInvalidError(
+        "transitionArtifactLimit must be a positive integer",
+      );
+    }
+
+    let filteredArtifacts = artifacts;
     if (filters.transitionArtifactIds && filters.transitionArtifactIds.length > 0) {
       for (const artifactId of filters.transitionArtifactIds) {
         const parsedArtifactId = parseAreaOverlayRefreshRunTransitionArtifactId(
@@ -1359,22 +1391,36 @@ export class ExternalOverlayService {
       }
 
       const selectedArtifactIds = new Set(filters.transitionArtifactIds);
-      return {
-        missionId,
-        chronology: {
-          missionId,
-          artifacts: artifacts.filter((artifact) =>
-            selectedArtifactIds.has(artifact.artifactId),
-          ),
-        },
-      };
+      filteredArtifacts = artifacts.filter((artifact) =>
+        selectedArtifactIds.has(artifact.artifactId),
+      );
     }
+
+    const paginatedArtifacts = filteredArtifacts.slice(
+      paginationOffset,
+      paginationOffset + paginationLimit,
+    );
+    const nextOffset =
+      paginationOffset + paginationLimit < filteredArtifacts.length
+        ? paginationOffset + paginationLimit
+        : null;
+    const previousOffset =
+      paginationOffset > 0
+        ? Math.max(0, paginationOffset - paginationLimit)
+        : null;
 
     return {
       missionId,
       chronology: {
         missionId,
-        artifacts,
+        artifacts: paginatedArtifacts,
+        pagination: {
+          totalCount: filteredArtifacts.length,
+          offset: paginationOffset,
+          limit: paginationLimit,
+          nextOffset,
+          previousOffset,
+        },
       },
     };
   }

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -2603,6 +2603,279 @@ describe("mission external overlays integration", () => {
     });
   });
 
+  it("paginates ordered transition artifacts directly from chronology", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-2000",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-2000",
+              label: "Danger Area EGD-2000",
+              areaType: "danger_area",
+              description: "Base area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+        ],
+      });
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B2000/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B2000-26",
+              label: "Danger Area EGD-2000 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B2000/26",
+              sourceReference: "NOTAM B2000/26",
+            },
+          },
+        ],
+      });
+
+    const thirdRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B2000/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B2000-26",
+              label: "Danger Area EGD-2000 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B2000/26",
+              sourceReference: "NOTAM B2000/26",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-2002",
+            },
+            observedAt: "2026-04-21T10:10:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5102,
+              centerLng: -0.1251,
+              radiusMeters: 250,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1100,
+            },
+            severity: "caution",
+            area: {
+              areaId: "TDA-2002",
+              label: "Temporary Danger Area 2002",
+              areaType: "temporary_danger_area",
+              description: "New area in later run",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    const fourthRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B2000/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B2000-26",
+              label: "Danger Area EGD-2000 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B2000/26",
+              sourceReference: "NOTAM B2000/26",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-2003",
+            },
+            observedAt: "2026-04-21T10:11:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5112,
+              centerLng: -0.1241,
+              radiusMeters: 220,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            severity: "info",
+            area: {
+              areaId: "TDA-2003",
+              label: "Temporary Danger Area 2003",
+              areaType: "temporary_danger_area",
+              description: "New later area",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(secondRun.status).toBe(201);
+    expect(thirdRun.status).toBe(201);
+    expect(fourthRun.status).toBe(201);
+
+    const fullArtifactChronologyResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true`,
+    );
+
+    const paginatedArtifactChronologyResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactOffset=1&transitionArtifactLimit=2`,
+    );
+
+    expect(paginatedArtifactChronologyResponse.status).toBe(200);
+    expect(paginatedArtifactChronologyResponse.body).toMatchObject({
+      missionId,
+      chronology: {
+        missionId,
+        pagination: {
+          totalCount: 3,
+          offset: 1,
+          limit: 2,
+          nextOffset: null,
+          previousOffset: 0,
+        },
+      },
+    });
+    expect(paginatedArtifactChronologyResponse.body.chronology.artifacts).toEqual(
+      fullArtifactChronologyResponse.body.chronology.artifacts.slice(1, 3),
+    );
+
+    const filteredSelectedArtifactId =
+      fullArtifactChronologyResponse.body.chronology.artifacts[1].artifactId;
+    const filteredPaginatedResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactIds=${filteredSelectedArtifactId}&transitionArtifactOffset=0&transitionArtifactLimit=1`,
+    );
+
+    expect(filteredPaginatedResponse.status).toBe(200);
+    expect(filteredPaginatedResponse.body).toMatchObject({
+      missionId,
+      chronology: {
+        pagination: {
+          totalCount: 1,
+          offset: 0,
+          limit: 1,
+          nextOffset: null,
+          previousOffset: null,
+        },
+      },
+    });
+    expect(filteredPaginatedResponse.body.chronology.artifacts).toEqual([
+      fullArtifactChronologyResponse.body.chronology.artifacts[1],
+    ]);
+
+    const invalidOffsetResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactOffset=-1`,
+    );
+
+    expect(invalidOffsetResponse.status).toBe(400);
+    expect(invalidOffsetResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_transition_artifact_chronology_pagination_query_invalid",
+      },
+    });
+
+    const invalidLimitResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactLimit=0`,
+    );
+
+    expect(invalidLimitResponse.status).toBe(400);
+    expect(invalidLimitResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_transition_artifact_chronology_pagination_query_invalid",
+      },
+    });
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #208 by adding transition artifact chronology pagination support to normalized area overlay chronology queries so ordered transition review payloads can be retrieved in bounded windows.

## What changed

- Extended the mission-linked refresh-run summary read path so transition artifact chronology queries can be paginated directly:
  - `GET /missions/:missionId/external-overlays/refresh-runs`
  - chronology artifact pagination query parameters:
    - `transitionArtifactChronology=true`
    - `transitionArtifactOffset`
    - `transitionArtifactLimit`
- Kept the implementation inside the normalized area overlay ingestion / auditability boundary.
- Reused the existing chronology, artifact, artifact-filter, and artifact-chronology model rather than introducing a separate paginated surface.
- Added bounded offset/limit pagination over the already ordered transition artifact chronology.
- Added pagination metadata to the response, including:
  - `totalCount`
  - `offset`
  - `limit`
  - `nextOffset`
  - `previousOffset`
- Preserved chronology order in paginated results so each page remains a stable ordered window over the full transition artifact chronology.
- Added explicit validation for invalid pagination queries:
  - `transitionArtifactOffset` must be a non-negative integer
  - `transitionArtifactLimit` must be a positive integer
  - invalid requests return `refresh_run_transition_artifact_chronology_pagination_query_invalid`
- Verified that paginated chronology results match the corresponding slice from the full transition artifact chronology.
- Verified that pagination composes correctly with transition artifact chronology filtering.
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling
  - source traceability
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
  - single-run filtering
  - direct two-run diff queries
  - chronology ordering
  - direct transition drilldown
  - transition artifact query support
  - transition artifact filtering support
  - transition artifact chronology listing support
  - transition artifact chronology filtering support
- Kept conflict assessment source-agnostic and unchanged.
- Updated the save point to the next read-path refinement step:
  - transition artifact chronology cursor support

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 22 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 353 tests.

## Notes

This issue is an ingestion-layer auditability read-path refinement only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #208.
