### PR TITLE
Feature/issue 216 area overlay freshness

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Show normalized area-source freshness degradation in operator-facing review context so stale and partial refresh states are visible without changing conflict-engine branching.",
+  "nextBuildStep": "Add operator-facing area-source freshness review context so stale and partial refresh states are visible without changing conflict-engine branching.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add transition artifact chronology export manifest support to normalized area overlay chronology queries so exported audit snapshots include a stable manifest envelope.",
+  "nextBuildStep": "Surface normalized area-source freshness degradation in operator-facing review context so stale and partial refresh states are visible without changing conflict-engine branching.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Surface normalized area-source freshness degradation in operator-facing review context so stale and partial refresh states are visible without changing conflict-engine branching.",
+  "nextBuildStep": "Show normalized area-source freshness degradation in operator-facing review context so stale and partial refresh states are visible without changing conflict-engine branching.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -24,6 +24,7 @@ import type {
   ExternalOverlayKind,
   ExternalOverlayPolygonGeometry,
   NormalizeAreaOverlaySourcesInput,
+  NormalizeAreaOverlayRefreshStatus,
 } from "./external-overlay.types";
 import {
   validateCreateAreaConflictExternalOverlayInput,
@@ -125,7 +126,44 @@ const normalizedAreaMetadata = (
     supersededByRunId: null,
     retiredByRunId: null,
   },
+  sourceRefresh: {
+    status: "fresh",
+    evaluatedByRunId: refreshRunId,
+    lastSuccessfulRefreshRunId: refreshRunId,
+  },
   ...extras,
+});
+
+const isSuccessfulAreaRefreshStatus = (
+  status: NormalizeAreaOverlayRefreshStatus,
+): boolean => status === "fresh";
+
+const areaRefreshStateFromMetadata = (
+  metadata: AreaConflictOverlayMetadata,
+): NonNullable<AreaConflictOverlayMetadata["sourceRefresh"]> | null => {
+  return metadata.sourceRefresh ?? null;
+};
+
+const priorSuccessfulRefreshRunId = (
+  metadata: AreaConflictOverlayMetadata,
+): string | null =>
+  areaRefreshStateFromMetadata(metadata)?.lastSuccessfulRefreshRunId ??
+  metadata.refreshProvenance?.lastUpdatedByRunId ??
+  metadata.refreshProvenance?.createdByRunId ??
+  null;
+
+const buildAreaSourceRefreshState = (
+  refreshRunId: string,
+  refreshStatus: NormalizeAreaOverlayRefreshStatus,
+  metadata?: AreaConflictOverlayMetadata,
+): NonNullable<AreaConflictOverlayMetadata["sourceRefresh"]> => ({
+  status: refreshStatus,
+  evaluatedByRunId: refreshRunId,
+  lastSuccessfulRefreshRunId: isSuccessfulAreaRefreshStatus(refreshStatus)
+    ? refreshRunId
+    : metadata
+      ? priorSuccessfulRefreshRunId(metadata)
+      : null,
 });
 
 const sourceTraceEntryKey = (
@@ -886,6 +924,7 @@ export class ExternalOverlayService {
   ): Promise<{ missionId: string; refreshRunId: string; overlays: ExternalOverlay[] }> {
     const validated = validateNormalizeAreaOverlaySourcesInput(input);
     const refreshRunId = randomUUID();
+    const refreshStatus = validated.refresh?.status ?? "fresh";
     const client = await this.pool.connect();
 
     try {
@@ -974,6 +1013,10 @@ export class ExternalOverlayService {
                 metadata: normalizedAreaMetadata(winner, refreshRunId, {
                   dedupeKey,
                   sourceTrace,
+                  sourceRefresh: buildAreaSourceRefreshState(
+                    refreshRunId,
+                    refreshStatus,
+                  ),
                   supersession: {
                     supersededExisting: false,
                     replacedSourceType: null,
@@ -1013,6 +1056,11 @@ export class ExternalOverlayService {
                 metadata: normalizedAreaMetadata(winner, refreshRunId, {
                   dedupeKey,
                   sourceTrace: mergedTrace,
+                  sourceRefresh: buildAreaSourceRefreshState(
+                    refreshRunId,
+                    refreshStatus,
+                    existingMetadata,
+                  ),
                   supersession: {
                     supersededExisting: true,
                     replacedSourceType: existing.source.sourceType,
@@ -1076,6 +1124,11 @@ export class ExternalOverlayService {
                   retiredAt: null,
                   reason: null,
                 },
+                sourceRefresh: buildAreaSourceRefreshState(
+                  refreshRunId,
+                  refreshStatus,
+                  existingMetadata,
+                ),
                 refreshProvenance: {
                   createdByRunId:
                     existingMetadata.refreshProvenance?.createdByRunId ?? refreshRunId,
@@ -1090,43 +1143,76 @@ export class ExternalOverlayService {
         );
       }
 
-      const retirementTimestamp = new Date().toISOString();
-      for (const overlay of existingAreaOverlays) {
-        if (isRetiredAreaOverlay(overlay)) {
-          continue;
-        }
+      if (isSuccessfulAreaRefreshStatus(refreshStatus)) {
+        const retirementTimestamp = new Date().toISOString();
+        for (const overlay of existingAreaOverlays) {
+          if (isRetiredAreaOverlay(overlay)) {
+            continue;
+          }
 
-        const dedupeKey = dedupeKeyFromOverlay(overlay);
-        if (
-          !dedupeKey ||
-          processedDedupeKeys.has(dedupeKey) ||
-          !isNormalizedAreaOverlay(overlay)
-        ) {
-          continue;
-        }
+          const dedupeKey = dedupeKeyFromOverlay(overlay);
+          if (
+            !dedupeKey ||
+            processedDedupeKeys.has(dedupeKey) ||
+            !isNormalizedAreaOverlay(overlay)
+          ) {
+            continue;
+          }
 
-        const metadata = areaMetadataFromOverlay(overlay);
-        await this.externalOverlayRepository.retireAreaConflictOverlay(
-          client,
-          overlay.id,
-          missionId,
-          {
-            ...metadata,
-            retirement: {
-              retired: true,
-              retiredAt: retirementTimestamp,
-              reason: "missing_from_refresh",
+          const metadata = areaMetadataFromOverlay(overlay);
+          await this.externalOverlayRepository.retireAreaConflictOverlay(
+            client,
+            overlay.id,
+            missionId,
+            {
+              ...metadata,
+              retirement: {
+                retired: true,
+                retiredAt: retirementTimestamp,
+                reason: "missing_from_refresh",
+              },
+              sourceRefresh: buildAreaSourceRefreshState(
+                refreshRunId,
+                refreshStatus,
+                metadata,
+              ),
+              refreshProvenance: {
+                createdByRunId:
+                  metadata.refreshProvenance?.createdByRunId ?? refreshRunId,
+                lastUpdatedByRunId: refreshRunId,
+                supersededByRunId:
+                  metadata.refreshProvenance?.supersededByRunId ?? null,
+                retiredByRunId: refreshRunId,
+              },
             },
-            refreshProvenance: {
-              createdByRunId:
-                metadata.refreshProvenance?.createdByRunId ?? refreshRunId,
-              lastUpdatedByRunId: refreshRunId,
-              supersededByRunId:
-                metadata.refreshProvenance?.supersededByRunId ?? null,
-              retiredByRunId: refreshRunId,
+          );
+        }
+      } else {
+        for (const overlay of existingAreaOverlays) {
+          if (isRetiredAreaOverlay(overlay) || !isNormalizedAreaOverlay(overlay)) {
+            continue;
+          }
+
+          const dedupeKey = dedupeKeyFromOverlay(overlay);
+          if (dedupeKey && processedDedupeKeys.has(dedupeKey)) {
+            continue;
+          }
+
+          const metadata = areaMetadataFromOverlay(overlay);
+          await this.externalOverlayRepository.retireAreaConflictOverlay(
+            client,
+            overlay.id,
+            missionId,
+            {
+              ...metadata,
+              sourceRefresh: buildAreaSourceRefreshState(
+                refreshRunId,
+                refreshStatus,
+                metadata,
+              ),
             },
-          },
-        );
+          );
+        }
       }
 
       return {

--- a/src/external-overlays/external-overlay.types.ts
+++ b/src/external-overlays/external-overlay.types.ts
@@ -110,7 +110,18 @@ export interface AreaConflictOverlayMetadata {
     supersededByRunId: string | null;
     retiredByRunId: string | null;
   } | null;
+  sourceRefresh?: {
+    status: "fresh" | "stale" | "partial" | "failed";
+    evaluatedByRunId: string;
+    lastSuccessfulRefreshRunId: string | null;
+  } | null;
 }
+
+export type NormalizeAreaOverlayRefreshStatus =
+  | "fresh"
+  | "stale"
+  | "partial"
+  | "failed";
 
 export interface ExternalOverlay {
   id: string;
@@ -284,6 +295,9 @@ export interface NormalizeAreaOverlaySourceRecordInput {
 
 export interface NormalizeAreaOverlaySourcesInput {
   records: NormalizeAreaOverlaySourceRecordInput[];
+  refresh?: {
+    status: NormalizeAreaOverlayRefreshStatus;
+  };
 }
 
 export interface ListExternalOverlaysFilters {

--- a/src/external-overlays/external-overlay.validators.ts
+++ b/src/external-overlays/external-overlay.validators.ts
@@ -2,6 +2,7 @@ import type {
   CreateAreaConflictExternalOverlayInput,
   CreateCrewedTrafficExternalOverlayInput,
   CreateDroneTrafficExternalOverlayInput,
+  NormalizeAreaOverlayRefreshStatus,
   CreateWeatherExternalOverlayInput,
   ExternalOverlaySeverity,
   NormalizeAreaOverlaySourcesInput,
@@ -14,6 +15,12 @@ const AREA_SOURCE_TYPES = [
   "temporary_danger_area",
   "notam_restriction",
 ] as const;
+const AREA_REFRESH_STATUSES: NormalizeAreaOverlayRefreshStatus[] = [
+  "fresh",
+  "stale",
+  "partial",
+  "failed",
+];
 
 const requiredString = (value: unknown, fieldName: string): string => {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -435,8 +442,31 @@ export const validateNormalizeAreaOverlaySourcesInput = (
   }
 
   const candidate = input as Record<string, unknown>;
-  if (!Array.isArray(candidate.records) || candidate.records.length === 0) {
-    throw new Error("records must be a non-empty array");
+  const refresh =
+    candidate.refresh && typeof candidate.refresh === "object"
+      ? (candidate.refresh as Record<string, unknown>)
+      : null;
+  const refreshStatus =
+    refresh?.status == null
+      ? "fresh"
+      : requiredString(refresh.status, "refresh.status").toLowerCase();
+
+  if (
+    !AREA_REFRESH_STATUSES.includes(
+      refreshStatus as NormalizeAreaOverlayRefreshStatus,
+    )
+  ) {
+    throw new Error(
+      "refresh.status must be one of: fresh, stale, partial, failed",
+    );
+  }
+
+  if (!Array.isArray(candidate.records)) {
+    throw new Error("records must be an array");
+  }
+
+  if (candidate.records.length === 0 && refreshStatus !== "failed") {
+    throw new Error("records must be a non-empty array unless refresh.status is 'failed'");
   }
 
   return {
@@ -539,5 +569,8 @@ export const validateNormalizeAreaOverlaySourcesInput = (
         },
       };
     }),
+    refresh: {
+      status: refreshStatus as NormalizeAreaOverlayRefreshStatus,
+    },
   };
 };

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -532,6 +532,11 @@ describe("mission external overlays integration", () => {
               supersededByRunId: null,
               retiredByRunId: null,
             }),
+            sourceRefresh: {
+              status: "fresh",
+              evaluatedByRunId: normalizeResponse.body.refreshRunId,
+              lastSuccessfulRefreshRunId: normalizeResponse.body.refreshRunId,
+            },
           }),
         }),
         expect.objectContaining({
@@ -552,6 +557,11 @@ describe("mission external overlays integration", () => {
               supersededByRunId: null,
               retiredByRunId: null,
             }),
+            sourceRefresh: {
+              status: "fresh",
+              evaluatedByRunId: normalizeResponse.body.refreshRunId,
+              lastSuccessfulRefreshRunId: normalizeResponse.body.refreshRunId,
+            },
           }),
         }),
       ],
@@ -672,6 +682,88 @@ describe("mission external overlays integration", () => {
 
     expect(listResponse.status).toBe(200);
     expect(listResponse.body.overlays).toHaveLength(1);
+  });
+
+  it("marks normalized area overlays stale without losing the last successful refresh provenance", async () => {
+    const missionId = await createMission();
+
+    const freshRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-FRESH-1",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-FRESH-1",
+              label: "Danger Area Fresh 1",
+              areaType: "danger_area",
+              authorityName: "CAA",
+            },
+          },
+        ],
+      });
+
+    const staleRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        refresh: {
+          status: "stale",
+        },
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-FRESH-1",
+            },
+            observedAt: "2026-04-21T10:17:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            severity: "caution",
+            area: {
+              areaId: "EGD-FRESH-1",
+              label: "Danger Area Fresh 1",
+              areaType: "danger_area",
+              authorityName: "CAA",
+            },
+          },
+        ],
+      });
+
+    expect(freshRun.status).toBe(201);
+    expect(staleRun.status).toBe(201);
+    expect(staleRun.body.overlays).toHaveLength(1);
+    expect(staleRun.body.overlays[0].metadata).toMatchObject({
+      sourceRefresh: {
+        status: "stale",
+        evaluatedByRunId: staleRun.body.refreshRunId,
+        lastSuccessfulRefreshRunId: freshRun.body.refreshRunId,
+      },
+    });
   });
 
   it("supersedes an existing lower-priority normalized area overlay on a later normalization run", async () => {
@@ -993,6 +1085,190 @@ describe("mission external overlays integration", () => {
       createdByRunId: firstRunId,
       lastUpdatedByRunId: secondRun.body.refreshRunId,
       retiredByRunId: secondRun.body.refreshRunId,
+    });
+  });
+
+  it("does not retire missing normalized area overlays during degraded partial refreshes", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-PARTIAL-1",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            area: {
+              areaId: "EGD-PARTIAL-1",
+              label: "Danger Area Partial 1",
+              areaType: "danger_area",
+              authorityName: "CAA",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-PARTIAL-1",
+            },
+            observedAt: "2026-04-21T10:08:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5091,
+              centerLng: -0.1261,
+              radiusMeters: 280,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            area: {
+              areaId: "TDA-PARTIAL-1",
+              label: "Temporary Danger Area Partial 1",
+              areaType: "temporary_danger_area",
+              authorityName: "CAA",
+            },
+          },
+        ],
+      });
+
+    const partialRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        refresh: {
+          status: "partial",
+        },
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-PARTIAL-1",
+            },
+            observedAt: "2026-04-21T10:18:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5091,
+              centerLng: -0.1261,
+              radiusMeters: 280,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            area: {
+              areaId: "TDA-PARTIAL-1",
+              label: "Temporary Danger Area Partial 1",
+              areaType: "temporary_danger_area",
+              authorityName: "CAA",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(partialRun.status).toBe(201);
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays?kind=area_conflict`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.overlays).toHaveLength(2);
+    expect(listResponse.body.overlays).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            areaId: "EGD-PARTIAL-1",
+            retirement: {
+              retired: false,
+              retiredAt: null,
+              reason: null,
+            },
+            sourceRefresh: {
+              status: "partial",
+              evaluatedByRunId: partialRun.body.refreshRunId,
+              lastSuccessfulRefreshRunId: firstRun.body.refreshRunId,
+            },
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("allows failed refresh runs with no records and preserves active overlays with failed freshness state", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-FAILED-1",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            area: {
+              areaId: "EGD-FAILED-1",
+              label: "Danger Area Failed 1",
+              areaType: "danger_area",
+              authorityName: "CAA",
+            },
+          },
+        ],
+      });
+
+    const failedRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        refresh: {
+          status: "failed",
+        },
+        records: [],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(failedRun.status).toBe(201);
+    expect(failedRun.body.overlays).toEqual([]);
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays?kind=area_conflict`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.overlays).toHaveLength(1);
+    expect(listResponse.body.overlays[0].metadata).toMatchObject({
+      sourceRefresh: {
+        status: "failed",
+        evaluatedByRunId: failedRun.body.refreshRunId,
+        lastSuccessfulRefreshRunId: firstRun.body.refreshRunId,
+      },
     });
   });
 

--- a/src/tests/traffic-conflict-assessment.test.ts
+++ b/src/tests/traffic-conflict-assessment.test.ts
@@ -843,6 +843,126 @@ describe("traffic conflict assessment integration", () => {
     ).toBe(false);
   });
 
+  it("keeps prior normalized area overlays active during partial refreshes so incomplete source pictures do not retire them", async () => {
+    const missionId = await createMission();
+    await recordTelemetry(missionId);
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-903",
+            },
+            observedAt: "2026-04-21T12:00:10.000Z",
+            validFrom: "2026-04-21T12:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5075,
+              centerLng: -0.1277,
+              radiusMeters: 150,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            area: {
+              areaId: "EGD-903",
+              label: "Danger Area EGD-903",
+              areaType: "danger_area",
+              description: "Should remain active in partial refresh",
+              authorityName: "CAA",
+              sourceReference: "ENR 5.1",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-903",
+            },
+            observedAt: "2026-04-21T12:00:20.000Z",
+            validFrom: "2026-04-21T12:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5095,
+              centerLng: -0.1267,
+              radiusMeters: 150,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            area: {
+              areaId: "TDA-903",
+              label: "Temporary Danger Area 903",
+              areaType: "temporary_danger_area",
+              description: "Still refreshed",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        refresh: {
+          status: "partial",
+        },
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-903",
+            },
+            observedAt: "2026-04-21T12:01:20.000Z",
+            validFrom: "2026-04-21T12:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5095,
+              centerLng: -0.1267,
+              radiusMeters: 150,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1000,
+            },
+            area: {
+              areaId: "TDA-903",
+              label: "Temporary Danger Area 903",
+              areaType: "temporary_danger_area",
+              description: "Still refreshed",
+              authorityName: "CAA",
+              sourceReference: "Temporary activation notice",
+            },
+          },
+        ],
+      });
+
+    const response = await request(app).get(
+      `/missions/${missionId}/conflict-assessment`,
+    );
+
+    expect(response.status).toBe(200);
+    const areaConflicts = response.body.assessment.conflicts.filter(
+      (item: { overlayKind: string }) => item.overlayKind === "area_conflict",
+    );
+    expect(areaConflicts).toHaveLength(2);
+    expect(
+      areaConflicts.some(
+        (item: { overlayLabel: string }) => item.overlayLabel === "Danger Area EGD-903",
+      ),
+    ).toBe(true);
+    expect(
+      areaConflicts.some(
+        (item: { overlayLabel: string }) => item.overlayLabel === "Temporary Danger Area 903",
+      ),
+    ).toBe(true);
+  });
+
   it("preserves mission isolation for conflict assessment reads", async () => {
     const firstMissionId = await createMission();
     const secondMissionId = await createMission();

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -65,6 +65,8 @@ const toneClass = (value) => {
   if (
     text.includes("review") ||
     text.includes("pending") ||
+    text.includes("stale") ||
+    text.includes("partial") ||
     text.includes("missing") ||
     text.includes("draft") ||
     text.includes("submitted")
@@ -75,6 +77,7 @@ const toneClass = (value) => {
   if (
     text.includes("blocked") ||
     text.includes("rejected") ||
+    text.includes("failed") ||
     text.includes("fail") ||
     text.includes("abort")
   ) {
@@ -110,6 +113,65 @@ const droneTrafficOverlays = () =>
   (uiState.externalOverlays ?? []).filter(
     (overlay) => overlay.kind === "drone_traffic",
   );
+
+const areaConflictOverlays = () =>
+  (uiState.externalOverlays ?? []).filter(
+    (overlay) => overlay.kind === "area_conflict",
+  );
+
+const areaOverlaySourceRefreshState = (overlay) =>
+  overlay?.metadata?.sourceRefresh ?? null;
+
+const areaOverlaySourceRefreshDetail = (overlay) => {
+  const refreshState = areaOverlaySourceRefreshState(overlay);
+  if (!refreshState) {
+    return "Not recorded";
+  }
+
+  return `${refreshState.status} | last successful ${formatDateTime(refreshState.lastSuccessfulRefreshRunId)}`;
+};
+
+const areaSourceRefreshSummary = () => {
+  const overlays = areaConflictOverlays();
+  if (overlays.length === 0) {
+    return {
+      label: "Area source refresh missing",
+      detail: "No normalized area overlays are currently available.",
+    };
+  }
+
+  const statuses = overlays
+    .map((overlay) => areaOverlaySourceRefreshState(overlay)?.status)
+    .filter(Boolean);
+  const highestPriorityStatus =
+    statuses.find((status) => status === "failed") ??
+    statuses.find((status) => status === "partial") ??
+    statuses.find((status) => status === "stale") ??
+    statuses.find((status) => status === "fresh") ??
+    "missing";
+  const degradedCount = overlays.filter((overlay) => {
+    const status = areaOverlaySourceRefreshState(overlay)?.status;
+    return status && status !== "fresh";
+  }).length;
+  const latestSuccessfulRefresh = overlays
+    .map((overlay) => areaOverlaySourceRefreshState(overlay)?.lastSuccessfulRefreshRunId)
+    .filter(Boolean)
+    .sort()
+    .at(-1);
+
+  return {
+    label:
+      highestPriorityStatus === "fresh"
+        ? "Fresh"
+        : highestPriorityStatus === "missing"
+          ? "Missing"
+          : `${highestPriorityStatus} (${degradedCount})`,
+    detail:
+      latestSuccessfulRefresh != null
+        ? `Last successful refresh ${formatDateTime(latestSuccessfulRefresh)}`
+        : "No successful refresh recorded",
+  };
+};
 
 const formatDateTime = (value) => {
   if (!value) {
@@ -1880,6 +1942,7 @@ const renderStatus = () => {
   const weatherState = weatherSummary();
   const trafficState = crewedTrafficSummary();
   const droneState = droneTrafficSummary();
+  const areaSourceState = areaSourceRefreshSummary();
   const conflictState = conflictAssessmentSummary();
   const advisoryState = conflictAdvisorySummary();
   const replayConflictRelation = currentConflictReplayRelation();
@@ -2056,6 +2119,10 @@ const renderStatus = () => {
               ? formatDateTime(activeDroneTrafficOverlays()[0].observedAt)
               : "Not recorded",
           )}</div>
+          <div class="k">Area source refresh</div>
+          <div>${renderBadge(areaSourceState.label)}</div>
+          <div class="k">Area refresh detail</div>
+          <div>${escapeHtml(areaSourceState.detail)}</div>
           <div class="k">Conflict assessment</div>
           <div>${renderBadge(conflictState.label)}</div>
           <div class="k">Primary conflict</div>
@@ -2267,6 +2334,12 @@ const renderConflictAssessment = () => {
                 <div class="alert-window-meta">
                   Source: ${escapeHtml(primaryConflict.relatedSource.provider)} / ${escapeHtml(primaryConflict.relatedSource.sourceType)}<br />
                   Observed: ${escapeHtml(formatDateTime(primaryConflict.overlayObservedAt))}<br />
+                  ${
+                    primaryConflict.overlayKind === "area_conflict"
+                      ? `Area source refresh: ${escapeHtml(areaOverlaySourceRefreshDetail(areaConflictOverlays().find((overlay) => overlay.id === primaryConflict.overlayId)))}
+                  <br />`
+                      : ""
+                  }
                   Range / bearing: ${escapeHtml(formatRangeBearing(primaryConflict.metrics))}<br />
                   Time relevance: ${escapeHtml(primaryConflict.overlayKind === "area_conflict" ? formatTemporalContext(primaryConflict) : "Not applicable")}<br />
                   Vertical context: ${escapeHtml(primaryConflict.overlayKind === "area_conflict" ? formatVerticalContext(primaryConflict) : formatVerticalSeparation(primaryConflict.metrics?.altitudeDeltaFt))}<br />
@@ -2285,7 +2358,7 @@ const renderConflictAssessment = () => {
             : renderList(
                 secondaryConflicts.map((conflict) => ({
                   label: `${conflict.overlayLabel} | ${conflict.severity}`,
-                  value: `${formatRangeBearing(conflict.metrics)} | ${conflict.overlayKind === "area_conflict" ? formatVerticalContext(conflict) : `${formatVerticalSeparation(conflict.metrics?.altitudeDeltaFt)} vertical`}`,
+                  value: `${formatRangeBearing(conflict.metrics)} | ${conflict.overlayKind === "area_conflict" ? `${formatVerticalContext(conflict)} | ${areaOverlaySourceRefreshDetail(areaConflictOverlays().find((overlay) => overlay.id === conflict.overlayId))}` : `${formatVerticalSeparation(conflict.metrics?.altitudeDeltaFt)} vertical`}`,
                 })),
                 "additional conflicts",
               )


### PR DESCRIPTION
## Summary

Implements GitHub issue #216 by adding freshness and partial-refresh handling to normalized area overlay ingestion so authoritative danger areas and NOTAM-derived restrictions remain operationally trustworthy during stale, partial, or failed source updates.

## What changed

- Added normalized area overlay source refresh metadata:
  - `sourceRefresh.status`
  - `sourceRefresh.evaluatedByRunId`
  - `sourceRefresh.lastSuccessfulRefreshRunId`
- Extended normalized area-source ingestion to accept refresh-level status:
  - `refresh.status`
  - supported values:
    - `fresh`
    - `stale`
    - `partial`
    - `failed`
- Preserved the existing normalized overlay model, source traceability, and refresh-run provenance model.
- Defined refresh handling as follows:
  - `fresh` refreshes behave as the authoritative complete source picture
  - `fresh` refreshes can retire previously-normalized overlays that disappear from the later refresh
  - `stale`, `partial`, and `failed` refreshes do not retire missing overlays
  - instead, carried-forward normalized overlays are marked with degraded `sourceRefresh` state
- Allowed failed refresh runs with no records so the ingestion boundary can record failed source-state evaluation without pretending a complete fresh refresh occurred.
- Surfaced normalized area-source refresh state in the live-ops review path so degraded freshness is visible in operator-facing posture and conflict review context.
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling on complete fresh refreshes
  - source traceability
  - refresh-run provenance
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
- Kept conflict assessment source-agnostic. It still consumes normalized area overlays without source-specific branching logic.
- Updated the save point to the next logical step:
  - surface normalized area-source freshness degradation in operator-facing review context

## Verification

- `npm.cmd run build` passed.
- `npm.cmd run build:runtime` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 28 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\traffic-conflict-assessment.test.ts` passed: 12 tests.
- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 360 tests.

## Notes

This issue refines normalized area overlay ingestion robustness and review visibility only. It does not add operator command automation or source-specific conflict-engine branching.

Closes #216.
