### PR TITLE
Add operator-facing partial-refresh summary-card context

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add operator-facing partial-refresh summary-card context so incomplete authoritative area state is visible at a glance.",
+  "nextBuildStep": "Add operator-facing partial-refresh advisory review detail so incomplete authoritative area state is visible throughout advisory presentation.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2034,6 +2034,7 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("droneTrafficSummary");
     expect(response.text).toContain("conflictAssessmentSummary");
     expect(response.text).toContain("conflictAdvisorySummary");
+    expect(response.text).toContain("refreshContext");
     expect(response.text).toContain("formatRangeBearing");
     expect(response.text).toContain("formatTemporalContext");
     expect(response.text).toContain("formatVerticalContext");

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -892,6 +892,10 @@ const deriveConflictAdvisories = () =>
     const replayRelevance = conflict.replayRelevant
       ? "Current replay window"
       : `${conflict.replayTimeDeltaSeconds} s from replay cursor`;
+    const refreshContext =
+      conflict.overlayKind === "area_conflict"
+        ? areaOverlaySourceRefreshCardContext(conflictOverlayForItem(conflict))
+        : null;
 
     return {
       id: conflict.id,
@@ -902,7 +906,16 @@ const deriveConflictAdvisories = () =>
       relatedSource: `${conflict.relatedSource.provider} / ${conflict.relatedSource.sourceType}`,
       reasoning: conflict.explanation,
       relevance: replayRelevance,
-      summary: `${formatRangeBearing(conflict.metrics)} | ${conflict.overlayKind === "area_conflict" ? `${formatTemporalContext(conflict)} | ${formatVerticalContext(conflict)}` : `${formatVerticalSeparation(conflict.metrics?.altitudeDeltaFt)} vertical`}`,
+      refreshContext,
+      summary: [
+        formatRangeBearing(conflict.metrics),
+        conflict.overlayKind === "area_conflict"
+          ? `${formatTemporalContext(conflict)} | ${formatVerticalContext(conflict)}`
+          : `${formatVerticalSeparation(conflict.metrics?.altitudeDeltaFt)} vertical`,
+        refreshContext,
+      ]
+        .filter(Boolean)
+        .join(" | "),
     };
   });
 
@@ -1482,7 +1495,13 @@ const buildOverlayCards = () => {
       ? {
           label: "Primary advisory",
           tone: primaryAdvisory.tone,
-          detail: `${primaryAdvisory.recommendation} | ${primaryAdvisory.relatedObject}`,
+          detail: [
+            primaryAdvisory.recommendation,
+            primaryAdvisory.relatedObject,
+            primaryAdvisory.refreshContext,
+          ]
+            .filter(Boolean)
+            .join(" | "),
         }
       : conflictAdvisorySummary(),
   ];


### PR DESCRIPTION
## Summary

Implements GitHub issue #229 by adding operator-facing partial-refresh summary-card context for normalized area overlays so incomplete authoritative area-source state is visible at a glance in both conflict and advisory summary presentation.

## What changed

- Extended the existing operator-facing live-ops summary-card layer for area-conflict-driven advisories.
- Reused the existing freshness, failed-refresh, and partial-refresh provenance model already present in the live review surface.
- Added area-source refresh context to advisory summaries so operators can distinguish:
  - fresh source state
  - stale source state
  - partial source state
  - failed refresh state
- Preserved carried-forward degraded-state wording for both:
  - partial refresh attempts
  - failed refresh attempts
- Applied the summary-card context in:
  - `conflictAdvisorySummary()`
  - the primary advisory map alert card built in `buildOverlayCards()`
- Preserved compatibility with the detailed review visibility already added in `#226` and the conflict summary-card context already present in `main`.
- Existing behavior remains intact:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling on fresh complete refreshes
  - source traceability
  - refresh-run provenance
  - freshness handling for fresh / stale / partial / failed states
  - failed-refresh provenance
  - partial-refresh provenance
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
- Existing traffic conflict behavior remains unchanged.

## Verification

- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

## Notes

This issue is an operator-facing review refinement only. It does not add operator automation, advisory execution changes, or source-specific conflict-engine branching.

Closes #229.
