### PR TITLE
Show failed refresh review state in live ops

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add failed-refresh provenance to operator-facing review context so unsuccessful authoritative updates are distinguishable from stale carried-forward overlay state.",
+  "nextBuildStep": "Add failed-refresh review context to operator-facing conflict summary cards so degraded authoritative area state is visible at a glance.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2065,6 +2065,10 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("conflictProximityEnvelopeSummary");
     expect(response.text).toContain("conflictEnvelopeRadius");
     expect(response.text).toContain("map-envelope-summary");
+    expect(response.text).toContain("lastFailedRefreshRunId");
+    expect(response.text).toContain("carriedForwardFromFailedRefresh");
+    expect(response.text).toContain("Last failed refresh");
+    expect(response.text).toContain("carried forward after failed refresh");
     expect(response.text).toContain(
       "No mission-specific fetch is attempted until a valid mission ID is provided.",
     );

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -128,7 +128,27 @@ const areaOverlaySourceRefreshDetail = (overlay) => {
     return "Not recorded";
   }
 
-  return `${refreshState.status} | last successful ${formatDateTime(refreshState.lastSuccessfulRefreshRunId)}`;
+  const detailParts = [`${refreshState.status}`];
+
+  if (refreshState.lastSuccessfulRefreshRunId) {
+    detailParts.push(
+      `last successful ${formatDateTime(refreshState.lastSuccessfulRefreshRunId)}`,
+    );
+  } else {
+    detailParts.push("no successful refresh recorded");
+  }
+
+  if (refreshState.lastFailedRefreshRunId) {
+    detailParts.push(
+      `last failed ${formatDateTime(refreshState.lastFailedRefreshRunId)}`,
+    );
+  }
+
+  if (refreshState.carriedForwardFromFailedRefresh) {
+    detailParts.push("carried forward after failed refresh");
+  }
+
+  return detailParts.join(" | ");
 };
 
 const areaSourceRefreshSummary = () => {
@@ -158,18 +178,43 @@ const areaSourceRefreshSummary = () => {
     .filter(Boolean)
     .sort()
     .at(-1);
+  const latestFailedRefresh = overlays
+    .map((overlay) => areaOverlaySourceRefreshState(overlay)?.lastFailedRefreshRunId)
+    .filter(Boolean)
+    .sort()
+    .at(-1);
+  const carriedForwardFailedCount = overlays.filter(
+    (overlay) =>
+      areaOverlaySourceRefreshState(overlay)?.carriedForwardFromFailedRefresh === true,
+  ).length;
 
   return {
     label:
       highestPriorityStatus === "fresh"
         ? "Fresh"
+        : highestPriorityStatus === "failed"
+          ? `Failed refresh (${degradedCount})`
         : highestPriorityStatus === "missing"
           ? "Missing"
           : `${highestPriorityStatus} (${degradedCount})`,
     detail:
-      latestSuccessfulRefresh != null
-        ? `Last successful refresh ${formatDateTime(latestSuccessfulRefresh)}`
-        : "No successful refresh recorded",
+      highestPriorityStatus === "failed"
+        ? [
+            latestFailedRefresh != null
+              ? `Last failed refresh ${formatDateTime(latestFailedRefresh)}`
+              : "Failed refresh recorded",
+            latestSuccessfulRefresh != null
+              ? `last successful ${formatDateTime(latestSuccessfulRefresh)}`
+              : "no successful refresh recorded",
+            carriedForwardFailedCount > 0
+              ? `${carriedForwardFailedCount} carried-forward overlay${carriedForwardFailedCount === 1 ? "" : "s"}`
+              : null,
+          ]
+            .filter(Boolean)
+            .join(" | ")
+        : latestSuccessfulRefresh != null
+          ? `Last successful refresh ${formatDateTime(latestSuccessfulRefresh)}`
+          : "No successful refresh recorded",
   };
 };
 


### PR DESCRIPTION
## Summary

Implements GitHub issue #220 by adding operator-facing failed-refresh review visibility for normalized area overlays so unsuccessful authoritative refresh attempts are distinguishable from stale carried-forward overlay state during operational review.

## What changed

- Extended the existing operator-facing live-ops review surface for normalized area overlays.
- Reused the existing backend freshness and failed-refresh provenance model rather than adding a new review endpoint.
- Added clearer failed-refresh rendering in live operations review context so operators can distinguish:
  - fresh source state
  - stale source state
  - partial source state
  - failed refresh state
- Where failed-refresh provenance exists, operator-facing review now exposes:
  - the current evaluated refresh state
  - the last successful refresh run
  - the last failed refresh run
  - whether the current overlay state was carried forward after a failed refresh attempt
- Updated the area source refresh summary so failed refreshes are presented as a distinct degraded state rather than generic warning copy.
- Updated the live-ops conflict review detail so area-conflict refresh state reflects failed-refresh carry-forward context directly.
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling on fresh complete refreshes
  - source traceability
  - refresh-run provenance
  - freshness handling for fresh / stale / partial / failed states
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
- Kept conflict assessment source-agnostic and unchanged in behavior.
- Updated the save point to the next bounded follow-on:
  - failed-refresh review context in operator-facing conflict summary cards

## Verification

- `.\node_modules\.bin\vitest.cmd run src\tests\mission-planning.test.ts` passed.
- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

## Notes

This issue is an operator-facing review refinement only. It does not add operator automation, advisory execution changes, or source-specific conflict-engine branching.

Closes #220.
