### PR TITLE
Add operator-facing Q-line index review visibility

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -89,7 +89,7 @@
     ]
 
   },
-  "nextBuildStep": "Add operator-facing Q-line index review visibility so coarse NOTAM index metadata is clearer in live operations review.",
+  "nextBuildStep": "Add operator-facing Q-line index summary context so coarse NOTAM index metadata is clearer at a glance in live operations review.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2073,10 +2073,13 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("notamGeometryContext");
     expect(response.text).toContain("areaOverlayNotamGeometryDetail");
     expect(response.text).toContain("areaOverlayNotamGeometrySummaryContext");
+    expect(response.text).toContain("areaOverlayQLineIndexReviewContext");
     expect(response.text).toContain("NOTAM geometry");
     expect(response.text).toContain("NOTAM geometry E-field");
     expect(response.text).toContain("NOTAM geometry Q-line fallback");
     expect(response.text).toContain("NOTAM geometry provided");
+    expect(response.text).toContain("Q-line index metadata");
+    expect(response.text).toContain("coarse index only");
     expect(response.text).toContain("Q-line center");
     expect(response.text).toContain("Q-line radius");
     expect(response.text).toContain("Last failed refresh");

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -165,6 +165,21 @@ const areaOverlayNotamGeometrySummaryContext = (overlay) => {
       : "NOTAM geometry provided";
 };
 
+const areaOverlayQLineIndexReviewContext = (overlay) => {
+  const geometryContext = areaOverlayNotamGeometryContext(overlay);
+  const qLineIndex = geometryContext?.qLineIndex;
+  if (!qLineIndex) {
+    return null;
+  }
+
+  return [
+    "Q-line index metadata",
+    `center ${formatCoordinate(qLineIndex.centerLat)}, ${formatCoordinate(qLineIndex.centerLng)}`,
+    `radius ${qLineIndex.radiusNm} NM`,
+    "coarse index only",
+  ].join(" | ");
+};
+
 const areaOverlaySourceRefreshDetail = (overlay) => {
   const refreshState = areaOverlaySourceRefreshState(overlay);
   if (!refreshState) {
@@ -234,7 +249,8 @@ const areaOverlaySourceRefreshCardContext = (overlay) => {
   }
 
   const notamGeometryContext = areaOverlayNotamGeometrySummaryContext(overlay);
-  return [label, notamGeometryContext].filter(Boolean).join(" | ");
+  const qLineIndexContext = areaOverlayQLineIndexReviewContext(overlay);
+  return [label, notamGeometryContext, qLineIndexContext].filter(Boolean).join(" | ");
 };
 
 const areaSourceRefreshSummary = () => {


### PR DESCRIPTION
## Summary

Implements GitHub issue #235 by adding operator-facing Q-line index review visibility for normalized area overlays so coarse NOTAM index metadata is clearer during live operational review.

## What changed

- Extended the existing live-ops operator review surface for normalized area overlays.
- Reused the normalized NOTAM geometry context already present in overlay metadata rather than adding a new endpoint.
- Added explicit Q-line index review context where Q-line metadata exists:
  - `Q-line index metadata`
  - center
  - radius in NM
  - `coarse index only`
- Preserved compatibility with the existing NOTAM geometry source visibility in both:
  - detailed review context
  - summary-card context
- Applied the new Q-line index wording inside the existing compact area-source context used by live-ops review cards.
- Preserved the existing internal rule:
  - E-field geometry takes precedence over Q-line geometry
  - Q-line remains coarse indexing metadata
  - internal normalized geometry remains decimal-only
- Existing behavior remains intact:
  - same-run deduplication
  - repeated-run supersession
  - retirement handling on fresh complete refreshes
  - source traceability
  - refresh-run provenance
  - freshness handling for fresh / stale / partial / failed states
  - failed-refresh provenance
  - partial-refresh provenance
  - geometry-aware area conflict assessment
  - altitude-band gating
  - validity-window gating
- Existing traffic conflict behavior remains unchanged.

## Verification

- `.\\node_modules\\.bin\\vitest.cmd run src\\tests\\mission-planning.test.ts` passed: 37 tests.
- `npm.cmd run build` passed.
- `node scripts\\validate-save-point.mjs fsms-save-point.json` passed.

## Notes

This issue is an operator-facing review refinement only. It does not add operator automation, advisory execution changes, or source-specific conflict-engine branching.

Closes #235.
