### PR TITLE
Add partial area refresh provenance

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add failed-refresh review context to operator-facing conflict summary cards so degraded authoritative area state is visible at a glance.",
+  "nextBuildStep": "Add operator-facing partial-refresh review visibility so incomplete authoritative area state is visible in live operations review.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -130,6 +130,8 @@ const normalizedAreaMetadata = (
     status: "fresh",
     evaluatedByRunId: refreshRunId,
     lastSuccessfulRefreshRunId: refreshRunId,
+    lastPartialRefreshRunId: null,
+    carriedForwardFromPartialRefresh: false,
     lastFailedRefreshRunId: null,
     carriedForwardFromFailedRefresh: false,
   },
@@ -158,10 +160,19 @@ const priorFailedRefreshRunId = (
   metadata: AreaConflictOverlayMetadata,
 ): string | null => areaRefreshStateFromMetadata(metadata)?.lastFailedRefreshRunId ?? null;
 
+const priorPartialRefreshRunId = (
+  metadata: AreaConflictOverlayMetadata,
+): string | null =>
+  areaRefreshStateFromMetadata(metadata)?.lastPartialRefreshRunId ?? null;
+
 const buildAreaSourceRefreshState = (
   refreshRunId: string,
   refreshStatus: NormalizeAreaOverlayRefreshStatus,
   metadata?: AreaConflictOverlayMetadata,
+  options: {
+    carriedForwardFromPartialRefresh?: boolean;
+    carriedForwardFromFailedRefresh?: boolean;
+  } = {},
 ): NonNullable<AreaConflictOverlayMetadata["sourceRefresh"]> => ({
   status: refreshStatus,
   evaluatedByRunId: refreshRunId,
@@ -170,13 +181,22 @@ const buildAreaSourceRefreshState = (
     : metadata
       ? priorSuccessfulRefreshRunId(metadata)
       : null,
+  lastPartialRefreshRunId:
+    refreshStatus === "partial"
+      ? refreshRunId
+      : metadata
+        ? priorPartialRefreshRunId(metadata)
+        : null,
+  carriedForwardFromPartialRefresh:
+    options.carriedForwardFromPartialRefresh ?? false,
   lastFailedRefreshRunId:
     refreshStatus === "failed"
       ? refreshRunId
       : metadata
         ? priorFailedRefreshRunId(metadata)
         : null,
-  carriedForwardFromFailedRefresh: refreshStatus === "failed",
+  carriedForwardFromFailedRefresh:
+    options.carriedForwardFromFailedRefresh ?? refreshStatus === "failed",
 });
 
 const sourceTraceEntryKey = (
@@ -320,6 +340,7 @@ type AreaOverlayRefreshRunSummary = {
   missionId: string;
   created: AreaOverlayRefreshRunSummaryItem[];
   updated: AreaOverlayRefreshRunSummaryItem[];
+  partial: AreaOverlayRefreshRunSummaryItem[];
   failed: AreaOverlayRefreshRunSummaryItem[];
   superseded: AreaOverlayRefreshRunSummaryItem[];
   retired: AreaOverlayRefreshRunSummaryItem[];
@@ -576,6 +597,7 @@ const buildAreaOverlayRefreshRunSummaries = (
       missionId,
       created: [],
       updated: [],
+      partial: [],
       failed: [],
       superseded: [],
       retired: [],
@@ -599,6 +621,10 @@ const buildAreaOverlayRefreshRunSummaries = (
     const sourceRefresh = areaMetadataFromOverlay(overlay).sourceRefresh;
     ensureSummary(provenance.createdByRunId).created.push(summaryItem);
     ensureSummary(provenance.lastUpdatedByRunId).updated.push(summaryItem);
+
+    if (sourceRefresh?.lastPartialRefreshRunId) {
+      ensureSummary(sourceRefresh.lastPartialRefreshRunId).partial.push(summaryItem);
+    }
 
     if (sourceRefresh?.lastFailedRefreshRunId) {
       ensureSummary(sourceRefresh.lastFailedRefreshRunId).failed.push(summaryItem);
@@ -701,6 +727,24 @@ const buildRefreshRunOrder = (overlays: ExternalOverlay[]): Map<string, number> 
 
       if (sourceRefresh.evaluatedByRunId !== sourceRefresh.lastFailedRefreshRunId) {
         addEdge(sourceRefresh.lastFailedRefreshRunId, sourceRefresh.evaluatedByRunId);
+      }
+    }
+
+    if (sourceRefresh?.lastPartialRefreshRunId) {
+      ensureNode(sourceRefresh.lastPartialRefreshRunId);
+
+      if (
+        sourceRefresh.lastSuccessfulRefreshRunId &&
+        sourceRefresh.lastSuccessfulRefreshRunId !== sourceRefresh.lastPartialRefreshRunId
+      ) {
+        addEdge(
+          sourceRefresh.lastSuccessfulRefreshRunId,
+          sourceRefresh.lastPartialRefreshRunId,
+        );
+      }
+
+      if (sourceRefresh.evaluatedByRunId !== sourceRefresh.lastPartialRefreshRunId) {
+        addEdge(sourceRefresh.lastPartialRefreshRunId, sourceRefresh.evaluatedByRunId);
       }
     }
   }
@@ -1214,6 +1258,9 @@ export class ExternalOverlayService {
                 refreshRunId,
                 refreshStatus,
                 metadata,
+                {
+                  carriedForwardFromPartialRefresh: refreshStatus === "partial",
+                },
               ),
               refreshProvenance: {
                 createdByRunId:
@@ -1248,6 +1295,9 @@ export class ExternalOverlayService {
                 refreshRunId,
                 refreshStatus,
                 metadata,
+                {
+                  carriedForwardFromPartialRefresh: refreshStatus === "partial",
+                },
               ),
             },
           );

--- a/src/external-overlays/external-overlay.types.ts
+++ b/src/external-overlays/external-overlay.types.ts
@@ -114,6 +114,8 @@ export interface AreaConflictOverlayMetadata {
     status: "fresh" | "stale" | "partial" | "failed";
     evaluatedByRunId: string;
     lastSuccessfulRefreshRunId: string | null;
+    lastPartialRefreshRunId: string | null;
+    carriedForwardFromPartialRefresh: boolean;
     lastFailedRefreshRunId: string | null;
     carriedForwardFromFailedRefresh: boolean;
   } | null;

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -536,6 +536,8 @@ describe("mission external overlays integration", () => {
               status: "fresh",
               evaluatedByRunId: normalizeResponse.body.refreshRunId,
               lastSuccessfulRefreshRunId: normalizeResponse.body.refreshRunId,
+              lastPartialRefreshRunId: null,
+              carriedForwardFromPartialRefresh: false,
               lastFailedRefreshRunId: null,
               carriedForwardFromFailedRefresh: false,
             },
@@ -563,6 +565,8 @@ describe("mission external overlays integration", () => {
               status: "fresh",
               evaluatedByRunId: normalizeResponse.body.refreshRunId,
               lastSuccessfulRefreshRunId: normalizeResponse.body.refreshRunId,
+              lastPartialRefreshRunId: null,
+              carriedForwardFromPartialRefresh: false,
               lastFailedRefreshRunId: null,
               carriedForwardFromFailedRefresh: false,
             },
@@ -766,6 +770,8 @@ describe("mission external overlays integration", () => {
         status: "stale",
         evaluatedByRunId: staleRun.body.refreshRunId,
         lastSuccessfulRefreshRunId: freshRun.body.refreshRunId,
+        lastPartialRefreshRunId: null,
+        carriedForwardFromPartialRefresh: false,
         lastFailedRefreshRunId: null,
         carriedForwardFromFailedRefresh: false,
       },
@@ -1209,10 +1215,251 @@ describe("mission external overlays integration", () => {
               status: "partial",
               evaluatedByRunId: partialRun.body.refreshRunId,
               lastSuccessfulRefreshRunId: firstRun.body.refreshRunId,
+              lastPartialRefreshRunId: partialRun.body.refreshRunId,
+              carriedForwardFromPartialRefresh: true,
               lastFailedRefreshRunId: null,
               carriedForwardFromFailedRefresh: false,
             },
           }),
+        }),
+      ]),
+    );
+  });
+
+  it("records partial refresh provenance in refresh-run summaries and preserves it after a later fresh recovery", async () => {
+    const missionId = await createMission();
+
+    const firstRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-PARTIAL-2200-A",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            area: {
+              areaId: "EGD-PARTIAL-2200-A",
+              label: "Danger Area Partial 2200 A",
+              areaType: "danger_area",
+              authorityName: "CAA",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-PARTIAL-2200-B",
+            },
+            observedAt: "2026-04-21T10:08:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5091,
+              centerLng: -0.1261,
+              radiusMeters: 280,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            area: {
+              areaId: "TDA-PARTIAL-2200-B",
+              label: "Temporary Danger Area Partial 2200 B",
+              areaType: "temporary_danger_area",
+              authorityName: "CAA",
+            },
+          },
+        ],
+      });
+
+    const partialRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        refresh: {
+          status: "partial",
+        },
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-PARTIAL-2200-B",
+            },
+            observedAt: "2026-04-21T10:18:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5091,
+              centerLng: -0.1261,
+              radiusMeters: 280,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            area: {
+              areaId: "TDA-PARTIAL-2200-B",
+              label: "Temporary Danger Area Partial 2200 B",
+              areaType: "temporary_danger_area",
+              authorityName: "CAA",
+            },
+          },
+        ],
+      });
+
+    const recoveryRun = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "danger_area",
+              sourceRecordId: "EGD-PARTIAL-2200-A",
+            },
+            observedAt: "2026-04-21T10:27:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5078,
+              centerLng: -0.1269,
+              radiusMeters: 350,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 900,
+            },
+            area: {
+              areaId: "EGD-PARTIAL-2200-A",
+              label: "Danger Area Partial 2200 A",
+              areaType: "danger_area",
+              authorityName: "CAA",
+            },
+          },
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "temporary_danger_area",
+              sourceRecordId: "TDA-PARTIAL-2200-B",
+            },
+            observedAt: "2026-04-21T10:28:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: 51.5091,
+              centerLng: -0.1261,
+              radiusMeters: 280,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 1200,
+            },
+            area: {
+              areaId: "TDA-PARTIAL-2200-B",
+              label: "Temporary Danger Area Partial 2200 B",
+              areaType: "temporary_danger_area",
+              authorityName: "CAA",
+            },
+          },
+        ],
+      });
+
+    expect(firstRun.status).toBe(201);
+    expect(partialRun.status).toBe(201);
+    expect(recoveryRun.status).toBe(201);
+
+    const listResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays?kind=area_conflict`,
+    );
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.overlays).toHaveLength(2);
+    expect(listResponse.body.overlays).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            areaId: "EGD-PARTIAL-2200-A",
+            sourceRefresh: {
+              status: "fresh",
+              evaluatedByRunId: recoveryRun.body.refreshRunId,
+              lastSuccessfulRefreshRunId: recoveryRun.body.refreshRunId,
+              lastPartialRefreshRunId: partialRun.body.refreshRunId,
+              carriedForwardFromPartialRefresh: false,
+              lastFailedRefreshRunId: null,
+              carriedForwardFromFailedRefresh: false,
+            },
+          }),
+        }),
+      ]),
+    );
+
+    const summaryResponse = await request(app).get(
+      `/missions/${missionId}/external-overlays/refresh-runs`,
+    );
+
+    expect(summaryResponse.status).toBe(200);
+    expect(summaryResponse.body.refreshRuns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          refreshRunId: partialRun.body.refreshRunId,
+          missionId,
+          created: [],
+          updated: [],
+          partial: expect.arrayContaining([
+            expect.objectContaining({
+              areaId: "EGD-PARTIAL-2200-A",
+              sourceType: "danger_area",
+              retired: false,
+            }),
+            expect.objectContaining({
+              areaId: "TDA-PARTIAL-2200-B",
+              sourceType: "temporary_danger_area",
+              retired: false,
+            }),
+          ]),
+          failed: [],
+          superseded: [],
+          retired: [],
+          active: [],
+        }),
+        expect.objectContaining({
+          refreshRunId: recoveryRun.body.refreshRunId,
+          missionId,
+          partial: [],
+          failed: [],
+          updated: expect.arrayContaining([
+            expect.objectContaining({
+              areaId: "EGD-PARTIAL-2200-A",
+              sourceType: "danger_area",
+              retired: false,
+            }),
+            expect.objectContaining({
+              areaId: "TDA-PARTIAL-2200-B",
+              sourceType: "temporary_danger_area",
+              retired: false,
+            }),
+          ]),
+          active: expect.arrayContaining([
+            expect.objectContaining({
+              areaId: "EGD-PARTIAL-2200-A",
+              sourceType: "danger_area",
+              retired: false,
+            }),
+            expect.objectContaining({
+              areaId: "TDA-PARTIAL-2200-B",
+              sourceType: "temporary_danger_area",
+              retired: false,
+            }),
+          ]),
         }),
       ]),
     );
@@ -1276,6 +1523,8 @@ describe("mission external overlays integration", () => {
         status: "failed",
         evaluatedByRunId: failedRun.body.refreshRunId,
         lastSuccessfulRefreshRunId: firstRun.body.refreshRunId,
+        lastPartialRefreshRunId: null,
+        carriedForwardFromPartialRefresh: false,
         lastFailedRefreshRunId: failedRun.body.refreshRunId,
         carriedForwardFromFailedRefresh: true,
       },
@@ -1371,6 +1620,8 @@ describe("mission external overlays integration", () => {
         status: "fresh",
         evaluatedByRunId: recoveryRun.body.refreshRunId,
         lastSuccessfulRefreshRunId: recoveryRun.body.refreshRunId,
+        lastPartialRefreshRunId: null,
+        carriedForwardFromPartialRefresh: false,
         lastFailedRefreshRunId: failedRun.body.refreshRunId,
         carriedForwardFromFailedRefresh: false,
       },


### PR DESCRIPTION
## Summary

Implements GitHub issue #224 by adding partial-refresh provenance to normalized area overlay ingestion so incomplete authoritative source updates remain explicitly reviewable instead of appearing as a fully fresh source picture.

## What changed

- Added partial-refresh provenance to normalized area overlay `sourceRefresh` metadata:
  - `lastPartialRefreshRunId`
  - `carriedForwardFromPartialRefresh`
- Preserved the existing freshness model:
  - `fresh`
  - `stale`
  - `partial`
  - `failed`
- Preserved the existing failed-refresh provenance model:
  - `lastFailedRefreshRunId`
  - `carriedForwardFromFailedRefresh`
- Preserved the existing refresh provenance model:
  - `createdByRunId`
  - `lastUpdatedByRunId`
  - `supersededByRunId`
  - `retiredByRunId`
- Defined partial-refresh handling as follows:
  - partial refresh attempts do not retire missing overlays
  - overlays updated during a partial refresh record the partial run id explicitly
  - overlays carried forward because they were missing from a partial refresh record that they were carried forward from a partial refresh
  - later fresh recovery preserves the last partial refresh provenance instead of erasing it
- Extended refresh-run summaries so partial refresh attempts are reviewable directly:
  - added `partial` items to the existing refresh-run summary model
- Updated refresh-run ordering so partial refresh attempts are included in chronology where provenance makes their ordering inferable
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling on complete fresh refreshes
  - source traceability
  - freshness handling for fresh / stale / partial / failed states
  - failed-refresh provenance
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
- Kept conflict assessment source-agnostic. It still consumes normalized area overlays without source-specific branching logic.
- Updated the save point to the next logical step:
  - add operator-facing partial-refresh review visibility

## Verification

- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 30 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 362 tests.
- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

## Notes

This issue refines normalized area overlay ingestion robustness and auditability only. It does not add operator command automation or source-specific conflict-engine branching.

Closes #224.
