### PR TITLE
Add operator-facing failed-refresh review visibility

### DIFF
--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2069,6 +2069,12 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("carriedForwardFromFailedRefresh");
     expect(response.text).toContain("Last failed refresh");
     expect(response.text).toContain("carried forward after failed refresh");
+    expect(response.text).toContain("areaOverlaySourceRefreshCardContext");
+    expect(response.text).toContain("Area source failed");
+    expect(response.text).toContain("Area source partial");
+    expect(response.text).toContain("Area source stale");
+    expect(response.text).toContain("Area source fresh");
+    expect(response.text).toContain("carried forward");
     expect(response.text).toContain(
       "No mission-specific fetch is attempted until a valid mission ID is provided.",
     );

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -151,6 +151,32 @@ const areaOverlaySourceRefreshDetail = (overlay) => {
   return detailParts.join(" | ");
 };
 
+const areaOverlaySourceRefreshCardContext = (overlay) => {
+  const refreshState = areaOverlaySourceRefreshState(overlay);
+  if (!refreshState) {
+    return null;
+  }
+
+  const label =
+    refreshState.status === "failed"
+      ? "Area source failed"
+      : refreshState.status === "partial"
+        ? "Area source partial"
+        : refreshState.status === "stale"
+          ? "Area source stale"
+          : refreshState.status === "fresh"
+            ? "Area source fresh"
+            : null;
+
+  if (!label) {
+    return null;
+  }
+
+  return refreshState.carriedForwardFromFailedRefresh
+    ? `${label} | carried forward`
+    : label;
+};
+
 const areaSourceRefreshSummary = () => {
   const overlays = areaConflictOverlays();
   if (overlays.length === 0) {
@@ -787,10 +813,22 @@ const conflictAssessmentSummary = () => {
   }
 
   const highest = conflicts[0];
+  const highestOverlay =
+    highest.overlayKind === "area_conflict" ? conflictOverlayForItem(highest) : null;
+  const highestRefreshContext = areaOverlaySourceRefreshCardContext(highestOverlay);
   return {
     label: `${conflicts.length} conflict candidate${conflicts.length === 1 ? "" : "s"}`,
     tone: highest.severity,
-    detail: `${highest.overlayLabel} | ${formatRangeBearing(highest.metrics)} | ${highest.overlayKind === "area_conflict" ? `${formatTemporalContext(highest)} | ${formatVerticalContext(highest)}` : `${formatVerticalSeparation(highest.metrics?.altitudeDeltaFt)} vertical`}`,
+    detail: [
+      highest.overlayLabel,
+      formatRangeBearing(highest.metrics),
+      highest.overlayKind === "area_conflict"
+        ? `${formatTemporalContext(highest)} | ${formatVerticalContext(highest)}`
+        : `${formatVerticalSeparation(highest.metrics?.altitudeDeltaFt)} vertical`,
+      highestRefreshContext,
+    ]
+      .filter(Boolean)
+      .join(" | "),
   };
 };
 
@@ -1369,6 +1407,13 @@ const buildOverlayCards = () => {
   const dispatchWorkspace = uiState.dispatchWorkspace;
   const primaryConflict = primaryConflictAssessmentItem();
   const primaryAdvisory = primaryConflictAdvisory();
+  const primaryConflictOverlay = primaryConflict
+    ? conflictOverlayForItem(primaryConflict)
+    : null;
+  const primaryConflictRefreshContext =
+    primaryConflict?.overlayKind === "area_conflict"
+      ? areaOverlaySourceRefreshCardContext(primaryConflictOverlay)
+      : null;
   const cards = [
     summarizeRiskState(planningWorkspace),
     summarizeAirspaceState(planningWorkspace),
@@ -1382,7 +1427,16 @@ const buildOverlayCards = () => {
       ? {
           label: "Primary conflict",
           tone: primaryConflict.severity,
-          detail: `${primaryConflict.overlayLabel} | ${formatRangeBearing(primaryConflict.metrics)} | ${primaryConflict.overlayKind === "area_conflict" ? formatVerticalContext(primaryConflict) : `${formatVerticalSeparation(primaryConflict.metrics?.altitudeDeltaFt)} vertical`}`,
+          detail: [
+            primaryConflict.overlayLabel,
+            formatRangeBearing(primaryConflict.metrics),
+            primaryConflict.overlayKind === "area_conflict"
+              ? formatVerticalContext(primaryConflict)
+              : `${formatVerticalSeparation(primaryConflict.metrics?.altitudeDeltaFt)} vertical`,
+            primaryConflictRefreshContext,
+          ]
+            .filter(Boolean)
+            .join(" | "),
         }
       : conflictAssessmentSummary(),
     primaryAdvisory


### PR DESCRIPTION
## Summary

Implements GitHub issue #222 by adding operator-facing failed-refresh review visibility to conflict summary cards so degraded authoritative area-source state is visible at a glance during live operational review.

## What changed

- Extended the existing operator-facing live-ops summary-card layer for area conflicts.
- Reused the existing freshness and failed-refresh provenance model from `#216`, `#218`, and `#220`.
- Added compact summary-card context for area-conflict overlays so operators can distinguish:
  - fresh source state
  - stale source state
  - partial source state
  - failed refresh state
- Added carried-forward failed-refresh context at summary-card level when present.
- Applied the summary-card context in:
  - the primary conflict overlay card in the map alert stack
  - the conflict assessment summary text used in the live-ops posture layer
- Preserved the existing detailed failed-refresh review visibility added in `#220`.
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling on fresh complete refreshes
  - source traceability
  - refresh-run provenance
  - freshness handling for fresh / stale / partial / failed states
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
- Existing traffic conflict behavior remains unchanged.

## Verification

- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `npm.cmd run build` passed.

## Notes

This issue is an operator-facing review refinement only. It does not add operator automation, advisory execution changes, or source-specific conflict-engine branching.

Closes #222.
