### PR TITLE
Add NOTAM geometry normalization rules

### DIFF
--- a/src/external-overlays/external-overlay.service.ts
+++ b/src/external-overlays/external-overlay.service.ts
@@ -101,6 +101,7 @@ const normalizedAreaMetadata = (
   authorityName: record.area.authorityName ?? null,
   notamNumber: record.area.notamNumber ?? null,
   sourceReference: record.area.sourceReference ?? null,
+  notamGeometryContext: record.area.notamGeometryContext ?? null,
   normalizedSourcePriority: areaSourcePriority(record.source.sourceType),
   dedupeKey: buildAreaDedupeKey(record),
   sourceTrace: [

--- a/src/external-overlays/external-overlay.types.ts
+++ b/src/external-overlays/external-overlay.types.ts
@@ -82,6 +82,14 @@ export interface AreaConflictOverlayMetadata {
   authorityName?: string | null;
   notamNumber?: string | null;
   sourceReference?: string | null;
+  notamGeometryContext?: {
+    geometrySource: "e_field" | "q_line" | "provided_geometry";
+    qLineIndex?: {
+      centerLat: number;
+      centerLng: number;
+      radiusNm: number;
+    } | null;
+  } | null;
   normalizedSourcePriority?: number | null;
   dedupeKey?: string | null;
   sourceTrace?: Array<{
@@ -294,6 +302,14 @@ export interface NormalizeAreaOverlaySourceRecordInput {
     authorityName?: string | null;
     notamNumber?: string | null;
     sourceReference?: string | null;
+    notamGeometryContext?: {
+      geometrySource: "e_field" | "q_line" | "provided_geometry";
+      qLineIndex?: {
+        centerLat: number;
+        centerLng: number;
+        radiusNm: number;
+      } | null;
+    } | null;
   };
 }
 

--- a/src/external-overlays/external-overlay.validators.ts
+++ b/src/external-overlays/external-overlay.validators.ts
@@ -51,6 +51,168 @@ const requiredNumber = (value: unknown, fieldName: string): number => {
   return value;
 };
 
+const dmsToDecimal = (
+  degrees: number,
+  minutes: number,
+  seconds: number,
+  hemisphere: string,
+): number => {
+  const absolute = degrees + minutes / 60 + seconds / 3600;
+  return hemisphere === "S" || hemisphere === "W" ? -absolute : absolute;
+};
+
+const parseAviationCoordinate = (
+  value: string,
+  fieldName: string,
+): number => {
+  const normalized = value.trim().toUpperCase();
+
+  const compactDmsMatch = normalized.match(
+    /^(\d{2,3})(\d{2})(\d{2})?([NSEW])$/,
+  );
+  if (compactDmsMatch) {
+    const [, degreeText, minuteText, secondText, hemisphere] = compactDmsMatch;
+    const degrees = Number(degreeText);
+    const minutes = Number(minuteText);
+    const seconds = secondText ? Number(secondText) : 0;
+    return dmsToDecimal(degrees, minutes, seconds, hemisphere);
+  }
+
+  const separatedDmsMatch = normalized.match(
+    /^(\d{2,3})[:\s](\d{2})(?:[:\s](\d{2}))?([NSEW])$/,
+  );
+  if (separatedDmsMatch) {
+    const [, degreeText, minuteText, secondText, hemisphere] = separatedDmsMatch;
+    const degrees = Number(degreeText);
+    const minutes = Number(minuteText);
+    const seconds = secondText ? Number(secondText) : 0;
+    return dmsToDecimal(degrees, minutes, seconds, hemisphere);
+  }
+
+  throw new Error(
+    `${fieldName} must be a valid number or aviation coordinate (DDMMN, DDDMMW, DDMMSSN, DDDMMSSW)`,
+  );
+};
+
+const requiredCoordinate = (value: unknown, fieldName: string): number => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    return parseAviationCoordinate(value, fieldName);
+  }
+
+  throw new Error(
+    `${fieldName} must be a valid number or aviation coordinate (DDMMN, DDDMMW, DDMMSSN, DDDMMSSW)`,
+  );
+};
+
+const normalizeAreaGeometry = (
+  geometryInput: unknown,
+  fieldPrefix: string,
+): CreateAreaConflictExternalOverlayInput["geometry"] => {
+  if (!geometryInput || typeof geometryInput !== "object") {
+    throw new Error(`${fieldPrefix} is required`);
+  }
+
+  const candidate = geometryInput as Record<string, any>;
+  const geometryType = requiredString(
+    candidate.type,
+    `${fieldPrefix}.type`,
+  ).toLowerCase();
+
+  if (geometryType === "circle") {
+    return {
+      type: "circle",
+      centerLat: requiredCoordinate(
+        candidate.centerLat,
+        `${fieldPrefix}.centerLat`,
+      ),
+      centerLng: requiredCoordinate(
+        candidate.centerLng,
+        `${fieldPrefix}.centerLng`,
+      ),
+      radiusMeters: requiredNumber(
+        candidate.radiusMeters,
+        `${fieldPrefix}.radiusMeters`,
+      ),
+      altitudeFloorFt: optionalNumber(
+        candidate.altitudeFloorFt,
+        `${fieldPrefix}.altitudeFloorFt`,
+      ),
+      altitudeCeilingFt: optionalNumber(
+        candidate.altitudeCeilingFt,
+        `${fieldPrefix}.altitudeCeilingFt`,
+      ),
+    };
+  }
+
+  if (geometryType === "polygon") {
+    if (!Array.isArray(candidate.points) || candidate.points.length < 3) {
+      throw new Error(`${fieldPrefix}.points must contain at least three points`);
+    }
+
+    return {
+      type: "polygon",
+      points: candidate.points.map((point: unknown, index: number) => {
+        if (!point || typeof point !== "object") {
+          throw new Error(`${fieldPrefix}.points[${index}] must be an object`);
+        }
+
+        const value = point as Record<string, unknown>;
+        return {
+          lat: requiredCoordinate(value.lat, `${fieldPrefix}.points[${index}].lat`),
+          lng: requiredCoordinate(value.lng, `${fieldPrefix}.points[${index}].lng`),
+        };
+      }),
+      altitudeFloorFt: optionalNumber(
+        candidate.altitudeFloorFt,
+        `${fieldPrefix}.altitudeFloorFt`,
+      ),
+      altitudeCeilingFt: optionalNumber(
+        candidate.altitudeCeilingFt,
+        `${fieldPrefix}.altitudeCeilingFt`,
+      ),
+    };
+  }
+
+  throw new Error(`${fieldPrefix}.type must be 'circle' or 'polygon'`);
+};
+
+const parseQLineIndex = (
+  input: unknown,
+  fieldPrefix: string,
+): { centerLat: number; centerLng: number; radiusNm: number } => {
+  if (!input || typeof input !== "object") {
+    throw new Error(`${fieldPrefix} must be an object`);
+  }
+
+  const candidate = input as Record<string, unknown>;
+  return {
+    centerLat: requiredCoordinate(candidate.centerLat, `${fieldPrefix}.centerLat`),
+    centerLng: requiredCoordinate(candidate.centerLng, `${fieldPrefix}.centerLng`),
+    radiusNm: requiredNumber(candidate.radiusNm, `${fieldPrefix}.radiusNm`),
+  };
+};
+
+const qLineIndexToCircleGeometry = (
+  qLineIndex: { centerLat: number; centerLng: number; radiusNm: number },
+  altitudeFloorFt: unknown,
+  altitudeCeilingFt: unknown,
+  fieldPrefix: string,
+): CreateAreaConflictExternalOverlayInput["geometry"] => ({
+  type: "circle",
+  centerLat: qLineIndex.centerLat,
+  centerLng: qLineIndex.centerLng,
+  radiusMeters: qLineIndex.radiusNm * 1852,
+  altitudeFloorFt: optionalNumber(altitudeFloorFt, `${fieldPrefix}.altitudeFloorFt`),
+  altitudeCeilingFt: optionalNumber(
+    altitudeCeilingFt,
+    `${fieldPrefix}.altitudeCeilingFt`,
+  ),
+});
+
 const optionalNumber = (value: unknown, fieldName: string): number | null => {
   if (value == null) {
     return null;
@@ -150,8 +312,8 @@ export const validateCreateWeatherExternalOverlayInput = (
     validTo: optionalTimestamp(candidate.validTo, "validTo"),
     geometry: {
       type: "point",
-      lat: requiredNumber(candidate.geometry.lat, "geometry.lat"),
-      lng: requiredNumber(candidate.geometry.lng, "geometry.lng"),
+      lat: requiredCoordinate(candidate.geometry.lat, "geometry.lat"),
+      lng: requiredCoordinate(candidate.geometry.lng, "geometry.lng"),
       altitudeMslFt: optionalNumber(
         candidate.geometry.altitudeMslFt,
         "geometry.altitudeMslFt",
@@ -221,8 +383,8 @@ export const validateCreateCrewedTrafficExternalOverlayInput = (
     validTo: optionalTimestamp(candidate.validTo, "validTo"),
     geometry: {
       type: "point",
-      lat: requiredNumber(candidate.geometry.lat, "geometry.lat"),
-      lng: requiredNumber(candidate.geometry.lng, "geometry.lng"),
+      lat: requiredCoordinate(candidate.geometry.lat, "geometry.lat"),
+      lng: requiredCoordinate(candidate.geometry.lng, "geometry.lng"),
       altitudeMslFt: optionalNumber(
         candidate.geometry.altitudeMslFt,
         "geometry.altitudeMslFt",
@@ -292,8 +454,8 @@ export const validateCreateDroneTrafficExternalOverlayInput = (
     validTo: optionalTimestamp(candidate.validTo, "validTo"),
     geometry: {
       type: "point",
-      lat: requiredNumber(candidate.geometry.lat, "geometry.lat"),
-      lng: requiredNumber(candidate.geometry.lng, "geometry.lng"),
+      lat: requiredCoordinate(candidate.geometry.lat, "geometry.lat"),
+      lng: requiredCoordinate(candidate.geometry.lng, "geometry.lng"),
       altitudeMslFt: optionalNumber(
         candidate.geometry.altitudeMslFt,
         "geometry.altitudeMslFt",
@@ -347,63 +509,7 @@ export const validateCreateAreaConflictExternalOverlayInput = (
     throw new Error("metadata is required");
   }
 
-  const geometryType = requiredString(
-    candidate.geometry.type,
-    "geometry.type",
-  ).toLowerCase();
-
-  let geometry: CreateAreaConflictExternalOverlayInput["geometry"];
-  if (geometryType === "circle") {
-    geometry = {
-      type: "circle",
-      centerLat: requiredNumber(candidate.geometry.centerLat, "geometry.centerLat"),
-      centerLng: requiredNumber(candidate.geometry.centerLng, "geometry.centerLng"),
-      radiusMeters: requiredNumber(
-        candidate.geometry.radiusMeters,
-        "geometry.radiusMeters",
-      ),
-      altitudeFloorFt: optionalNumber(
-        candidate.geometry.altitudeFloorFt,
-        "geometry.altitudeFloorFt",
-      ),
-      altitudeCeilingFt: optionalNumber(
-        candidate.geometry.altitudeCeilingFt,
-        "geometry.altitudeCeilingFt",
-      ),
-    };
-  } else if (geometryType === "polygon") {
-    if (
-      !Array.isArray(candidate.geometry.points) ||
-      candidate.geometry.points.length < 3
-    ) {
-      throw new Error("geometry.points must contain at least three points");
-    }
-
-    geometry = {
-      type: "polygon",
-      points: candidate.geometry.points.map((point: unknown, index: number) => {
-        if (!point || typeof point !== "object") {
-          throw new Error(`geometry.points[${index}] must be an object`);
-        }
-
-        const value = point as Record<string, unknown>;
-        return {
-          lat: requiredNumber(value.lat, `geometry.points[${index}].lat`),
-          lng: requiredNumber(value.lng, `geometry.points[${index}].lng`),
-        };
-      }),
-      altitudeFloorFt: optionalNumber(
-        candidate.geometry.altitudeFloorFt,
-        "geometry.altitudeFloorFt",
-      ),
-      altitudeCeilingFt: optionalNumber(
-        candidate.geometry.altitudeCeilingFt,
-        "geometry.altitudeCeilingFt",
-      ),
-    };
-  } else {
-    throw new Error("geometry.type must be 'circle' or 'polygon'");
-  }
+  const geometry = normalizeAreaGeometry(candidate.geometry, "geometry");
 
   return {
     kind: "area_conflict",
@@ -430,6 +536,11 @@ export const validateCreateAreaConflictExternalOverlayInput = (
       authorityName: optionalString(candidate.metadata.authorityName),
       notamNumber: optionalString(candidate.metadata.notamNumber),
       sourceReference: optionalString(candidate.metadata.sourceReference),
+      notamGeometryContext:
+        candidate.metadata.notamGeometryContext &&
+        typeof candidate.metadata.notamGeometryContext === "object"
+          ? (candidate.metadata.notamGeometryContext as CreateAreaConflictExternalOverlayInput["metadata"]["notamGeometryContext"])
+          : null,
     },
   };
 };
@@ -482,10 +593,6 @@ export const validateNormalizeAreaOverlaySourcesInput = (
       if (!value.area || typeof value.area !== "object") {
         throw new Error(`records[${index}].area is required`);
       }
-      if (!value.geometry || typeof value.geometry !== "object") {
-        throw new Error(`records[${index}].geometry is required`);
-      }
-
       const sourceType = requiredString(
         value.source.sourceType,
         `records[${index}].source.sourceType`,
@@ -514,6 +621,52 @@ export const validateNormalizeAreaOverlaySourcesInput = (
         );
       }
 
+      const qLineIndex =
+        value.notamGeometry &&
+        typeof value.notamGeometry === "object" &&
+        (value.notamGeometry as Record<string, unknown>).qLine
+          ? parseQLineIndex(
+              (value.notamGeometry as Record<string, unknown>).qLine,
+              `records[${index}].notamGeometry.qLine`,
+            )
+          : null;
+
+      const eFieldGeometry =
+        value.notamGeometry &&
+        typeof value.notamGeometry === "object" &&
+        (value.notamGeometry as Record<string, unknown>).eFieldGeometry
+          ? normalizeAreaGeometry(
+              (value.notamGeometry as Record<string, unknown>).eFieldGeometry,
+              `records[${index}].notamGeometry.eFieldGeometry`,
+            )
+          : null;
+
+      const selectedGeometry =
+        eFieldGeometry ??
+        (value.geometry
+          ? normalizeAreaGeometry(value.geometry, `records[${index}].geometry`)
+          : qLineIndex
+            ? qLineIndexToCircleGeometry(
+                qLineIndex,
+                value.altitudeFloorFt,
+                value.altitudeCeilingFt,
+                `records[${index}].notamGeometry.qLine`,
+              )
+            : null);
+
+      if (!selectedGeometry) {
+        throw new Error(
+          `records[${index}].geometry is required unless records[${index}].notamGeometry.qLine is provided`,
+        );
+      }
+
+      const geometrySource =
+        eFieldGeometry != null
+          ? "e_field"
+          : qLineIndex != null && value.geometry == null
+            ? "q_line"
+            : "provided_geometry";
+
       const normalized = validateCreateAreaConflictExternalOverlayInput({
         kind: "area_conflict",
         source: {
@@ -524,7 +677,7 @@ export const validateNormalizeAreaOverlaySourcesInput = (
         observedAt: value.observedAt,
         validFrom: value.validFrom,
         validTo: value.validTo,
-        geometry: value.geometry,
+        geometry: selectedGeometry,
         severity: value.severity,
         confidence: value.confidence,
         freshnessSeconds: value.freshnessSeconds,
@@ -536,6 +689,10 @@ export const validateNormalizeAreaOverlaySourcesInput = (
           authorityName: value.area.authorityName,
           notamNumber: value.area.notamNumber,
           sourceReference: value.area.sourceReference,
+          notamGeometryContext: {
+            geometrySource,
+            qLineIndex,
+          },
         },
       });
 
@@ -566,6 +723,7 @@ export const validateNormalizeAreaOverlaySourcesInput = (
           authorityName: normalized.metadata.authorityName ?? null,
           notamNumber: normalized.metadata.notamNumber ?? null,
           sourceReference: normalized.metadata.sourceReference ?? null,
+          notamGeometryContext: normalized.metadata.notamGeometryContext ?? null,
         },
       };
     }),

--- a/src/tests/external-overlays.test.ts
+++ b/src/tests/external-overlays.test.ts
@@ -441,6 +441,49 @@ describe("mission external overlays integration", () => {
     });
   });
 
+  it("accepts NOTAM-style aviation coordinates for direct area conflict overlay creation", async () => {
+    const missionId = await createMission();
+
+    const createResponse = await request(app)
+      .post(`/missions/${missionId}/external-overlays`)
+      .send({
+        kind: "area_conflict",
+        source: {
+          provider: "airspace-hub",
+          sourceType: "zone_service",
+          sourceRecordId: "zone-dms-1",
+        },
+        observedAt: "2026-04-21T10:07:00.000Z",
+        geometry: {
+          type: "circle",
+          centerLat: "520512N",
+          centerLng: "0001907W",
+          radiusMeters: 350,
+          altitudeFloorFt: 100,
+          altitudeCeilingFt: 900,
+        },
+        severity: "caution",
+        metadata: {
+          areaId: "zone-dms-1",
+          label: "Tower protection zone DMS",
+          areaType: "restricted_zone",
+          description: "Temporary restricted area around event site",
+        },
+      });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.overlay).toMatchObject({
+      missionId,
+      kind: "area_conflict",
+      geometry: expect.objectContaining({
+        type: "circle",
+        centerLat: 52.086666666666666,
+        centerLng: -0.3186111111111111,
+        radiusMeters: 350,
+      }),
+    });
+  });
+
   it("normalizes authoritative danger area and NOTAM records into area conflict overlays", async () => {
     const missionId = await createMission();
 
@@ -775,6 +818,217 @@ describe("mission external overlays integration", () => {
         lastFailedRefreshRunId: null,
         carriedForwardFromFailedRefresh: false,
       },
+    });
+  });
+
+  it("accepts NOTAM-style aviation coordinates during normalized area-source ingestion", async () => {
+    const missionId = await createMission();
+
+    const normalizeResponse = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1234/26-DMS",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "polygon",
+              points: [
+                { lat: "520258N", lng: "0001553W" },
+                { lat: "520225N", lng: "0002056W" },
+                { lat: "520512N", lng: "0001907W" },
+              ],
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 3500,
+            },
+            severity: "caution",
+            area: {
+              areaId: "NOTAM-DMS-B1234-26",
+              label: "NOTAM Restriction DMS",
+              areaType: "notam_restriction",
+              description: "Polygon from NOTAM DMS coordinates",
+              authorityName: "CAA",
+              notamNumber: "B1234/26",
+              sourceReference: "NOTAM B1234/26",
+            },
+          },
+        ],
+      });
+
+    expect(normalizeResponse.status).toBe(201);
+    expect(normalizeResponse.body.overlays).toHaveLength(1);
+    expect(normalizeResponse.body.overlays[0]).toMatchObject({
+      kind: "area_conflict",
+      geometry: {
+        type: "polygon",
+      },
+      metadata: expect.objectContaining({
+        areaId: "NOTAM-DMS-B1234-26",
+        areaType: "notam_restriction",
+      }),
+    });
+    expect(normalizeResponse.body.overlays[0].geometry.points[0].lat).toBeCloseTo(
+      52.04944444444445,
+    );
+    expect(normalizeResponse.body.overlays[0].geometry.points[0].lng).toBeCloseTo(
+      -0.26472222222222225,
+    );
+    expect(normalizeResponse.body.overlays[0].geometry.points[1].lat).toBeCloseTo(
+      52.040277777777774,
+    );
+    expect(normalizeResponse.body.overlays[0].geometry.points[1].lng).toBeCloseTo(
+      -0.3488888888888889,
+    );
+    expect(normalizeResponse.body.overlays[0].geometry.points[2].lat).toBeCloseTo(
+      52.086666666666666,
+    );
+    expect(normalizeResponse.body.overlays[0].geometry.points[2].lng).toBeCloseTo(
+      -0.3186111111111111,
+    );
+  });
+
+  it("prefers E field polygon coordinates over Q line geometry and preserves Q line as coarse index metadata", async () => {
+    const missionId = await createMission();
+
+    const normalizeResponse = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1235/26-DMS",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            geometry: {
+              type: "circle",
+              centerLat: "5205N",
+              centerLng: "00019W",
+              radiusMeters: 7408,
+              altitudeFloorFt: 0,
+              altitudeCeilingFt: 3500,
+            },
+            notamGeometry: {
+              qLine: {
+                centerLat: "5205N",
+                centerLng: "00019W",
+                radiusNm: 4,
+              },
+              eFieldGeometry: {
+                type: "polygon",
+                points: [
+                  { lat: "520258N", lng: "0001553W" },
+                  { lat: "520225N", lng: "0002056W" },
+                  { lat: "520512N", lng: "0001907W" },
+                ],
+                altitudeFloorFt: 0,
+                altitudeCeilingFt: 3500,
+              },
+            },
+            severity: "caution",
+            area: {
+              areaId: "NOTAM-DMS-B1235-26",
+              label: "NOTAM Restriction DMS Preferred E",
+              areaType: "notam_restriction",
+              description: "E field polygon should win over Q line circle",
+              authorityName: "CAA",
+              notamNumber: "B1235/26",
+              sourceReference: "NOTAM B1235/26",
+            },
+          },
+        ],
+      });
+
+    expect(normalizeResponse.status).toBe(201);
+    expect(normalizeResponse.body.overlays).toHaveLength(1);
+    expect(normalizeResponse.body.overlays[0]).toMatchObject({
+      kind: "area_conflict",
+      geometry: {
+        type: "polygon",
+      },
+      metadata: expect.objectContaining({
+        areaId: "NOTAM-DMS-B1235-26",
+        notamGeometryContext: {
+          geometrySource: "e_field",
+          qLineIndex: {
+            centerLat: 52.083333333333336,
+            centerLng: -0.31666666666666665,
+            radiusNm: 4,
+          },
+        },
+      }),
+    });
+  });
+
+  it("falls back to Q line circle geometry when E field geometry is unavailable", async () => {
+    const missionId = await createMission();
+
+    const normalizeResponse = await request(app)
+      .post(`/missions/${missionId}/external-overlays/normalize-area-sources`)
+      .send({
+        records: [
+          {
+            source: {
+              provider: "uk-ais",
+              sourceType: "notam_restriction",
+              sourceRecordId: "B1236/26-QONLY",
+            },
+            observedAt: "2026-04-21T10:07:00.000Z",
+            validFrom: "2026-04-21T10:00:00.000Z",
+            validTo: "2026-04-21T14:00:00.000Z",
+            notamGeometry: {
+              qLine: {
+                centerLat: "5205N",
+                centerLng: "00019W",
+                radiusNm: 4,
+              },
+            },
+            altitudeFloorFt: 0,
+            altitudeCeilingFt: 3500,
+            severity: "caution",
+            area: {
+              areaId: "NOTAM-DMS-B1236-26",
+              label: "NOTAM Restriction Q Line Only",
+              areaType: "notam_restriction",
+              description: "Q line circle fallback",
+              authorityName: "CAA",
+              notamNumber: "B1236/26",
+              sourceReference: "NOTAM B1236/26",
+            },
+          },
+        ],
+      });
+
+    expect(normalizeResponse.status).toBe(201);
+    expect(normalizeResponse.body.overlays).toHaveLength(1);
+    expect(normalizeResponse.body.overlays[0]).toMatchObject({
+      kind: "area_conflict",
+      geometry: {
+        type: "circle",
+        centerLat: 52.083333333333336,
+        centerLng: -0.31666666666666665,
+        radiusMeters: 7408,
+      },
+      metadata: expect.objectContaining({
+        areaId: "NOTAM-DMS-B1236-26",
+        notamGeometryContext: {
+          geometrySource: "q_line",
+          qLineIndex: {
+            centerLat: 52.083333333333336,
+            centerLng: -0.31666666666666665,
+            radiusNm: 4,
+          },
+        },
+      }),
     });
   });
 


### PR DESCRIPTION
## Summary

Adds NOTAM geometry normalization rules at the external overlay ingestion boundary so aviation-format coordinates can be accepted while internal geometry remains normalized to decimal degrees.

## What changed

- Added ingestion support for aviation coordinate strings:
  - `DDMMN`
  - `DDDMMW`
  - `DDMMSSN`
  - `DDDMMSSW`
  - also accepts colon/space-separated variants
- Kept the internal geometry model decimal-only.
- Added NOTAM-specific normalized ingestion behavior:
  - prefer `E` field geometry when available
  - treat `Q` line coordinates as coarse area indexing metadata
  - fall back to a `Q` line circle only when no better geometry is available
- Preserved decimal-degree storage and downstream conflict-assessment behavior.
- Added NOTAM geometry context metadata so review paths can distinguish:
  - `e_field`
  - `q_line`
  - `provided_geometry`
- Preserved the `Q` line center/radius as coarse index metadata where provided.

## Files changed

- `src/external-overlays/external-overlay.validators.ts`
- `src/external-overlays/external-overlay.types.ts`
- `src/external-overlays/external-overlay.service.ts`
- `src/tests/external-overlays.test.ts`

## Verification

- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\external-overlays.test.ts` passed: 34 tests.
- `.\\node_modules\\.bin\\vitest.cmd run` passed: 23 files, 366 tests.
- `npm.cmd run build` passed.

## Notes

This change is limited to the ingestion boundary. It does not introduce a separate NOTAM adapter, does not change the internal geometry model, and does not alter conflict-engine behavior beyond providing cleaner normalized geometry inputs.
