### PR TITLE
Add area overlay transition artifact chronology bookmark

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add transition artifact chronology bookmark support to normalized area overlay chronology queries so bounded ordered transition review payload windows can be revisited directly.",
+  "nextBuildStep": "Add transition artifact chronology snapshot export support to normalized area overlay chronology queries so bounded ordered transition review payload windows can be exported for audit review.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -19,6 +19,7 @@ type RefreshRunQuery = {
   transitionArtifactOffset?: string;
   transitionArtifactLimit?: string;
   transitionArtifactCursor?: string;
+  transitionArtifactBookmark?: string;
   chronology?: string;
 };
 
@@ -179,6 +180,11 @@ export class ExternalOverlayController {
         req.query.transitionArtifactCursor.trim().length > 0
           ? req.query.transitionArtifactCursor.trim()
           : undefined;
+      const transitionArtifactBookmark =
+        typeof req.query.transitionArtifactBookmark === "string" &&
+        req.query.transitionArtifactBookmark.trim().length > 0
+          ? req.query.transitionArtifactBookmark.trim()
+          : undefined;
 
       if (transitionArtifactChronology) {
         const result =
@@ -197,6 +203,7 @@ export class ExternalOverlayController {
               transitionArtifactOffset,
               transitionArtifactLimit,
               transitionArtifactCursor,
+              transitionArtifactBookmark,
             },
           );
 

--- a/src/external-overlays/external-overlay.errors.ts
+++ b/src/external-overlays/external-overlay.errors.ts
@@ -78,3 +78,12 @@ export class MissionExternalOverlayRefreshRunTransitionArtifactChronologyCursorQ
     super(message);
   }
 }
+
+export class MissionExternalOverlayRefreshRunTransitionArtifactChronologyBookmarkQueryInvalidError extends Error {
+  readonly statusCode = 400;
+  readonly type = "refresh_run_transition_artifact_chronology_bookmark_query_invalid";
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -7,6 +7,7 @@ import {
   MissionExternalOverlayRefreshRunDiffQueryInvalidError,
   MissionExternalOverlayRefreshRunNotFoundError,
   MissionExternalOverlayRefreshRunTransitionArtifactChronologyQueryInvalidError,
+  MissionExternalOverlayRefreshRunTransitionArtifactChronologyBookmarkQueryInvalidError,
   MissionExternalOverlayRefreshRunTransitionArtifactChronologyCursorQueryInvalidError,
   MissionExternalOverlayRefreshRunTransitionArtifactChronologyPaginationQueryInvalidError,
   MissionExternalOverlayRefreshRunTransitionArtifactQueryInvalidError,
@@ -318,6 +319,7 @@ type AreaOverlayRefreshRunTransitionArtifactChronology = {
     previousOffset: number | null;
     nextCursor: string | null;
     previousCursor: string | null;
+    bookmark: string;
   };
 };
 
@@ -401,6 +403,71 @@ const parseAreaOverlayRefreshRunTransitionArtifactCursor = (
     return {
       offset: parsed.offset,
       limit: parsed.limit,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const buildAreaOverlayRefreshRunTransitionArtifactBookmark = (
+  missionId: string,
+  offset: number,
+  limit: number,
+  artifactIds?: string[],
+): string =>
+  Buffer.from(
+    JSON.stringify({
+      missionId,
+      offset,
+      limit,
+      artifactIds: artifactIds && artifactIds.length > 0 ? artifactIds : undefined,
+    }),
+    "utf8",
+  ).toString("base64url");
+
+const parseAreaOverlayRefreshRunTransitionArtifactBookmark = (
+  bookmark: string,
+): {
+  missionId: string;
+  offset: number;
+  limit: number;
+  artifactIds?: string[];
+} | null => {
+  try {
+    const decoded = Buffer.from(bookmark, "base64url").toString("utf8");
+    const parsed = JSON.parse(decoded) as {
+      missionId?: unknown;
+      offset?: unknown;
+      limit?: unknown;
+      artifactIds?: unknown;
+    };
+
+    if (
+      typeof parsed.missionId !== "string" ||
+      parsed.missionId.length === 0 ||
+      !Number.isInteger(parsed.offset) ||
+      !Number.isInteger(parsed.limit) ||
+      typeof parsed.offset !== "number" ||
+      typeof parsed.limit !== "number"
+    ) {
+      return null;
+    }
+
+    if (
+      parsed.artifactIds !== undefined &&
+      (!Array.isArray(parsed.artifactIds) ||
+        parsed.artifactIds.some(
+          (artifactId) => typeof artifactId !== "string" || artifactId.length === 0,
+        ))
+    ) {
+      return null;
+    }
+
+    return {
+      missionId: parsed.missionId,
+      offset: parsed.offset,
+      limit: parsed.limit,
+      artifactIds: parsed.artifactIds as string[] | undefined,
     };
   } catch {
     return null;
@@ -1361,6 +1428,7 @@ export class ExternalOverlayService {
       transitionArtifactOffset?: string;
       transitionArtifactLimit?: string;
       transitionArtifactCursor?: string;
+      transitionArtifactBookmark?: string;
     },
   ): Promise<{
     missionId: string;
@@ -1387,12 +1455,45 @@ export class ExternalOverlayService {
     const artifacts = chronologyResult.chronology.transitions.map((transition) =>
       buildAreaOverlayRefreshRunTransitionArtifact(missionId, transition),
     );
+    let filteredArtifactIds = filters.transitionArtifactIds;
     let paginationOffset = filters.transitionArtifactOffset
       ? Number(filters.transitionArtifactOffset)
       : 0;
     let paginationLimit = filters.transitionArtifactLimit
       ? Number(filters.transitionArtifactLimit)
       : Math.max(artifacts.length, 1);
+
+    if (filters.transitionArtifactBookmark) {
+      if (
+        filters.transitionArtifactIds ||
+        filters.transitionArtifactOffset ||
+        filters.transitionArtifactLimit ||
+        filters.transitionArtifactCursor
+      ) {
+        throw new MissionExternalOverlayRefreshRunTransitionArtifactChronologyBookmarkQueryInvalidError(
+          "transitionArtifactBookmark cannot be combined with transitionArtifactIds, transitionArtifactOffset, transitionArtifactLimit, or transitionArtifactCursor",
+        );
+      }
+
+      const parsedBookmark = parseAreaOverlayRefreshRunTransitionArtifactBookmark(
+        filters.transitionArtifactBookmark,
+      );
+      if (!parsedBookmark) {
+        throw new MissionExternalOverlayRefreshRunTransitionArtifactChronologyBookmarkQueryInvalidError(
+          "transitionArtifactBookmark is invalid",
+        );
+      }
+
+      if (parsedBookmark.missionId !== missionId) {
+        throw new MissionExternalOverlayRefreshRunTransitionArtifactChronologyBookmarkQueryInvalidError(
+          "transitionArtifactBookmark must match the requested mission",
+        );
+      }
+
+      filteredArtifactIds = parsedBookmark.artifactIds;
+      paginationOffset = parsedBookmark.offset;
+      paginationLimit = parsedBookmark.limit;
+    }
 
     if (filters.transitionArtifactCursor) {
       if (filters.transitionArtifactOffset || filters.transitionArtifactLimit) {
@@ -1430,8 +1531,8 @@ export class ExternalOverlayService {
     }
 
     let filteredArtifacts = artifacts;
-    if (filters.transitionArtifactIds && filters.transitionArtifactIds.length > 0) {
-      for (const artifactId of filters.transitionArtifactIds) {
+    if (filteredArtifactIds && filteredArtifactIds.length > 0) {
+      for (const artifactId of filteredArtifactIds) {
         const parsedArtifactId = parseAreaOverlayRefreshRunTransitionArtifactId(
           artifactId,
         );
@@ -1448,7 +1549,7 @@ export class ExternalOverlayService {
         }
       }
 
-      const selectedArtifactIds = new Set(filters.transitionArtifactIds);
+      const selectedArtifactIds = new Set(filteredArtifactIds);
       filteredArtifacts = artifacts.filter((artifact) =>
         selectedArtifactIds.has(artifact.artifactId),
       );
@@ -1480,6 +1581,12 @@ export class ExternalOverlayService {
             paginationLimit,
           )
         : null;
+    const bookmark = buildAreaOverlayRefreshRunTransitionArtifactBookmark(
+      missionId,
+      paginationOffset,
+      paginationLimit,
+      filteredArtifactIds,
+    );
 
     return {
       missionId,
@@ -1494,6 +1601,7 @@ export class ExternalOverlayService {
           previousOffset,
           nextCursor,
           previousCursor,
+          bookmark,
         },
       },
     };

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -3093,6 +3093,7 @@ describe("mission external overlays integration", () => {
           offset: 0,
           limit: 1,
           previousCursor: null,
+          bookmark: expect.any(String),
         },
       },
     });
@@ -3148,6 +3149,183 @@ describe("mission external overlays integration", () => {
     expect(mixedCursorResponse.body).toMatchObject({
       error: {
         type: "refresh_run_transition_artifact_chronology_cursor_query_invalid",
+      },
+    });
+  });
+
+  it("revisits bounded transition artifact chronology windows directly by bookmark", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "D-BOOKMARK-1",
+            },
+            observedAt: "2026-04-21T10:00:00.000Z",
+            validFrom: "2026-04-21T09:00:00.000Z",
+            validTo: "2026-04-21T13:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5074,
+              centerLng: -0.1278,
+              radiusMeters: 200,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            severity: "caution",
+            area: {
+              areaId: "D-BOOKMARK-1",
+              label: "Danger Area Bookmark 1",
+              areaType: "danger_area",
+              authorityName: "CAA",
+            },
+          },
+        ],
+      });
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "NOTAM-BOOKMARK-2",
+            },
+            observedAt: "2026-04-21T10:30:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5074,
+              centerLng: -0.1278,
+              radiusMeters: 200,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            severity: "critical",
+            area: {
+              areaId: "D-BOOKMARK-1",
+              label: "Danger Area Bookmark 1",
+              areaType: "notam_restriction",
+              authorityName: "NATS",
+              notamNumber: "B3000/26",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-BOOKMARK-2",
+            },
+            observedAt: "2026-04-21T10:35:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5112,
+              centerLng: -0.1241,
+              radiusMeters: 220,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            severity: "info",
+            area: {
+              areaId: "TDA-BOOKMARK-2",
+              label: "Temporary Danger Area Bookmark 2",
+              areaType: "temporary_danger_area",
+              authorityName: "CAA",
+            },
+          },
+        ],
+      });
+
+    const thirdRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "NOTAM-BOOKMARK-3",
+            },
+            observedAt: "2026-04-21T11:00:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T15:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5112,
+              centerLng: -0.1241,
+              radiusMeters: 220,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            severity: "critical",
+            area: {
+              areaId: "TDA-BOOKMARK-2",
+              label: "Temporary Danger Area Bookmark 2",
+              areaType: "notam_restriction",
+              authorityName: "NATS",
+              notamNumber: "B3001/26",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(secondRun.status).toBe(201);
+    expect(thirdRun.status).toBe(201);
+
+    const fullChronologyResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true`,
+    );
+    const selectedArtifactId =
+      fullChronologyResponse.body.chronology.artifacts[1].artifactId;
+
+    const filteredWindowResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactIds=${selectedArtifactId}&transitionArtifactOffset=0&transitionArtifactLimit=1`,
+    );
+
+    expect(filteredWindowResponse.status).toBe(200);
+    expect(filteredWindowResponse.body.chronology.pagination.bookmark).toEqual(
+      expect.any(String),
+    );
+
+    const bookmarkedWindowResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactBookmark=${filteredWindowResponse.body.chronology.pagination.bookmark}`,
+    );
+
+    expect(bookmarkedWindowResponse.status).toBe(200);
+    expect(bookmarkedWindowResponse.body.chronology).toEqual(
+      filteredWindowResponse.body.chronology,
+    );
+
+    const invalidBookmarkResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactBookmark=bad-bookmark`,
+    );
+
+    expect(invalidBookmarkResponse.status).toBe(400);
+    expect(invalidBookmarkResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_transition_artifact_chronology_bookmark_query_invalid",
+      },
+    });
+
+    const mixedBookmarkResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactBookmark=${filteredWindowResponse.body.chronology.pagination.bookmark}&transitionArtifactOffset=1`,
+    );
+
+    expect(mixedBookmarkResponse.status).toBe(400);
+    expect(mixedBookmarkResponse.body).toMatchObject({
+      error: {
+        type: "refresh_run_transition_artifact_chronology_bookmark_query_invalid",
       },
     });
   });


### PR DESCRIPTION
## Summary

Implements GitHub issue #212 by adding transition artifact chronology bookmark support to normalized area overlay chronology queries so bounded ordered transition review payload windows can be revisited directly.

## What changed

- Extended the mission-linked refresh-run summary read path so transition artifact chronology queries can revisit a bounded window directly by bookmark:
  - `GET /missions/:missionId/external-overlays/refresh-runs`
  - bookmark query parameters:
    - `transitionArtifactChronology=true`
    - `transitionArtifactBookmark`
- Kept the implementation inside the normalized area overlay ingestion / auditability boundary.
- Reused the existing chronology, filtering, pagination, and cursor model rather than introducing a separate bookmark store.
- Added a self-contained bookmark format that records:
  - `missionId`
  - `offset`
  - `limit`
  - selected `artifactIds` where chronology filtering is active
- Added bookmark metadata to the transition artifact chronology response:
  - `pagination.bookmark`
- Bookmark-based requests now replay the same bounded ordered transition artifact window directly, including filtered chronology windows.
- Added explicit validation for invalid bookmark queries:
  - invalid `transitionArtifactBookmark`
  - mission mismatch in the bookmark payload
  - combining `transitionArtifactBookmark` with `transitionArtifactIds`
  - combining `transitionArtifactBookmark` with `transitionArtifactOffset`
  - combining `transitionArtifactBookmark` with `transitionArtifactLimit`
  - combining `transitionArtifactBookmark` with `transitionArtifactCursor`
  - invalid requests return `refresh_run_transition_artifact_chronology_bookmark_query_invalid`
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling
  - source traceability
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
  - single-run filtering
  - direct two-run diff queries
  - chronology ordering
  - direct transition drilldown
  - transition artifact query support
  - transition artifact filtering support
  - transition artifact chronology listing support
  - transition artifact chronology filtering support
  - transition artifact chronology pagination support
  - transition artifact chronology cursor support
- Kept conflict assessment source-agnostic and unchanged.
- Updated the save point to the next read-path refinement step:
  - transition artifact chronology snapshot export support

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 24 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 355 tests.

## Notes

This issue is an ingestion-layer auditability read-path refinement only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #212.
