### PR TITLE
Add failed area refresh provenance

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add operator-facing area-source freshness review context so stale and partial refresh states are visible without changing conflict-engine branching.",
+  "nextBuildStep": "Surface failed-refresh provenance in operator-facing review context so unsuccessful authoritative updates are distinguishable from stale carried-forward overlay state.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Surface failed-refresh provenance in operator-facing review context so unsuccessful authoritative updates are distinguishable from stale carried-forward overlay state.",
+  "nextBuildStep": "Add failed-refresh provenance to operator-facing review context so unsuccessful authoritative updates are distinguishable from stale carried-forward overlay state.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -130,6 +130,8 @@ const normalizedAreaMetadata = (
     status: "fresh",
     evaluatedByRunId: refreshRunId,
     lastSuccessfulRefreshRunId: refreshRunId,
+    lastFailedRefreshRunId: null,
+    carriedForwardFromFailedRefresh: false,
   },
   ...extras,
 });
@@ -152,6 +154,10 @@ const priorSuccessfulRefreshRunId = (
   metadata.refreshProvenance?.createdByRunId ??
   null;
 
+const priorFailedRefreshRunId = (
+  metadata: AreaConflictOverlayMetadata,
+): string | null => areaRefreshStateFromMetadata(metadata)?.lastFailedRefreshRunId ?? null;
+
 const buildAreaSourceRefreshState = (
   refreshRunId: string,
   refreshStatus: NormalizeAreaOverlayRefreshStatus,
@@ -164,6 +170,13 @@ const buildAreaSourceRefreshState = (
     : metadata
       ? priorSuccessfulRefreshRunId(metadata)
       : null,
+  lastFailedRefreshRunId:
+    refreshStatus === "failed"
+      ? refreshRunId
+      : metadata
+        ? priorFailedRefreshRunId(metadata)
+        : null,
+  carriedForwardFromFailedRefresh: refreshStatus === "failed",
 });
 
 const sourceTraceEntryKey = (
@@ -307,6 +320,7 @@ type AreaOverlayRefreshRunSummary = {
   missionId: string;
   created: AreaOverlayRefreshRunSummaryItem[];
   updated: AreaOverlayRefreshRunSummaryItem[];
+  failed: AreaOverlayRefreshRunSummaryItem[];
   superseded: AreaOverlayRefreshRunSummaryItem[];
   retired: AreaOverlayRefreshRunSummaryItem[];
   active: AreaOverlayRefreshRunSummaryItem[];
@@ -562,6 +576,7 @@ const buildAreaOverlayRefreshRunSummaries = (
       missionId,
       created: [],
       updated: [],
+      failed: [],
       superseded: [],
       retired: [],
       active: [],
@@ -581,8 +596,13 @@ const buildAreaOverlayRefreshRunSummaries = (
     }
 
     const summaryItem = areaOverlayRefreshSummaryItemFromOverlay(overlay);
+    const sourceRefresh = areaMetadataFromOverlay(overlay).sourceRefresh;
     ensureSummary(provenance.createdByRunId).created.push(summaryItem);
     ensureSummary(provenance.lastUpdatedByRunId).updated.push(summaryItem);
+
+    if (sourceRefresh?.lastFailedRefreshRunId) {
+      ensureSummary(sourceRefresh.lastFailedRefreshRunId).failed.push(summaryItem);
+    }
 
     if (provenance.supersededByRunId) {
       ensureSummary(provenance.supersededByRunId).superseded.push(summaryItem);
@@ -641,6 +661,7 @@ const buildRefreshRunOrder = (overlays: ExternalOverlay[]): Map<string, number> 
     }
 
     const provenance = areaMetadataFromOverlay(overlay).refreshProvenance;
+    const sourceRefresh = areaMetadataFromOverlay(overlay).sourceRefresh;
     if (!provenance) {
       continue;
     }
@@ -662,6 +683,24 @@ const buildRefreshRunOrder = (overlays: ExternalOverlay[]): Map<string, number> 
       addEdge(provenance.lastUpdatedByRunId, provenance.retiredByRunId);
       if (provenance.supersededByRunId) {
         addEdge(provenance.supersededByRunId, provenance.retiredByRunId);
+      }
+    }
+
+    if (sourceRefresh?.lastFailedRefreshRunId) {
+      ensureNode(sourceRefresh.lastFailedRefreshRunId);
+
+      if (
+        sourceRefresh.lastSuccessfulRefreshRunId &&
+        sourceRefresh.lastSuccessfulRefreshRunId !== sourceRefresh.lastFailedRefreshRunId
+      ) {
+        addEdge(
+          sourceRefresh.lastSuccessfulRefreshRunId,
+          sourceRefresh.lastFailedRefreshRunId,
+        );
+      }
+
+      if (sourceRefresh.evaluatedByRunId !== sourceRefresh.lastFailedRefreshRunId) {
+        addEdge(sourceRefresh.lastFailedRefreshRunId, sourceRefresh.evaluatedByRunId);
       }
     }
   }

--- a/src/external-overlays/external-overlay.types.ts
+++ b/src/external-overlays/external-overlay.types.ts
@@ -114,6 +114,8 @@ export interface AreaConflictOverlayMetadata {
     status: "fresh" | "stale" | "partial" | "failed";
     evaluatedByRunId: string;
     lastSuccessfulRefreshRunId: string | null;
+    lastFailedRefreshRunId: string | null;
+    carriedForwardFromFailedRefresh: boolean;
   } | null;
 }
 

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -536,6 +536,8 @@ describe("mission external overlays integration", () => {
               status: "fresh",
               evaluatedByRunId: normalizeResponse.body.refreshRunId,
               lastSuccessfulRefreshRunId: normalizeResponse.body.refreshRunId,
+              lastFailedRefreshRunId: null,
+              carriedForwardFromFailedRefresh: false,
             },
           }),
         }),
@@ -561,6 +563,8 @@ describe("mission external overlays integration", () => {
               status: "fresh",
               evaluatedByRunId: normalizeResponse.body.refreshRunId,
               lastSuccessfulRefreshRunId: normalizeResponse.body.refreshRunId,
+              lastFailedRefreshRunId: null,
+              carriedForwardFromFailedRefresh: false,
             },
           }),
         }),
@@ -762,6 +766,8 @@ describe("mission external overlays integration", () => {
         status: "stale",
         evaluatedByRunId: staleRun.body.refreshRunId,
         lastSuccessfulRefreshRunId: freshRun.body.refreshRunId,
+        lastFailedRefreshRunId: null,
+        carriedForwardFromFailedRefresh: false,
       },
     });
   });
@@ -1203,6 +1209,8 @@ describe("mission external overlays integration", () => {
               status: "partial",
               evaluatedByRunId: partialRun.body.refreshRunId,
               lastSuccessfulRefreshRunId: firstRun.body.refreshRunId,
+              lastFailedRefreshRunId: null,
+              carriedForwardFromFailedRefresh: false,
             },
           }),
         }),
@@ -1268,8 +1276,150 @@ describe("mission external overlays integration", () => {
         status: "failed",
         evaluatedByRunId: failedRun.body.refreshRunId,
         lastSuccessfulRefreshRunId: firstRun.body.refreshRunId,
+        lastFailedRefreshRunId: failedRun.body.refreshRunId,
+        carriedForwardFromFailedRefresh: true,
       },
     });
+  });
+
+  it("records failed refresh provenance in refresh-run summaries and preserves it after a later fresh recovery", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-FAILED-2200",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            area: {
+              areaId: "EGD-FAILED-2200",
+              label: "Danger Area Failed 2200",
+              areaType: "danger_area",
+              authorityName: "CAA",
+            },
+          },
+        ],
+      });
+
+    const failedRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        refresh: {
+          status: "failed",
+        },
+        records: [],
+      });
+
+    const recoveryRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-FAILED-2200",
+            },
+            observedAt: "2026-04-21T10:27:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            area: {
+              areaId: "EGD-FAILED-2200",
+              label: "Danger Area Failed 2200",
+              areaType: "danger_area",
+              authorityName: "CAA",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(failedRun.status).toBe(201);
+    expect(recoveryRun.status).toBe(201);
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays?kind=area_conflict`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.overlays).toHaveLength(1);
+    expect(listResponse.body.overlays[0].metadata).toMatchObject({
+      sourceRefresh: {
+        status: "fresh",
+        evaluatedByRunId: recoveryRun.body.refreshRunId,
+        lastSuccessfulRefreshRunId: recoveryRun.body.refreshRunId,
+        lastFailedRefreshRunId: failedRun.body.refreshRunId,
+        carriedForwardFromFailedRefresh: false,
+      },
+    });
+
+    const summaryResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs`,
+    );
+
+    expect(summaryResponse.status).toBe(200);
+    expect(summaryResponse.body.refreshRuns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          refreshRunId: failedRun.body.refreshRunId,
+          missionId,
+          created: [],
+          updated: [],
+          failed: [
+            expect.objectContaining({
+              areaId: "EGD-FAILED-2200",
+              sourceType: "danger_area",
+              retired: false,
+            }),
+          ],
+          superseded: [],
+          retired: [],
+          active: [],
+        }),
+        expect.objectContaining({
+          refreshRunId: recoveryRun.body.refreshRunId,
+          missionId,
+          failed: [],
+          updated: [
+            expect.objectContaining({
+              areaId: "EGD-FAILED-2200",
+              sourceType: "danger_area",
+              retired: false,
+            }),
+          ],
+          active: [
+            expect.objectContaining({
+              areaId: "EGD-FAILED-2200",
+              sourceType: "danger_area",
+              retired: false,
+            }),
+          ],
+        }),
+      ]),
+    );
   });
 
   it("returns refresh-run summaries and supports filtering a single authoritative snapshot", async () => {
@@ -1369,6 +1519,7 @@ describe("mission external overlays integration", () => {
             }),
           ],
           updated: [],
+          failed: [],
           superseded: [],
           retired: [],
           active: [],
@@ -1384,6 +1535,7 @@ describe("mission external overlays integration", () => {
               retired: false,
             }),
           ],
+          failed: [],
           superseded: [
             expect.objectContaining({
               areaId: "NOTAM-B1200-26",


### PR DESCRIPTION
## Summary

Implements GitHub issue #218 by adding failed-refresh provenance to normalized area overlay ingestion so unsuccessful authoritative refresh attempts remain reviewable without being mistaken for successful source updates.

## What changed

- Added failed-refresh provenance to normalized area overlay `sourceRefresh` metadata:
  - `lastFailedRefreshRunId`
  - `carriedForwardFromFailedRefresh`
- Preserved the existing freshness model:
  - `fresh`
  - `stale`
  - `partial`
  - `failed`
- Preserved the existing refresh provenance model:
  - `createdByRunId`
  - `lastUpdatedByRunId`
  - `supersededByRunId`
  - `retiredByRunId`
- Defined failed-refresh handling as follows:
  - failed refresh attempts do not retire missing overlays
  - carried-forward overlays record the failed run id explicitly
  - carried-forward overlays mark whether the current state exists because of a failed refresh attempt
  - later fresh recovery preserves the last failed refresh provenance instead of erasing it
- Extended refresh-run summaries so failed refresh attempts are reviewable directly:
  - added `failed` items to the existing refresh-run summary model
- Updated refresh-run ordering so failed refresh attempts are included in chronology where provenance makes their ordering inferable
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling on complete fresh refreshes
  - source traceability
  - freshness handling for fresh / stale / partial / failed states
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
- Kept conflict assessment source-agnostic. It still consumes normalized area overlays without source-specific branching logic.
- Updated the save point to the next logical step:
  - surface failed-refresh provenance in operator-facing review context

## Verification

- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 361 tests.

## Notes

This issue refines normalized area overlay ingestion robustness and auditability only. It does not add operator command automation or source-specific conflict-engine branching.

Closes #218.
