### PR TITLE
Add source-record detail panels

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,32 +1,32 @@
 # NEXT STEP
 
 ## Goal
-Add deeper source-record detail panels for safety and regulatory review.
+Add accountable review outcomes for safety and regulatory source records.
 
 ---
 
 ## Build
 
 ### 1. Operator visibility
-- show source-record context inside the focused timeline and regulatory sections
-- surface latest safety/SOP follow-up cues with linked timeline evidence
-- surface regulatory amendment source records with affected requirement rows and review state
+- add lightweight review outcome controls to safety/SOP and regulatory source-record panels
+- capture review state such as noted, needs action, or accepted for evidence pack
+- show latest review outcome next to the source record before accountable-manager sign-off
 
 ### 2. Product boundary
 - continue to label demo airspace data as synthetic/local
 - do not imply live CAA, NOTAM, or manufacturer feed connectivity
-- keep source-record details framed as accountable review support, not compliance certification or automated closure
+- keep review outcomes framed as internal accountable review notes, not compliance certification or regulatory submission
 
 ### 3. Tests
-- add mission workspace UI tests for focused safety and regulatory source-record detail context
+- add backend and mission workspace UI tests for source-record review outcomes
 - run mission-planning UI tests
 - run TypeScript build and diff whitespace check
 
 ---
 
 ## Done When
-- Timeline and regulatory focus sections show the most relevant source-record detail without manual hunting
-- Safety/SOP and regulatory review prompts remain linked to evidence and review state
+- Safety/SOP and regulatory source records can carry an explicit accountable review outcome
+- Mission workspace shows latest outcome state without implying certification or automatic closure
 - Copy remains explicit that links support audit review, not compliance certification
 - Degraded or carried-forward overlays remain visually distinguishable
 - The demo remains clearly synthetic and safe for local presentation

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -46,7 +46,8 @@
       "Adjusted organisation document portal test expectations to remain stable with expanded seeded pilot data",
       "Added mission workspace drill-down links from post-operation readiness categories to live-ops map evidence, conflict review context, operations timeline, regulatory matrix, and rendered audit report",
       "Extended post-operation evidence readiness categories with source record metadata for latest map, conflict, safety, and regulatory evidence",
-      "Added URL-driven visual focus for source-record drill-downs into live-ops map evidence, conflict acknowledgements, operations timeline, and regulatory matrix review sections"
+      "Added URL-driven visual focus for source-record drill-downs into live-ops map evidence, conflict acknowledgements, operations timeline, and regulatory matrix review sections",
+      "Added focused safety/SOP and regulatory source-record detail panels inside the mission workspace timeline and regulatory review sections"
     ],
     "removed": [],
     "fixed": [
@@ -123,7 +124,8 @@
       "Accountable managers can inspect headline risk pressure earlier from a single dashboard surface",
       "Operators can jump from post-operation readiness prompts to the relevant evidence review surface instead of manually hunting through the workspace",
       "Operators can open the latest source record or source JSON behind each populated post-operation readiness category",
-      "Operators now see a focused review cue when a source-record drill-down lands on the relevant live-ops or mission-workspace evidence area"
+      "Operators now see a focused review cue when a source-record drill-down lands on the relevant live-ops or mission-workspace evidence area",
+      "Operators can review safety/SOP and regulatory source-record IDs, summaries, timestamps, source JSON links, and review surfaces without manually hunting through the workspace"
     ]
   },
   "complianceImplications": {
@@ -142,7 +144,8 @@
       "Mission governance joins OA and insurance state into dispatch evidence",
       "Document preview/download and evidence-pack concepts preserve source-document accountability",
       "Post-operation readiness now carries source record IDs, review URLs, and API URLs so audit prompts remain traceable to underlying evidence",
-      "Source-record drill-down review URLs preserve evidence IDs and highlight the relevant review surface without treating the item as certified, closed, or automatically resolved"
+      "Source-record drill-down review URLs preserve evidence IDs and highlight the relevant review surface without treating the item as certified, closed, or automatically resolved",
+      "Safety/SOP and regulatory drill-down sections now display source-record detail as accountable review support, not compliance certification or automatic closure"
     ]
   },
   "risksLimitations": {
@@ -184,11 +187,12 @@
       "Validated mission lifecycle request and correlation IDs are persisted on submitted, approved, and launched audit events",
       "Validated recovered migrations with npm run migrate:test against the configured Postgres test database after PR 238 merged",
       "Validated source-record drill-down metadata with audit evidence and mission planning focused tests",
-      "Validated source-record drill-down focus state with TypeScript build and mission-planning UI tests"
+      "Validated source-record drill-down focus state with TypeScript build and mission-planning UI tests",
+      "Validated safety/SOP and regulatory focused source-record detail panels with TypeScript build and mission-planning UI tests"
     ]
 
   },
-  "nextBuildStep": "Add deeper source-record detail panels for safety and regulatory review.",
+  "nextBuildStep": "Add accountable review outcomes for safety and regulatory source records.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2017,6 +2017,12 @@ describe("mission planning drafts", () => {
       expect(response.text).toContain("renderWorkspaceFocusNote");
       expect(response.text).toContain("applyWorkspaceFocusState");
       expect(response.text).toContain("opened from a post-operation source-record drill-down");
+      expect(response.text).toContain("renderFocusedSourceRecordDetails");
+      expect(response.text).toContain("Regulatory Source Records");
+      expect(response.text).toContain("Safety and SOP Source Records");
+      expect(response.text).toContain("Latest source record");
+      expect(response.text).toContain("Open review surface");
+      expect(response.text).toContain("These records support accountable review only");
       expect(response.text).toContain("Open live-ops map evidence");
       expect(response.text).toContain("Review live conflict evidence");
       expect(response.text).toContain("Review operations timeline");

--- a/static/operator-mission-workspace.js
+++ b/static/operator-mission-workspace.js
@@ -421,6 +421,75 @@ const readinessCategoryLabel = (category) =>
 const latestReadinessSourceRecord = (category) =>
   category?.sourceRecords?.[0] ?? null;
 
+const renderSourceRecordActions = (sourceRecord) => `
+  <div class="action-footer" style="justify-content: flex-start; margin-top: 10px;">
+    ${
+      sourceRecord.reviewUrl
+        ? `<a class="action-button link-button" href="${escapeHtml(sourceRecord.reviewUrl)}">
+            Open review surface
+          </a>`
+        : ""
+    }
+    ${
+      sourceRecord.apiUrl
+        ? `<a class="action-button link-button" href="${escapeHtml(sourceRecord.apiUrl)}" target="_blank" rel="noopener">
+            Open source JSON
+          </a>`
+        : ""
+    }
+  </div>
+`;
+
+const renderFocusedSourceRecordDetails = ({
+  categoryKey,
+  title,
+  emptyMessage,
+  relatedReviewDetail = "",
+}) => {
+  const category = readinessCategory(categoryKey);
+  const sourceRecords = category?.sourceRecords ?? [];
+
+  return `
+    <section class="summary-block focus-target" style="margin-bottom: 14px;">
+      <h4>${escapeHtml(title)}</h4>
+      <div>${renderBadge(readinessCategoryLabel(category))}</div>
+      <div class="action-meta" style="margin-top: 10px;">
+        ${escapeHtml(
+          category?.message ??
+            "Source-record readiness is not loaded for this mission yet.",
+        )}
+        <br />These records support accountable review only; they do not certify compliance or automatically close safety, SOP, or regulatory actions.
+        ${relatedReviewDetail ? `<br />${escapeHtml(relatedReviewDetail)}` : ""}
+      </div>
+      ${
+        sourceRecords.length === 0
+          ? `<div class="empty-state" style="margin-top: 12px;">${escapeHtml(emptyMessage)}</div>`
+          : `<div class="action-grid" style="margin-top: 12px;">
+              ${sourceRecords
+                .map(
+                  (sourceRecord, index) => `
+                    <article class="action-card${index === 0 ? " focus-target" : ""}">
+                      <h4>${escapeHtml(sourceRecord.label)}</h4>
+                      <div>${index === 0 ? renderBadge("Latest source record") : renderBadge("Source record")}</div>
+                      <div class="kv" style="margin-top: 10px;">
+                        <div class="k">Record ID</div>
+                        <div>${escapeHtml(sourceRecord.id)}</div>
+                        <div class="k">Recorded</div>
+                        <div>${escapeHtml(formatDateTime(sourceRecord.recordedAt))}</div>
+                        <div class="k">Summary</div>
+                        <div>${escapeHtml(sourceRecord.summary)}</div>
+                      </div>
+                      ${renderSourceRecordActions(sourceRecord)}
+                    </article>
+                  `,
+                )
+                .join("")}
+            </div>`
+      }
+    </section>
+  `;
+};
+
 const renderReadinessDrilldownCard = ({
   title,
   category,
@@ -1221,6 +1290,19 @@ const renderRegulatoryMatrix = () => {
         ? renderWorkspaceFocusNote("Regulatory matrix")
         : ""
     }
+    ${
+      isWorkspaceFocusTarget("regulatory-matrix-panel")
+        ? renderFocusedSourceRecordDetails({
+            categoryKey: "regulatory_amendment_reviews",
+            title: "Regulatory Source Records",
+            emptyMessage:
+              "No regulatory amendment source records are captured in the latest post-operation readiness view.",
+            relatedReviewDetail: reviewImpact
+              ? `${reviewImpact.impactedMappingCount} requirement rows are currently linked to amendment review impact.`
+              : "Load a mission to connect amendment records to impacted requirement rows.",
+          })
+        : ""
+    }
     <div class="summary-grid" style="margin-bottom: 14px;">
       <section class="summary-block">
         <h4>Matrix Status</h4>
@@ -1639,6 +1721,17 @@ const renderTimeline = () => {
   timelinePanel.innerHTML = `${
     isWorkspaceFocusTarget("timeline-panel")
       ? renderWorkspaceFocusNote("Operations timeline")
+      : ""
+  }${
+    isWorkspaceFocusTarget("timeline-panel")
+      ? renderFocusedSourceRecordDetails({
+          categoryKey: "safety_action_closure_evidence",
+          title: "Safety and SOP Source Records",
+          emptyMessage:
+            "No safety action or SOP follow-up source records are captured in the latest post-operation readiness view.",
+          relatedReviewDetail:
+            "Review the mission timeline below to connect safety/SOP evidence to the operational sequence.",
+        })
       : ""
   }${phaseSummary}${renderedItems}`;
 };


### PR DESCRIPTION
## Summary
- Adds focused Safety/SOP source-record detail panels above the operations timeline
- Adds focused Regulatory source-record detail panels above the regulatory matrix
- Shows record ID, timestamp, summary, review surface link, and source JSON link
- Keeps the wording framed as accountable review support, not compliance certification or automatic closure

## Validation
- npm.cmd run build
- npx.cmd vitest run src/tests/mission-planning.test.ts --pool=threads --reporter=verbose
- npm.cmd run validate:savepoint
- git diff --check
