### PR TITLE
Add area overlay transition artifact export

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add transition artifact chronology snapshot export support to normalized area overlay chronology queries so bounded ordered transition review payload windows can be exported for audit review.",
+  "nextBuildStep": "Add transition artifact chronology export manifest support to normalized area overlay chronology queries so exported audit snapshots include a stable manifest envelope.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.controller.ts
+++ b/src/external-overlays/external-overlay.controller.ts
@@ -20,6 +20,7 @@ type RefreshRunQuery = {
   transitionArtifactLimit?: string;
   transitionArtifactCursor?: string;
   transitionArtifactBookmark?: string;
+  transitionArtifactExport?: string;
   chronology?: string;
 };
 
@@ -185,6 +186,11 @@ export class ExternalOverlayController {
         req.query.transitionArtifactBookmark.trim().length > 0
           ? req.query.transitionArtifactBookmark.trim()
           : undefined;
+      const transitionArtifactExport =
+        typeof req.query.transitionArtifactExport === "string" &&
+        ["1", "true", "yes"].includes(
+          req.query.transitionArtifactExport.trim().toLowerCase(),
+        );
 
       if (transitionArtifactChronology) {
         const result =
@@ -204,6 +210,7 @@ export class ExternalOverlayController {
               transitionArtifactLimit,
               transitionArtifactCursor,
               transitionArtifactBookmark,
+              transitionArtifactExport,
             },
           );
 

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -323,6 +323,14 @@ type AreaOverlayRefreshRunTransitionArtifactChronology = {
   };
 };
 
+type AreaOverlayRefreshRunTransitionArtifactChronologyExport = {
+  exportId: string;
+  exportType: "refresh_run_transition_artifact_chronology_snapshot";
+  missionId: string;
+  exportedAt: string;
+  snapshot: AreaOverlayRefreshRunTransitionArtifactChronology;
+};
+
 const buildAreaOverlayRefreshRunTransitionArtifactId = (
   missionId: string,
   fromRefreshRunId: string,
@@ -473,6 +481,16 @@ const parseAreaOverlayRefreshRunTransitionArtifactBookmark = (
     return null;
   }
 };
+
+const buildAreaOverlayRefreshRunTransitionArtifactChronologyExportId = (
+  missionId: string,
+  bookmark: string,
+): string =>
+  [
+    "refresh_run_transition_artifact_chronology_snapshot",
+    missionId,
+    bookmark,
+  ].join(":");
 
 const areaOverlayRefreshSummaryItemFromOverlay = (
   overlay: ExternalOverlay,
@@ -1429,10 +1447,12 @@ export class ExternalOverlayService {
       transitionArtifactLimit?: string;
       transitionArtifactCursor?: string;
       transitionArtifactBookmark?: string;
+      transitionArtifactExport?: boolean;
     },
   ): Promise<{
     missionId: string;
     chronology: AreaOverlayRefreshRunTransitionArtifactChronology;
+    export?: AreaOverlayRefreshRunTransitionArtifactChronologyExport;
   }> {
     if (
       filters.refreshRunId ||
@@ -1604,6 +1624,35 @@ export class ExternalOverlayService {
           bookmark,
         },
       },
+      ...(filters.transitionArtifactExport
+        ? {
+            export: {
+              exportId:
+                buildAreaOverlayRefreshRunTransitionArtifactChronologyExportId(
+                  missionId,
+                  bookmark,
+                ),
+              exportType:
+                "refresh_run_transition_artifact_chronology_snapshot" as const,
+              missionId,
+              exportedAt: new Date().toISOString(),
+              snapshot: {
+                missionId,
+                artifacts: paginatedArtifacts,
+                pagination: {
+                  totalCount: filteredArtifacts.length,
+                  offset: paginationOffset,
+                  limit: paginationLimit,
+                  nextOffset,
+                  previousOffset,
+                  nextCursor,
+                  previousCursor,
+                  bookmark,
+                },
+              },
+            },
+          }
+        : {}),
     };
   }
 

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -3330,6 +3330,173 @@ describe("mission external overlays integration", () => {
     });
   });
 
+  it("exports bounded transition artifact chronology windows directly for audit review", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "D-EXPORT-1",
+            },
+            observedAt: "2026-04-21T10:00:00.000Z",
+            validFrom: "2026-04-21T09:00:00.000Z",
+            validTo: "2026-04-21T13:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5074,
+              centerLng: -0.1278,
+              radiusMeters: 200,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            severity: "caution",
+            area: {
+              areaId: "D-EXPORT-1",
+              label: "Danger Area Export 1",
+              areaType: "danger_area",
+              authorityName: "CAA",
+            },
+          },
+        ],
+      });
+
+    const secondRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "NOTAM-EXPORT-2",
+            },
+            observedAt: "2026-04-21T10:30:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5074,
+              centerLng: -0.1278,
+              radiusMeters: 200,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            severity: "critical",
+            area: {
+              areaId: "D-EXPORT-1",
+              label: "Danger Area Export 1",
+              areaType: "notam_restriction",
+              authorityName: "NATS",
+              notamNumber: "B3100/26",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-EXPORT-2",
+            },
+            observedAt: "2026-04-21T10:35:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5112,
+              centerLng: -0.1241,
+              radiusMeters: 220,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            severity: "info",
+            area: {
+              areaId: "TDA-EXPORT-2",
+              label: "Temporary Danger Area Export 2",
+              areaType: "temporary_danger_area",
+              authorityName: "CAA",
+            },
+          },
+        ],
+      });
+
+    const thirdRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "NOTAM-EXPORT-3",
+            },
+            observedAt: "2026-04-21T11:00:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T15:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5112,
+              centerLng: -0.1241,
+              radiusMeters: 220,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            severity: "critical",
+            area: {
+              areaId: "TDA-EXPORT-2",
+              label: "Temporary Danger Area Export 2",
+              areaType: "notam_restriction",
+              authorityName: "NATS",
+              notamNumber: "B3101/26",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(secondRun.status).toBe(201);
+    expect(thirdRun.status).toBe(201);
+
+    const fullChronologyResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true`,
+    );
+    const selectedArtifactId =
+      fullChronologyResponse.body.chronology.artifacts[1].artifactId;
+
+    const exportResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactExport=true&transitionArtifactIds=${selectedArtifactId}&transitionArtifactOffset=0&transitionArtifactLimit=1`,
+    );
+
+    expect(exportResponse.status).toBe(200);
+    expect(exportResponse.body).toMatchObject({
+      missionId,
+      export: {
+        exportId: expect.any(String),
+        exportType: "refresh_run_transition_artifact_chronology_snapshot",
+        missionId,
+        exportedAt: expect.any(String),
+      },
+    });
+    expect(exportResponse.body.export.snapshot).toEqual(
+      exportResponse.body.chronology,
+    );
+    expect(exportResponse.body.export.exportId).toContain(
+      exportResponse.body.chronology.pagination.bookmark,
+    );
+
+    const bookmarkedExportResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs?transitionArtifactChronology=true&transitionArtifactExport=true&transitionArtifactBookmark=${exportResponse.body.chronology.pagination.bookmark}`,
+    );
+
+    expect(bookmarkedExportResponse.status).toBe(200);
+    expect(bookmarkedExportResponse.body.export.snapshot).toEqual(
+      exportResponse.body.chronology,
+    );
+  });
+
   it("keeps weather, crewed traffic, drone traffic, and area conflict paths intact when listed together", async () => {
     const missionId = await createMission();
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #214 by adding transition artifact chronology snapshot export support to normalized area overlay chronology queries so bounded ordered transition review payload windows can be exported for audit review.

## What changed

- Extended the mission-linked refresh-run summary read path with transition artifact chronology export support:
  - `GET /missions/:missionId/external-overlays/refresh-runs`
  - export query parameters:
    - `transitionArtifactChronology=true`
    - `transitionArtifactExport=true`
- Kept the implementation inside the normalized area overlay ingestion / auditability boundary.
- Reused the existing chronology, filtering, pagination, cursor, and bookmark model rather than introducing a separate export persistence layer.
- Added a bounded export envelope that exposes:
  - `exportId`
  - `exportType`
  - `missionId`
  - `exportedAt`
  - `snapshot`
- Kept the export snapshot payload consistent with the bounded `chronology` response for the same request.
- Export mode composes with the existing chronology window controls:
  - `transitionArtifactIds`
  - `transitionArtifactOffset`
  - `transitionArtifactLimit`
  - `transitionArtifactCursor`
  - `transitionArtifactBookmark`
- Added stable export identity derived from mission id plus the bounded chronology bookmark for the exported window.
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling
  - source traceability
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
  - single-run filtering
  - direct two-run diff queries
  - chronology ordering
  - direct transition drilldown
  - transition artifact query support
  - transition artifact filtering support
  - transition artifact chronology listing support
  - transition artifact chronology filtering support
  - transition artifact chronology pagination support
  - transition artifact chronology cursor support
  - transition artifact chronology bookmark support
- Kept conflict assessment source-agnostic and unchanged.
- Updated the save point to the next read-path refinement step:
  - transition artifact chronology export manifest support

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 25 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 11 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 356 tests.

## Notes

This issue is an ingestion-layer auditability read-path refinement only. It does not add operator automation, lifecycle changes, or conflict-engine source branching.

Closes #214.
