### PR TITLE
Add operator-facing NOTAM geometry source summary context

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add operator-facing NOTAM geometry source summary context so geometry provenance is visible at a glance in live operations review.",
+  "nextBuildStep": "Add operator-facing Q-line index review visibility so coarse NOTAM index metadata is clearer in live operations review.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2072,7 +2072,11 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("carriedForwardFromPartialRefresh");
     expect(response.text).toContain("notamGeometryContext");
     expect(response.text).toContain("areaOverlayNotamGeometryDetail");
+    expect(response.text).toContain("areaOverlayNotamGeometrySummaryContext");
     expect(response.text).toContain("NOTAM geometry");
+    expect(response.text).toContain("NOTAM geometry E-field");
+    expect(response.text).toContain("NOTAM geometry Q-line fallback");
+    expect(response.text).toContain("NOTAM geometry provided");
     expect(response.text).toContain("Q-line center");
     expect(response.text).toContain("Q-line radius");
     expect(response.text).toContain("Last failed refresh");

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -152,6 +152,19 @@ const areaOverlayNotamGeometryDetail = (overlay) => {
   return detailParts.join(" | ");
 };
 
+const areaOverlayNotamGeometrySummaryContext = (overlay) => {
+  const geometryContext = areaOverlayNotamGeometryContext(overlay);
+  if (!geometryContext) {
+    return null;
+  }
+
+  return geometryContext.geometrySource === "e_field"
+    ? "NOTAM geometry E-field"
+    : geometryContext.geometrySource === "q_line"
+      ? "NOTAM geometry Q-line fallback"
+      : "NOTAM geometry provided";
+};
+
 const areaOverlaySourceRefreshDetail = (overlay) => {
   const refreshState = areaOverlaySourceRefreshState(overlay);
   if (!refreshState) {
@@ -194,7 +207,7 @@ const areaOverlaySourceRefreshDetail = (overlay) => {
 const areaOverlaySourceRefreshCardContext = (overlay) => {
   const refreshState = areaOverlaySourceRefreshState(overlay);
   if (!refreshState) {
-    return null;
+    return areaOverlayNotamGeometrySummaryContext(overlay);
   }
 
   const label =
@@ -220,8 +233,8 @@ const areaOverlaySourceRefreshCardContext = (overlay) => {
     return `${label} | carried forward after partial refresh`;
   }
 
-  const notamGeometryDetail = areaOverlayNotamGeometryDetail(overlay);
-  return [label, notamGeometryDetail].filter(Boolean).join(" | ");
+  const notamGeometryContext = areaOverlayNotamGeometrySummaryContext(overlay);
+  return [label, notamGeometryContext].filter(Boolean).join(" | ");
 };
 
 const areaSourceRefreshSummary = () => {


### PR DESCRIPTION
## Summary

Implements GitHub issue #233 by adding operator-facing NOTAM geometry source summary context for normalized area overlays so geometry provenance is visible at a glance in live operational review.

## What changed

- Extended the existing live-ops operator summary-card surface for normalized area overlays.
- Reused the normalized NOTAM geometry context already present in overlay metadata rather than adding a new endpoint.
- Added compact summary-card geometry provenance so operators can distinguish at a glance:
  - geometry derived from E-field geometry
  - geometry derived from Q-line fallback
  - geometry derived from provided geometry
- Applied the summary context in the existing compact summary paths used by:
  - primary conflict summary cards
  - advisory summary cards
  - fallback summary helpers
- Preserved the existing detailed review visibility for:
  - Q-line center
  - Q-line radius
- Preserved the existing internal rule:
  - E-field geometry takes precedence over Q-line geometry
  - Q-line remains coarse indexing metadata
  - internal normalized geometry remains decimal-only
- Existing behavior remains intact:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling on fresh complete refreshes
  - source traceability
  - refresh-run provenance
  - freshness handling for fresh / stale / partial / failed states
  - failed-refresh provenance
  - partial-refresh provenance
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
- Existing traffic conflict behavior remains unchanged.

## Verification

- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

## Notes

This issue is an operator-facing review refinement only. It does not add operator automation, advisory execution changes, or source-specific conflict-engine branching.

Closes #233.
