### PR TITLE
Add post-operation source record drilldowns

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,32 +1,32 @@
 # NEXT STEP
 
 ## Goal
-Connect post-operation evidence drill-downs to deeper source-record detail views.
+Add visual focus handling for source-record drill-down targets.
 
 ---
 
 ## Build
 
 ### 1. Operator visibility
-- expand the new drill-down cards beyond panel-level navigation
-- link safety/SOP follow-up to the exact safety event, action proposal, or implementation evidence where available
-- link regulatory review records to the specific alert, mapping, and review action history
+- read drill-down query parameters such as map evidence ID and conflict acknowledgement ID
+- highlight the matching source record in live-ops evidence history or conflict review context
+- highlight timeline/regulatory sections when opened from the mission workspace drill-down cards
 
 ### 2. Product boundary
 - continue to label demo airspace data as synthetic/local
 - do not imply live CAA, NOTAM, or manufacturer feed connectivity
-- keep source-record links framed as audit review support, not compliance certification
+- keep visual focus framed as audit review support, not compliance certification or automated closure
 
 ### 3. Tests
-- add focused API and UI tests for source-record drill-down targets
+- add focused live-ops and mission workspace UI tests for drill-down focus state
 - run mission-planning UI tests
 - run TypeScript build and diff whitespace check
 
 ---
 
 ## Done When
-- Mission workspace can jump from summary readiness prompts to the most relevant source evidence records
-- Links target the current mission and existing source evidence views
+- Source-record drill-down links visually focus the relevant record or review section
+- Focus state remains shareable by URL and safe when the referenced record is missing
 - Copy remains explicit that links support audit review, not compliance certification
 - Degraded or carried-forward overlays remain visually distinguishable
 - The demo remains clearly synthetic and safe for local presentation

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -23,7 +23,8 @@
       "Accountable manager governance summary and risk-stage surface",
       "Operator document portal cards with preview/download actions and role-context access wording",
       "Mission planning and dispatch governance panels with OA, insurance, pilot authorisation, and pending-amendment status",
-      "Post-operation evidence readiness drill-down links in the operator mission workspace"
+      "Post-operation evidence readiness drill-down links in the operator mission workspace",
+      "Latest source-record links and source JSON actions on post-operation evidence readiness drill-down cards"
     ],
     "confirmedInputOutputChains": [
       "OA/insurance source document metadata -> assessment service -> mission governance summary -> risk-map/dashboard output",
@@ -43,7 +44,8 @@
       "Rewired app route ordering so governance routes coexist with the evolved mission and live-ops route set",
       "Updated package dependencies to patch known vulnerable dev dependency versions",
       "Adjusted organisation document portal test expectations to remain stable with expanded seeded pilot data",
-      "Added mission workspace drill-down links from post-operation readiness categories to live-ops map evidence, conflict review context, operations timeline, regulatory matrix, and rendered audit report"
+      "Added mission workspace drill-down links from post-operation readiness categories to live-ops map evidence, conflict review context, operations timeline, regulatory matrix, and rendered audit report",
+      "Extended post-operation evidence readiness categories with source record metadata for latest map, conflict, safety, and regulatory evidence"
     ],
     "removed": [],
     "fixed": [
@@ -118,7 +120,8 @@
     "userVisibleBehaviorChanges": [
       "Operators can see why an OA, insurance policy, or pilot authorisation needs review before mission dispatch",
       "Accountable managers can inspect headline risk pressure earlier from a single dashboard surface",
-      "Operators can jump from post-operation readiness prompts to the relevant evidence review surface instead of manually hunting through the workspace"
+      "Operators can jump from post-operation readiness prompts to the relevant evidence review surface instead of manually hunting through the workspace",
+      "Operators can open the latest source record or source JSON behind each populated post-operation readiness category"
     ]
   },
   "complianceImplications": {
@@ -135,7 +138,8 @@
     ],
     "auditTraceabilityImpact": [
       "Mission governance joins OA and insurance state into dispatch evidence",
-      "Document preview/download and evidence-pack concepts preserve source-document accountability"
+      "Document preview/download and evidence-pack concepts preserve source-document accountability",
+      "Post-operation readiness now carries source record IDs, review URLs, and API URLs so audit prompts remain traceable to underlying evidence"
     ]
   },
   "risksLimitations": {
@@ -175,11 +179,12 @@
       "Validated focused governance tests for OA, insurance, mission governance, risk map, accountable-manager dashboard, stored files, and organisation documents after the merge",
       "Validated external overlay tests after preserving main-branch live-ops and map evidence work",
       "Validated mission lifecycle request and correlation IDs are persisted on submitted, approved, and launched audit events",
-      "Validated recovered migrations with npm run migrate:test against the configured Postgres test database after PR 238 merged"
+      "Validated recovered migrations with npm run migrate:test against the configured Postgres test database after PR 238 merged",
+      "Validated source-record drill-down metadata with audit evidence and mission planning focused tests"
     ]
 
   },
-  "nextBuildStep": "Connect post-operation evidence drill-downs to deeper source-record detail views.",
+  "nextBuildStep": "Add visual focus handling for source-record drill-down targets.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -33,6 +33,7 @@ import type {
   PostOperationEvidencePdf,
   PostOperationEvidenceReadiness,
   PostOperationEvidenceReadinessCategory,
+  PostOperationEvidenceReadinessSourceRecord,
   PostOperationEvidenceRenderedReport,
   PostOperationEvidenceSnapshot,
 } from "./audit-evidence.types";
@@ -667,6 +668,8 @@ export class AuditEvidenceService {
   private buildPostOperationEvidenceReadinessCategories(
     evidenceExport: PostOperationEvidenceExportPackage,
   ): PostOperationEvidenceReadinessCategory[] {
+    const missionId = evidenceExport.missionId;
+
     return [
       {
         key: "live_ops_map_view_state_snapshots",
@@ -680,6 +683,17 @@ export class AuditEvidenceService {
           evidenceExport.liveOpsMapViewStateSnapshots.length > 0
             ? "Live-ops map view-state metadata is included for accountable-manager review; it is metadata-only evidence and not pilot command guidance."
             : "No live-ops map view-state metadata is recorded in this evidence pack; this is a review prompt only, not an automatic rejection or compliance certificate.",
+        sourceRecords: evidenceExport.liveOpsMapViewStateSnapshots.map(
+          (snapshot) =>
+            this.buildReadinessSourceRecord({
+              id: snapshot.id,
+              label: "Map view-state snapshot",
+              summary: `${snapshot.captureScope}; ${snapshot.visibleAreaOverlayCount}/${snapshot.totalAreaOverlayCount} area overlays visible; ${snapshot.degradedAreaOverlayCount} degraded`,
+              recordedAt: snapshot.createdAt,
+              apiUrl: `/missions/${missionId}/live-operations/map-view-state/audit-snapshots`,
+              reviewUrl: `/operator/missions/${missionId}/live-operations?mapEvidenceId=${snapshot.id}`,
+            }),
+        ),
       },
       {
         key: "conflict_guidance_acknowledgements",
@@ -693,6 +707,17 @@ export class AuditEvidenceService {
           evidenceExport.conflictGuidanceAcknowledgements.length > 0
             ? "Live conflict guidance acknowledgements are included for review."
             : "No live conflict guidance acknowledgements are recorded in this evidence pack.",
+        sourceRecords: evidenceExport.conflictGuidanceAcknowledgements.map(
+          (acknowledgement) =>
+            this.buildReadinessSourceRecord({
+              id: acknowledgement.id,
+              label: "Conflict acknowledgement",
+              summary: `${acknowledgement.conflictId}; ${acknowledgement.guidanceActionCode}; ${acknowledgement.acknowledgementRole}`,
+              recordedAt: acknowledgement.createdAt,
+              apiUrl: `/missions/${missionId}/conflict-guidance-acknowledgements`,
+              reviewUrl: `/operator/missions/${missionId}/live-operations?conflictAcknowledgementId=${acknowledgement.id}`,
+            }),
+        ),
       },
       {
         key: "safety_action_closure_evidence",
@@ -706,6 +731,17 @@ export class AuditEvidenceService {
           evidenceExport.safetyActionClosureEvidence.length > 0
             ? "Safety action closure evidence is included for review."
             : "No safety action closure evidence is recorded in this evidence pack.",
+        sourceRecords: evidenceExport.safetyActionClosureEvidence.map(
+          (evidence) =>
+            this.buildReadinessSourceRecord({
+              id: evidence.implementationEvidenceId,
+              label: "Safety action implementation evidence",
+              summary: `${evidence.evidenceCategory}; ${evidence.proposalType}; ${evidence.implementationSummary}`,
+              recordedAt: evidence.completedAt,
+              apiUrl: `/safety-events/${evidence.safetyEventId}/agenda-links/${evidence.safetyEventAgendaLinkId}/action-proposals/${evidence.safetyActionProposalId}/implementation-evidence`,
+              reviewUrl: `/operator/mission-workspace?missionId=${missionId}#timeline-panel`,
+            }),
+        ),
       },
       {
         key: "regulatory_amendment_reviews",
@@ -719,8 +755,24 @@ export class AuditEvidenceService {
           evidenceExport.regulatoryAmendmentAlerts.length > 0
             ? "Regulatory amendment review records are included for review."
             : "No regulatory amendment review records are recorded in this evidence pack.",
+        sourceRecords: evidenceExport.regulatoryAmendmentAlerts.map((alert) =>
+          this.buildReadinessSourceRecord({
+            id: alert.id,
+            label: "Regulatory amendment alert",
+            summary: `${alert.status}; ${alert.severity}; ${alert.message}`,
+            recordedAt: alert.triggeredAt,
+            apiUrl: `/missions/${missionId}/alerts`,
+            reviewUrl: `/operator/mission-workspace?missionId=${missionId}#regulatory-matrix-panel`,
+          }),
+        ),
       },
     ];
+  }
+
+  private buildReadinessSourceRecord(
+    record: PostOperationEvidenceReadinessSourceRecord,
+  ): PostOperationEvidenceReadinessSourceRecord {
+    return record;
   }
 
   private buildReadinessEvidenceSnapshot(

--- a/src/audit-evidence/audit-evidence.types.ts
+++ b/src/audit-evidence/audit-evidence.types.ts
@@ -310,6 +310,16 @@ export interface PostOperationEvidenceReadinessCategory {
   count: number;
   status: "present" | "not_recorded";
   message: string;
+  sourceRecords: PostOperationEvidenceReadinessSourceRecord[];
+}
+
+export interface PostOperationEvidenceReadinessSourceRecord {
+  id: string;
+  label: string;
+  summary: string;
+  recordedAt: string;
+  apiUrl: string;
+  reviewUrl: string;
 }
 
 export interface PostOperationEvidenceReadiness {

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -1820,6 +1820,7 @@ describe("audit evidence snapshots", () => {
         label: "Live-ops map view-state snapshots",
         count: 0,
         status: "not_recorded",
+        sourceRecords: [],
         message:
           "No live-ops map view-state metadata is recorded in this evidence pack; this is a review prompt only, not an automatic rejection or compliance certificate.",
       }),
@@ -1844,7 +1845,7 @@ describe("audit evidence snapshots", () => {
 
   it("summarizes post-operation evidence readiness with records and sign-off state", async () => {
     const { missionId } = await createCompletedMission();
-    await request(app)
+    const mapSnapshotResponse = await request(app)
       .post(
         `/missions/${missionId}/live-operations/map-view-state/audit-snapshots`,
       )
@@ -1859,11 +1860,12 @@ describe("audit evidence snapshots", () => {
         activeConflictCount: 1,
         areaRefreshRunCount: 5,
       });
-    await createConflictGuidanceAcknowledgement(missionId, {
+    expect(mapSnapshotResponse.status).toBe(201);
+    const acknowledgement = await createConflictGuidanceAcknowledgement(missionId, {
       conflictId: "conflict-readiness-1",
     });
-    await createSafetyActionClosureEvidence(missionId);
-    await createRegulatoryAmendmentAlert(missionId, {
+    const closure = await createSafetyActionClosureEvidence(missionId);
+    const alert = await createRegulatoryAmendmentAlert(missionId, {
       acknowledge: true,
     });
     const snapshotResponse = await request(app)
@@ -1917,6 +1919,14 @@ describe("audit evidence snapshots", () => {
         label: "Live-ops map view-state snapshots",
         count: 1,
         status: "present",
+        sourceRecords: [
+          expect.objectContaining({
+            id: mapSnapshotResponse.body.snapshot.id,
+            label: "Map view-state snapshot",
+            apiUrl: `/missions/${missionId}/live-operations/map-view-state/audit-snapshots`,
+            reviewUrl: `/operator/missions/${missionId}/live-operations?mapEvidenceId=${mapSnapshotResponse.body.snapshot.id}`,
+          }),
+        ],
         message:
           "Live-ops map view-state metadata is included for accountable-manager review; it is metadata-only evidence and not pilot command guidance.",
       }),
@@ -1924,16 +1934,40 @@ describe("audit evidence snapshots", () => {
         key: "conflict_guidance_acknowledgements",
         count: 1,
         status: "present",
+        sourceRecords: [
+          expect.objectContaining({
+            id: acknowledgement.id,
+            label: "Conflict acknowledgement",
+            apiUrl: `/missions/${missionId}/conflict-guidance-acknowledgements`,
+            reviewUrl: `/operator/missions/${missionId}/live-operations?conflictAcknowledgementId=${acknowledgement.id}`,
+          }),
+        ],
       }),
       expect.objectContaining({
         key: "safety_action_closure_evidence",
         count: 1,
         status: "present",
+        sourceRecords: [
+          expect.objectContaining({
+            id: closure.evidence.id,
+            label: "Safety action implementation evidence",
+            apiUrl: `/safety-events/${closure.event.id}/agenda-links/${closure.agendaLink.id}/action-proposals/${closure.proposal.id}/implementation-evidence`,
+            reviewUrl: `/operator/mission-workspace?missionId=${missionId}#timeline-panel`,
+          }),
+        ],
       }),
       expect.objectContaining({
         key: "regulatory_amendment_reviews",
         count: 1,
         status: "present",
+        sourceRecords: [
+          expect.objectContaining({
+            id: alert.id,
+            label: "Regulatory amendment alert",
+            apiUrl: `/missions/${missionId}/alerts`,
+            reviewUrl: `/operator/mission-workspace?missionId=${missionId}#regulatory-matrix-panel`,
+          }),
+        ],
       }),
     ]);
     expect(await countRows(missionId)).toEqual(before);

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2007,6 +2007,12 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("Evidence Drill-down Links");
     expect(response.text).toContain("renderReadinessDrilldowns");
     expect(response.text).toContain("renderReadinessDrilldownCard");
+    expect(response.text).toContain("latestReadinessSourceRecord");
+    expect(response.text).toContain("Latest source record:");
+    expect(response.text).toContain("Open source JSON");
+    expect(response.text).toContain("sourceRecords");
+    expect(response.text).toContain("reviewUrl");
+    expect(response.text).toContain("apiUrl");
     expect(response.text).toContain("Open live-ops map evidence");
     expect(response.text).toContain("Review live conflict evidence");
     expect(response.text).toContain("Review operations timeline");

--- a/static/operator-mission-workspace.js
+++ b/static/operator-mission-workspace.js
@@ -393,6 +393,9 @@ const readinessCategory = (key) =>
 const readinessCategoryLabel = (category) =>
   category ? `${category.count} ${category.status}` : "Not loaded";
 
+const latestReadinessSourceRecord = (category) =>
+  category?.sourceRecords?.[0] ?? null;
+
 const renderReadinessDrilldownCard = ({
   title,
   category,
@@ -400,26 +403,43 @@ const renderReadinessDrilldownCard = ({
   actionLabel,
   description,
   targetBlank = false,
-}) => `
-  <section class="action-card">
-    <h4>${escapeHtml(title)}</h4>
-    <div>${renderBadge(readinessCategoryLabel(category))}</div>
-    <div class="action-meta">
-      ${escapeHtml(category?.message ?? description)}
-    </div>
-    <div class="action-footer" style="justify-content: flex-start;">
-      ${
-        href
-          ? `<a class="action-button link-button" href="${escapeHtml(href)}"${
-              targetBlank ? ' target="_blank" rel="noopener"' : ""
-            }>
-              ${escapeHtml(actionLabel)}
-            </a>`
-          : `<div class="action-status tone-warn">Create a post-operation snapshot before this drill-down is available.</div>`
-      }
-    </div>
-  </section>
-`;
+}) => {
+  const sourceRecord = latestReadinessSourceRecord(category);
+  const reviewHref = sourceRecord?.reviewUrl ?? href;
+  const apiHref = sourceRecord?.apiUrl ?? "";
+  const linkTarget = targetBlank ? ' target="_blank" rel="noopener"' : "";
+
+  return `
+    <section class="action-card">
+      <h4>${escapeHtml(title)}</h4>
+      <div>${renderBadge(readinessCategoryLabel(category))}</div>
+      <div class="action-meta">
+        ${escapeHtml(category?.message ?? description)}
+        ${
+          sourceRecord
+            ? `<br />Latest source record: ${escapeHtml(sourceRecord.label)} ${escapeHtml(sourceRecord.id)} recorded ${escapeHtml(formatDateTime(sourceRecord.recordedAt))}.`
+            : ""
+        }
+      </div>
+      <div class="action-footer" style="justify-content: flex-start;">
+        ${
+          reviewHref
+            ? `<a class="action-button link-button" href="${escapeHtml(reviewHref)}"${linkTarget}>
+                ${escapeHtml(sourceRecord ? `Open ${sourceRecord.label}` : actionLabel)}
+              </a>`
+            : `<div class="action-status tone-warn">Create a post-operation snapshot before this drill-down is available.</div>`
+        }
+        ${
+          apiHref
+            ? `<a class="action-button link-button" href="${escapeHtml(apiHref)}" target="_blank" rel="noopener">
+                Open source JSON
+              </a>`
+            : ""
+        }
+      </div>
+    </section>
+  `;
+};
 
 const renderReadinessDrilldowns = ({
   mapEvidenceUrl,


### PR DESCRIPTION
## Summary
- Adds source-record metadata to post-operation evidence readiness categories.
- Provides latest source record IDs, summaries, timestamps, review URLs, and API URLs for map evidence, conflict acknowledgements, safety action evidence, and regulatory amendment alerts.
- Updates the operator mission workspace so drill-down cards can open the latest source record or source JSON.
- Keeps the workflow framed as accountable audit review support, not compliance certification.

## Verification
- `npm run build`
- `npm run validate:savepoint`
- `npx vitest run src/tests/audit-evidence.test.ts --pool=threads --reporter=dot`
- `npx vitest run src/tests/mission-planning.test.ts --pool=threads --reporter=dot`
