### PR TITLE
Add area overlay transition artifact chronology cursor

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add transition artifact chronology cursor support to normalized area overlay chronology queries so bounded ordered transition review payload windows can be resumed directly.",
+  "nextBuildStep": "Add transition artifact chronology bookmark support to normalized area overlay chronology queries so bounded ordered transition review payload windows can be revisited directly.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -18,6 +18,7 @@ type RefreshRunQuery = {
   transitionArtifactIds?: string;
   transitionArtifactOffset?: string;
   transitionArtifactLimit?: string;
+  transitionArtifactCursor?: string;
   chronology?: string;
 };
 
@@ -173,6 +174,11 @@ export class ExternalOverlayController {
         req.query.transitionArtifactLimit.trim().length > 0
           ? req.query.transitionArtifactLimit.trim()
           : undefined;
+      const transitionArtifactCursor =
+        typeof req.query.transitionArtifactCursor === "string" &&
+        req.query.transitionArtifactCursor.trim().length > 0
+          ? req.query.transitionArtifactCursor.trim()
+          : undefined;
 
       if (transitionArtifactChronology) {
         const result =
@@ -190,6 +196,7 @@ export class ExternalOverlayController {
               transitionArtifactIds,
               transitionArtifactOffset,
               transitionArtifactLimit,
+              transitionArtifactCursor,
             },
           );
 

--- a/src/external-overlays/external-overlay.errors.ts
+++ b/src/external-overlays/external-overlay.errors.ts
@@ -69,3 +69,12 @@ export class MissionExternalOverlayRefreshRunTransitionArtifactChronologyPaginat
     super(message);
   }
 }
+
+export class MissionExternalOverlayRefreshRunTransitionArtifactChronologyCursorQueryInvalidError extends Error {
+  readonly statusCode = 400;
+  readonly type = "refresh_run_transition_artifact_chronology_cursor_query_invalid";
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -7,6 +7,7 @@ import {
   MissionExternalOverlayRefreshRunDiffQueryInvalidError,
   MissionExternalOverlayRefreshRunNotFoundError,
   MissionExternalOverlayRefreshRunTransitionArtifactChronologyQueryInvalidError,
+  MissionExternalOverlayRefreshRunTransitionArtifactChronologyCursorQueryInvalidError,
   MissionExternalOverlayRefreshRunTransitionArtifactChronologyPaginationQueryInvalidError,
   MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError,
   MissionExternalOverlayRefreshRunTransitionDrilldownQueryInvalidError,
@@ -315,6 +316,8 @@ type AreaOverlayRefreshRunTransitionArtifactChronology = {
     limit: number;
     nextOffset: number | null;
     previousOffset: number | null;
+    nextCursor: string | null;
+    previousCursor: string | null;
   };
 };
 
@@ -369,6 +372,40 @@ const buildAreaOverlayRefreshRunTransitionArtifact = (
   toRefreshRunId: transition.toRefreshRunId,
   transition,
 });
+
+const buildAreaOverlayRefreshRunTransitionArtifactCursor = (
+  offset: number,
+  limit: number,
+): string =>
+  Buffer.from(JSON.stringify({ offset, limit }), "utf8").toString("base64url");
+
+const parseAreaOverlayRefreshRunTransitionArtifactCursor = (
+  cursor: string,
+): { offset: number; limit: number } | null => {
+  try {
+    const decoded = Buffer.from(cursor, "base64url").toString("utf8");
+    const parsed = JSON.parse(decoded) as {
+      offset?: unknown;
+      limit?: unknown;
+    };
+
+    if (
+      !Number.isInteger(parsed.offset) ||
+      !Number.isInteger(parsed.limit) ||
+      typeof parsed.offset !== "number" ||
+      typeof parsed.limit !== "number"
+    ) {
+      return null;
+    }
+
+    return {
+      offset: parsed.offset,
+      limit: parsed.limit,
+    };
+  } catch {
+    return null;
+  }
+};
 
 const areaOverlayRefreshSummaryItemFromOverlay = (
   overlay: ExternalOverlay,
@@ -1323,6 +1360,7 @@ export class ExternalOverlayService {
       transitionArtifactIds?: string[];
       transitionArtifactOffset?: string;
       transitionArtifactLimit?: string;
+      transitionArtifactCursor?: string;
     },
   ): Promise<{
     missionId: string;
@@ -1349,12 +1387,32 @@ export class ExternalOverlayService {
     const artifacts = chronologyResult.chronology.transitions.map((transition) =>
       buildAreaOverlayRefreshRunTransitionArtifact(missionId, transition),
     );
-    const paginationOffset = filters.transitionArtifactOffset
+    let paginationOffset = filters.transitionArtifactOffset
       ? Number(filters.transitionArtifactOffset)
       : 0;
-    const paginationLimit = filters.transitionArtifactLimit
+    let paginationLimit = filters.transitionArtifactLimit
       ? Number(filters.transitionArtifactLimit)
       : Math.max(artifacts.length, 1);
+
+    if (filters.transitionArtifactCursor) {
+      if (filters.transitionArtifactOffset || filters.transitionArtifactLimit) {
+        throw new MissionExternalOverlayRefreshRunTransitionArtifactChronologyCursorQueryInvalidError(
+          "transitionArtifactCursor cannot be combined with transitionArtifactOffset or transitionArtifactLimit",
+        );
+      }
+
+      const parsedCursor = parseAreaOverlayRefreshRunTransitionArtifactCursor(
+        filters.transitionArtifactCursor,
+      );
+      if (!parsedCursor) {
+        throw new MissionExternalOverlayRefreshRunTransitionArtifactChronologyCursorQueryInvalidError(
+          "transitionArtifactCursor is invalid",
+        );
+      }
+
+      paginationOffset = parsedCursor.offset;
+      paginationLimit = parsedCursor.limit;
+    }
 
     if (
       !Number.isInteger(paginationOffset) ||
@@ -1408,6 +1466,20 @@ export class ExternalOverlayService {
       paginationOffset > 0
         ? Math.max(0, paginationOffset - paginationLimit)
         : null;
+    const nextCursor =
+      nextOffset !== null
+        ? buildAreaOverlayRefreshRunTransitionArtifactCursor(
+            nextOffset,
+            paginationLimit,
+          )
+        : null;
+    const previousCursor =
+      previousOffset !== null
+        ? buildAreaOverlayRefreshRunTransitionArtifactCursor(
+            previousOffset,
+            paginationLimit,
+          )
+        : null;
 
     return {
       missionId,
@@ -1420,6 +1492,8 @@ export class ExternalOverlayService {
           limit: paginationLimit,
           nextOffset,
           previousOffset,
+          nextCursor,
+          previousCursor,
         },
       },
     };

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -2876,6 +2876,282 @@ describe("mission external overlays integration", () => {
     });
   });
 
+  it("resumes paginated transition artifact chronology windows directly by cursor", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-2100",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-2100",
+              label: "Danger Area EGD-2100",
+              areaType: "danger_area",
+              description: "Base area",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+        ],
+      });
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B2100/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B2100-26",
+              label: "Danger Area EGD-2100 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B2100/26",
+              sourceReference: "NOTAM B2100/26",
+            },
+          },
+        ],
+      });
+
+    const thirdRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B2100/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B2100-26",
+              label: "Danger Area EGD-2100 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B2100/26",
+              sourceReference: "NOTAM B2100/26",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-2102",
+            },
+            observedAt: "2026-04-21T10:10:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5102,
+              centerLng: -0.1251,
+              radiusMeters: 250,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1100,
+            },
+            severity: "caution",
+            area: {
+              areaId: "TDA-2102",
+              label: "Temporary Danger Area 2102",
+              areaType: "temporary_danger_area",
+              description: "New area in later run",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    const fourthRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B2100/26",
+            },
+            observedAt: "2026-04-21T10:09:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "critical",
+            area: {
+              areaId: "NOTAM-B2100-26",
+              label: "Danger Area EGD-2100 NOTAM",
+              areaType: "notam_restriction",
+              description: "Superseding area",
+              authorityName: "NATS",
+              notamNumber: "B2100/26",
+              sourceReference: "NOTAM B2100/26",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-2103",
+            },
+            observedAt: "2026-04-21T10:11:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5112,
+              centerLng: -0.1241,
+              radiusMeters: 220,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            severity: "info",
+            area: {
+              areaId: "TDA-2103",
+              label: "Temporary Danger Area 2103",
+              areaType: "temporary_danger_area",
+              description: "New later area",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(secondRun.status).toBe(201);
+    expect(thirdRun.status).toBe(201);
+    expect(fourthRun.status).toBe(201);
+
+    const firstPageResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactLimit=1`,
+    );
+    const fullArtifactChronologyResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true`,
+    );
+
+    expect(firstPageResponse.status).toBe(200);
+    expect(firstPageResponse.body).toMatchObject({
+      missionId,
+      chronology: {
+        pagination: {
+          totalCount: 3,
+          offset: 0,
+          limit: 1,
+          previousCursor: null,
+        },
+      },
+    });
+    expect(firstPageResponse.body.chronology.pagination.nextCursor).toEqual(
+      expect.any(String),
+    );
+
+    const secondPageResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactCursor=${firstPageResponse.body.chronology.pagination.nextCursor}`,
+    );
+
+    expect(secondPageResponse.status).toBe(200);
+    expect(secondPageResponse.body).toMatchObject({
+      missionId,
+      chronology: {
+        pagination: {
+          totalCount: 3,
+          offset: 1,
+          limit: 1,
+          previousCursor: expect.any(String),
+        },
+      },
+    });
+    expect(secondPageResponse.body.chronology.artifacts).toEqual(
+      fullArtifactChronologyResponse.body.chronology.artifacts.slice(1, 2),
+    );
+
+    const previousPageResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactCursor=${secondPageResponse.body.chronology.pagination.previousCursor}`,
+    );
+
+    expect(previousPageResponse.status).toBe(200);
+    expect(previousPageResponse.body.chronology.artifacts).toEqual(
+      firstPageResponse.body.chronology.artifacts,
+    );
+
+    const invalidCursorResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactCursor=bad-cursor`,
+    );
+
+    expect(invalidCursorResponse.status).toBe(400);
+    expect(invalidCursorResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_transition_artifact_chronology_cursor_query_invalid",
+      },
+    });
+
+    const mixedCursorResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactCursor=${firstPageResponse.body.chronology.pagination.nextCursor}&transitionArtifactOffset=1`,
+    );
+
+    expect(mixedCursorResponse.status).toBe(400);
+    expect(mixedCursorResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_transition_artifact_chronology_cursor_query_invalid",
+      },
+    });
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #210 by adding transition artifact chronology cursor support to normalized area overlay chronology queries so bounded ordered transition review payload windows can be resumed directly.

## What changed

- Extended the mission-linked refresh-run summary read path so transition artifact chronology queries can resume bounded windows directly by cursor:
  - `GET /missions/:missionId/external-overlays/refresh-runs`
  - chronology artifact cursor query parameter:
    - `transitionArtifactChronology=true`
    - `transitionArtifactCursor`
- Kept the implementation inside the normalized area overlay ingestion / auditability boundary.
- Reused the existing chronology, artifact, filtering, and pagination model rather than introducing a separate cursor store.
- Added opaque cursor generation on top of the existing ordered transition artifact chronology windowing model.
- Added cursor metadata to the response, including:
  - `nextCursor`
  - `previousCursor`
- Preserved the existing pagination metadata:
  - `totalCount`
  - `offset`
  - `limit`
  - `nextOffset`
  - `previousOffset`
- Added explicit validation for invalid cursor queries:
  - invalid `transitionArtifactCursor`
  - combining `transitionArtifactCursor` with `transitionArtifactOffset`
  - combining `transitionArtifactCursor` with `transitionArtifactLimit`
  - invalid requests return `refresh_run_transition_artifact_chronology_cursor_query_invalid`
- Verified that cursor-based responses match the corresponding slices of the full ordered transition artifact chronology.
- Verified that next and previous windows can be resumed directly by the returned cursor metadata.
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling
  - source traceability
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
  - single-run filtering
  - direct two-run diff queries
  - chronology ordering
  - direct transition drilldown
  - transition artifact query support
  - transition artifact filtering support
  - transition artifact chronology listing support
  - transition artifact chronology filtering support
  - transition artifact chronology pagination support
- Kept conflict assessment source-agnostic and unchanged.
- Updated the save point to the next read-path refinement step:
  - transition artifact chronology bookmark support

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 23 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 354 tests.

## Notes

This issue is an ingestion-layer auditability read-path refinement only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #210.
