### PR TITLE
Add operator-facing NOTAM geometry source visibility

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add operator-facing partial-refresh summary-card context so incomplete authoritative area state is visible at a glance.",
+  "nextBuildStep": "Add operator-facing NOTAM geometry source summary context so geometry provenance is visible at a glance in live operations review.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2069,6 +2069,11 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("carriedForwardFromFailedRefresh");
     expect(response.text).toContain("lastPartialRefreshRunId");
     expect(response.text).toContain("carriedForwardFromPartialRefresh");
+    expect(response.text).toContain("notamGeometryContext");
+    expect(response.text).toContain("areaOverlayNotamGeometryDetail");
+    expect(response.text).toContain("NOTAM geometry");
+    expect(response.text).toContain("Q-line center");
+    expect(response.text).toContain("Q-line radius");
     expect(response.text).toContain("Last failed refresh");
     expect(response.text).toContain("Last partial refresh");
     expect(response.text).toContain("carried forward after partial refresh");

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -122,6 +122,36 @@ const areaConflictOverlays = () =>
 const areaOverlaySourceRefreshState = (overlay) =>
   overlay?.metadata?.sourceRefresh ?? null;
 
+const areaOverlayNotamGeometryContext = (overlay) =>
+  overlay?.metadata?.notamGeometryContext ?? null;
+
+const formatCoordinate = (value) =>
+  value == null || Number.isNaN(value) ? "Not recorded" : Number(value).toFixed(5);
+
+const areaOverlayNotamGeometryDetail = (overlay) => {
+  const geometryContext = areaOverlayNotamGeometryContext(overlay);
+  if (!geometryContext) {
+    return null;
+  }
+
+  const detailParts = [
+    geometryContext.geometrySource === "e_field"
+      ? "NOTAM geometry: E-field"
+      : geometryContext.geometrySource === "q_line"
+        ? "NOTAM geometry: Q-line fallback"
+        : "NOTAM geometry: provided geometry",
+  ];
+
+  if (geometryContext.qLineIndex) {
+    detailParts.push(
+      `Q-line center ${formatCoordinate(geometryContext.qLineIndex.centerLat)}, ${formatCoordinate(geometryContext.qLineIndex.centerLng)}`,
+    );
+    detailParts.push(`Q-line radius ${geometryContext.qLineIndex.radiusNm} NM`);
+  }
+
+  return detailParts.join(" | ");
+};
+
 const areaOverlaySourceRefreshDetail = (overlay) => {
   const refreshState = areaOverlaySourceRefreshState(overlay);
   if (!refreshState) {
@@ -190,7 +220,8 @@ const areaOverlaySourceRefreshCardContext = (overlay) => {
     return `${label} | carried forward after partial refresh`;
   }
 
-  return label;
+  const notamGeometryDetail = areaOverlayNotamGeometryDetail(overlay);
+  return [label, notamGeometryDetail].filter(Boolean).join(" | ");
 };
 
 const areaSourceRefreshSummary = () => {
@@ -2261,6 +2292,10 @@ const renderStatus = () => {
           <div>${renderBadge(areaSourceState.label)}</div>
           <div class="k">Area refresh detail</div>
           <div>${escapeHtml(areaSourceState.detail)}</div>
+          <div class="k">NOTAM geometry</div>
+          <div>${escapeHtml(
+            primaryConflictOverlay ? areaOverlayNotamGeometryDetail(primaryConflictOverlay) ?? "Not recorded" : "Not recorded",
+          )}</div>
           <div class="k">Conflict assessment</div>
           <div>${renderBadge(conflictState.label)}</div>
           <div class="k">Primary conflict</div>
@@ -2475,6 +2510,8 @@ const renderConflictAssessment = () => {
                   ${
                     primaryConflict.overlayKind === "area_conflict"
                       ? `Area source refresh: ${escapeHtml(areaOverlaySourceRefreshDetail(areaConflictOverlays().find((overlay) => overlay.id === primaryConflict.overlayId)))}
+                  <br />
+                  NOTAM geometry: ${escapeHtml(areaOverlayNotamGeometryDetail(areaConflictOverlays().find((overlay) => overlay.id === primaryConflict.overlayId)) ?? "Not recorded")}
                   <br />`
                       : ""
                   }


### PR DESCRIPTION
## Summary

Implements GitHub issue #231 by adding operator-facing NOTAM geometry source visibility for normalized area overlays so operators can distinguish when normalized NOTAM geometry comes from E-field geometry versus Q-line fallback.

## What changed

- Extended the existing live-ops operator review surface for normalized area overlays.
- Reused the normalized NOTAM geometry context already present in overlay metadata rather than adding a new endpoint.
- Added operator-facing NOTAM geometry provenance visibility so review can distinguish:
  - geometry derived from E-field geometry
  - geometry derived from Q-line fallback
  - geometry derived from provided geometry
- Where Q-line index metadata exists, live review now surfaces:
  - Q-line center
  - Q-line radius in NM
- Applied the visibility in the existing area-conflict review flow:
  - operational posture detail
  - primary conflict detail
  - compact area-source context used in summary-card-level presentation
- Preserved the existing internal rule:
  - E-field geometry takes precedence over Q-line geometry
  - Q-line remains coarse indexing metadata
  - internal normalized geometry remains decimal-only
- Existing behavior remains intact:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling on fresh complete refreshes
  - source traceability
  - refresh-run provenance
  - freshness handling for fresh / stale / partial / failed states
  - failed-refresh provenance
  - partial-refresh provenance
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
- Existing traffic conflict behavior remains unchanged.

## Verification

- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

## Notes

This issue is an operator-facing review refinement only. It does not add operator automation, advisory execution changes, or source-specific conflict-engine branching.

Closes #231.
