### PR TITLE
Add operator-facing partial-refresh review visibility

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add operator-facing partial-refresh review visibility so incomplete authoritative area state is visible in live operations review.",
+  "nextBuildStep": "Add operator-facing partial-refresh summary-card context so incomplete authoritative area state is visible at a glance.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2067,14 +2067,19 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("map-envelope-summary");
     expect(response.text).toContain("lastFailedRefreshRunId");
     expect(response.text).toContain("carriedForwardFromFailedRefresh");
+    expect(response.text).toContain("lastPartialRefreshRunId");
+    expect(response.text).toContain("carriedForwardFromPartialRefresh");
     expect(response.text).toContain("Last failed refresh");
+    expect(response.text).toContain("Last partial refresh");
+    expect(response.text).toContain("carried forward after partial refresh");
     expect(response.text).toContain("carried forward after failed refresh");
     expect(response.text).toContain("areaOverlaySourceRefreshCardContext");
     expect(response.text).toContain("Area source failed");
     expect(response.text).toContain("Area source partial");
     expect(response.text).toContain("Area source stale");
     expect(response.text).toContain("Area source fresh");
-    expect(response.text).toContain("carried forward");
+    expect(response.text).toContain("carried forward after failed refresh");
+    expect(response.text).toContain("carried forward after partial refresh");
     expect(response.text).toContain(
       "No mission-specific fetch is attempted until a valid mission ID is provided.",
     );

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -144,6 +144,16 @@ const areaOverlaySourceRefreshDetail = (overlay) => {
     );
   }
 
+  if (refreshState.lastPartialRefreshRunId) {
+    detailParts.push(
+      `last partial ${formatDateTime(refreshState.lastPartialRefreshRunId)}`,
+    );
+  }
+
+  if (refreshState.carriedForwardFromPartialRefresh) {
+    detailParts.push("carried forward after partial refresh");
+  }
+
   if (refreshState.carriedForwardFromFailedRefresh) {
     detailParts.push("carried forward after failed refresh");
   }
@@ -172,9 +182,15 @@ const areaOverlaySourceRefreshCardContext = (overlay) => {
     return null;
   }
 
-  return refreshState.carriedForwardFromFailedRefresh
-    ? `${label} | carried forward`
-    : label;
+  if (refreshState.carriedForwardFromFailedRefresh) {
+    return `${label} | carried forward after failed refresh`;
+  }
+
+  if (refreshState.carriedForwardFromPartialRefresh) {
+    return `${label} | carried forward after partial refresh`;
+  }
+
+  return label;
 };
 
 const areaSourceRefreshSummary = () => {
@@ -209,6 +225,15 @@ const areaSourceRefreshSummary = () => {
     .filter(Boolean)
     .sort()
     .at(-1);
+  const latestPartialRefresh = overlays
+    .map((overlay) => areaOverlaySourceRefreshState(overlay)?.lastPartialRefreshRunId)
+    .filter(Boolean)
+    .sort()
+    .at(-1);
+  const carriedForwardPartialCount = overlays.filter(
+    (overlay) =>
+      areaOverlaySourceRefreshState(overlay)?.carriedForwardFromPartialRefresh === true,
+  ).length;
   const carriedForwardFailedCount = overlays.filter(
     (overlay) =>
       areaOverlaySourceRefreshState(overlay)?.carriedForwardFromFailedRefresh === true,
@@ -238,6 +263,20 @@ const areaSourceRefreshSummary = () => {
           ]
             .filter(Boolean)
             .join(" | ")
+        : highestPriorityStatus === "partial"
+          ? [
+              latestPartialRefresh != null
+                ? `Last partial refresh ${formatDateTime(latestPartialRefresh)}`
+                : "Partial refresh recorded",
+              latestSuccessfulRefresh != null
+                ? `last successful ${formatDateTime(latestSuccessfulRefresh)}`
+                : "no successful refresh recorded",
+              carriedForwardPartialCount > 0
+                ? `${carriedForwardPartialCount} carried-forward overlay${carriedForwardPartialCount === 1 ? "" : "s"}`
+                : null,
+            ]
+              .filter(Boolean)
+              .join(" | ")
         : latestSuccessfulRefresh != null
           ? `Last successful refresh ${formatDateTime(latestSuccessfulRefresh)}`
           : "No successful refresh recorded",


### PR DESCRIPTION
## Summary

Implements GitHub issue #226 by adding operator-facing partial-refresh review visibility for normalized area overlays so incomplete authoritative source updates are distinguishable from fresh and failed source states during live operational review.

## What changed

- Extended the existing operator-facing live-ops review surface for normalized area overlays.
- Reused the existing freshness, failed-refresh, and partial-refresh provenance model rather than adding a new review endpoint.
- Added clearer partial-refresh rendering in live operations review context so operators can distinguish:
  - fresh source state
  - stale source state
  - partial source state
  - failed refresh state
- Where partial-refresh provenance exists, operator-facing review now exposes:
  - the current evaluated refresh state
  - the last successful complete refresh run
  - the last partial refresh run
  - whether the current overlay state was carried forward after a partial refresh attempt
- Updated the area source refresh summary so partial refreshes are presented as a distinct degraded state rather than generic warning copy.
- Preserved compatibility with the existing failed-refresh review visibility.
- Preserved existing behavior:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling on fresh complete refreshes
  - source traceability
  - refresh-run provenance
  - freshness handling for fresh / stale / partial / failed states
  - failed-refresh provenance
  - partial-refresh provenance
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
- Kept conflict assessment source-agnostic and unchanged in behavior.
- Updated the save point to the next bounded follow-on:
  - add operator-facing partial-refresh summary-card context

## Verification

- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

## Notes

This issue is an operator-facing review refinement only. It does not add operator automation, advisory execution changes, or source-specific conflict-engine branching.

Closes #226.
