### PR TITLE
Model SOPs under operational authority

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,32 +1,32 @@
 # NEXT STEP
 
 ## Goal
-Add accountable review outcomes for safety and regulatory source records.
+Connect SOP-linked change recommendations to mission evidence.
 
 ---
 
 ## Build
 
 ### 1. Operator visibility
-- add lightweight review outcome controls to safety/SOP and regulatory source-record panels
-- capture review state such as noted, needs action, or accepted for evidence pack
-- show latest review outcome next to the source record before accountable-manager sign-off
+- generate draft change recommendation records against linked SOP documents
+- show which SOP code, SOP clause, and parent OA condition a recommendation relates to
+- keep the recommendation visible in the post-operation review flow before accountable-manager sign-off
 
 ### 2. Product boundary
 - continue to label demo airspace data as synthetic/local
 - do not imply live CAA, NOTAM, or manufacturer feed connectivity
-- keep review outcomes framed as internal accountable review notes, not compliance certification or regulatory submission
+- keep recommendations framed as accountable review prompts, not automatic SOP amendment or regulatory submission
 
 ### 3. Tests
-- add backend and mission workspace UI tests for source-record review outcomes
+- add backend and mission workspace UI tests for SOP-linked recommendation records
 - run mission-planning UI tests
 - run TypeScript build and diff whitespace check
 
 ---
 
 ## Done When
-- Safety/SOP and regulatory source records can carry an explicit accountable review outcome
-- Mission workspace shows latest outcome state without implying certification or automatic closure
+- Post-operation review can show draft recommendations linked to a specific SOP and parent OA condition
+- Mission workspace shows recommendation state without implying the SOP has been amended automatically
 - Copy remains explicit that links support audit review, not compliance certification
 - Degraded or carried-forward overlays remain visually distinguishable
 - The demo remains clearly synthetic and safe for local presentation

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,14 +1,14 @@
 # NEXT STEP
 
 ## Goal
-Connect SOP-linked change recommendations to mission evidence.
+Add schema-backed SOP-linked change recommendations to mission evidence.
 
 ---
 
 ## Build
 
 ### 1. Operator visibility
-- generate draft change recommendation records against linked SOP documents
+- add migration-backed draft change recommendation records against linked SOP documents
 - show which SOP code, SOP clause, and parent OA condition a recommendation relates to
 - keep the recommendation visible in the post-operation review flow before accountable-manager sign-off
 
@@ -18,7 +18,7 @@ Connect SOP-linked change recommendations to mission evidence.
 - keep recommendations framed as accountable review prompts, not automatic SOP amendment or regulatory submission
 
 ### 3. Tests
-- add backend and mission workspace UI tests for SOP-linked recommendation records
+- add backend, migration, and mission workspace UI tests for SOP-linked recommendation records
 - run mission-planning UI tests
 - run TypeScript build and diff whitespace check
 

--- a/docs/operational-authority-sop-assurance.md
+++ b/docs/operational-authority-sop-assurance.md
@@ -85,6 +85,13 @@ The hierarchy should be:
 
 The original OA remains a controlled evidence object.
 
+Important modelling rule:
+
+- the OA is the controlling approval envelope issued by the CAA
+- SOPs are distinct linked procedures beneath that OA profile
+- VerityATLAS should not collapse SOPs into the OA record itself
+- change recommendations should point to the relevant SOP procedure or clause wherever possible, while retaining the parent OA condition that gives the SOP its authority context
+
 Minimum fields:
 
 - `id`
@@ -138,6 +145,8 @@ SOPs are separate from the OA but must be linked to it.
 
 SOPs define how the company intends to operate inside its authorised envelope.
 
+In implementation terms, SOPs should sit below the active OA profile as linked procedure records. The OA remains the main title and compliance envelope; SOPs become the subtitle/procedure layer used for mission method assurance and change recommendation targeting.
+
 Minimum fields:
 
 - `sopId`
@@ -150,6 +159,19 @@ Minimum fields:
 - `supersededBy`
 - `owner`
 - `approvalRecord`
+- `linkedOaConditionIds`
+- `changeRecommendationScope`
+
+Recommended operator-facing labels:
+
+- main section: `Operational Authority`
+- subsection: `Linked SOPs / Standard Operating Procedures`
+- recommendation target: `SOP clause or procedure requiring review`
+
+Example change recommendation wording:
+
+- "This finding may require accountable review of SOP-FLT-003 clause SOP 3.2 under OA condition OA 7.1."
+- "This does not alter the OA or SOP automatically; it surfaces a linked procedure review requirement for the operator."
 
 ### 5. Mission Assurance Against OA And SOP
 

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -37,7 +37,8 @@
       "Recovered Operational Authority, insurance, mission governance, risk-map, accountable-manager dashboard, auth, membership, stored-file, organisation-document, and OA pilot-authorisation modules into the GitHub-connected branch",
       "Integrated governance migrations 031-047 into the recovered branch, including OA/insurance profiles, stored files, users, sessions, memberships, and pilot authorisation review tables",
       "Restored investor and architecture documentation for OA, insurance, SOP assurance, renewal readiness, evidence packs, deployment model, security, GDPR readiness, market positioning, and competitor framing",
-      "Added governance-focused test coverage for OA, insurance, mission governance, risk map, accountable-manager dashboard, auth, stored files, and organisation documents"
+      "Added governance-focused test coverage for OA, insurance, mission governance, risk map, accountable-manager dashboard, auth, stored files, and organisation documents",
+      "Added first-class Operational Authority linked SOP document scaffolding so SOPs sit below the OA profile instead of being collapsed into OA conditions"
     ],
     "modified": [
       "Merged the recovered governance build with latest main-branch live operations, regulatory review, evidence, map, and mission workspace improvements",
@@ -47,7 +48,8 @@
       "Added mission workspace drill-down links from post-operation readiness categories to live-ops map evidence, conflict review context, operations timeline, regulatory matrix, and rendered audit report",
       "Extended post-operation evidence readiness categories with source record metadata for latest map, conflict, safety, and regulatory evidence",
       "Added URL-driven visual focus for source-record drill-downs into live-ops map evidence, conflict acknowledgements, operations timeline, and regulatory matrix review sections",
-      "Added focused safety/SOP and regulatory source-record detail panels inside the mission workspace timeline and regulatory review sections"
+      "Added focused safety/SOP and regulatory source-record detail panels inside the mission workspace timeline and regulatory review sections",
+      "Documented the OA/SOP hierarchy as OA controlling approval envelope with SOPs as distinct linked procedures used for recommendation targeting"
     ],
     "removed": [],
     "fixed": [
@@ -77,13 +79,15 @@
   "dataModels": {
     "newRuntimeVariables": [
       "Operational Authority profiles, conditions, pilot authorisations, and pilot authorisation reviews",
+      "Operational Authority linked SOP documents with SOP code, version, source clauses, linked OA condition IDs, and change recommendation scope",
       "Insurance documents, profiles, conditions, source upload metadata, and assessment reasons",
       "Stored files, organisation documents, users, user sessions, and organisation memberships"
     ],
     "updatedStructures": [
       "Mission governance summaries now join OA and insurance readiness for mission-level advisory review",
       "Risk-map summaries now accept governance renewal, competency, maintenance, and override-pressure signals",
-      "Pilot readiness can include OA authorisation and pending-amendment context"
+      "Pilot readiness can include OA authorisation and pending-amendment context",
+      "SOP records are now modelled as linked procedures under an OA profile rather than as OA conditions, preserving the distinction between authority envelope and operating method"
     ],
     "assumptions": [
       "The platform remains focused on commercial operators using an Operational Authority, with open-category access treated as a possible future constrained mode",
@@ -93,6 +97,7 @@
   "apisServices": {
     "endpointsUsed": [
       "Operational Authority routes for document/profile/condition and pilot-authorisation management",
+      "Operational Authority profile routes for listing and creating linked SOP documents",
       "Insurance routes for policy/profile/condition assessment and source upload metadata",
       "Mission governance routes for combined OA and insurance mission readiness",
       "Risk-map and accountable-manager dashboard routes for early-warning summary surfaces",
@@ -125,19 +130,22 @@
       "Operators can jump from post-operation readiness prompts to the relevant evidence review surface instead of manually hunting through the workspace",
       "Operators can open the latest source record or source JSON behind each populated post-operation readiness category",
       "Operators now see a focused review cue when a source-record drill-down lands on the relevant live-ops or mission-workspace evidence area",
-      "Operators can review safety/SOP and regulatory source-record IDs, summaries, timestamps, source JSON links, and review surfaces without manually hunting through the workspace"
+      "Operators can review safety/SOP and regulatory source-record IDs, summaries, timestamps, source JSON links, and review surfaces without manually hunting through the workspace",
+      "Compliance teams can record SOP documents as distinct linked procedures under the OA profile so later change recommendations can target the relevant SOP"
     ]
   },
   "complianceImplications": {
     "truth": [
       "Uploaded OA, insurance, membership, and stored-file records become traceable source evidence for governance assessment",
-      "Pending OA amendment is represented explicitly and is not treated as granted authorisation"
+      "Pending OA amendment is represented explicitly and is not treated as granted authorisation",
+      "The OA is treated as the controlling approval envelope while SOPs are modelled as separate linked operating methods under that envelope"
     ],
     "prediction": [
       "Renewal-soon and override-pressure stages provide early warning before operational readiness degrades"
     ],
     "advisory": [
       "The system surfaces where operations may need accountable review, policy change, SOP amendment, OA renewal, insurance renewal, or mission adjustment",
+      "SOP change recommendations should target the relevant SOP code or clause while preserving the parent OA condition context",
       "Insurance assessment can advise what mission characteristic may need changing to remain within cover rather than presenting a stark no-go"
     ],
     "auditTraceabilityImpact": [
@@ -145,7 +153,8 @@
       "Document preview/download and evidence-pack concepts preserve source-document accountability",
       "Post-operation readiness now carries source record IDs, review URLs, and API URLs so audit prompts remain traceable to underlying evidence",
       "Source-record drill-down review URLs preserve evidence IDs and highlight the relevant review surface without treating the item as certified, closed, or automatically resolved",
-      "Safety/SOP and regulatory drill-down sections now display source-record detail as accountable review support, not compliance certification or automatic closure"
+      "Safety/SOP and regulatory drill-down sections now display source-record detail as accountable review support, not compliance certification or automatic closure",
+      "Linked SOP documents create the first traceable target for future post-operation SOP amendment recommendations"
     ]
   },
   "risksLimitations": {
@@ -188,11 +197,12 @@
       "Validated recovered migrations with npm run migrate:test against the configured Postgres test database after PR 238 merged",
       "Validated source-record drill-down metadata with audit evidence and mission planning focused tests",
       "Validated source-record drill-down focus state with TypeScript build and mission-planning UI tests",
-      "Validated safety/SOP and regulatory focused source-record detail panels with TypeScript build and mission-planning UI tests"
+      "Validated safety/SOP and regulatory focused source-record detail panels with TypeScript build and mission-planning UI tests",
+      "Validated OA-linked SOP document creation/listing, role access, TypeScript build, and operational-authority integration tests"
     ]
 
   },
-  "nextBuildStep": "Add accountable review outcomes for safety and regulatory source records.",
+  "nextBuildStep": "Connect SOP-linked change recommendations to mission evidence.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -202,7 +202,7 @@
     ]
 
   },
-  "nextBuildStep": "Connect SOP-linked change recommendations to mission evidence.",
+  "nextBuildStep": "Add schema-backed SOP-linked change recommendations to mission evidence.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/migrations/048_create_operational_authority_sop_documents.sql
+++ b/src/migrations/048_create_operational_authority_sop_documents.sql
@@ -1,0 +1,30 @@
+create table if not exists operational_authority_sop_documents (
+  id uuid primary key,
+  operational_authority_profile_id uuid not null references operational_authority_profiles(id) on delete cascade,
+  organisation_id uuid not null,
+  sop_code text not null,
+  title text not null,
+  version text not null,
+  status text not null default 'draft' check (
+    status in ('draft', 'active', 'under_review', 'superseded')
+  ),
+  owner text,
+  source_document_id text,
+  source_document_type text,
+  source_clause_refs jsonb not null default '[]'::jsonb,
+  linked_oa_condition_ids jsonb not null default '[]'::jsonb,
+  change_recommendation_scope jsonb not null default '[]'::jsonb,
+  review_notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (operational_authority_profile_id, sop_code, version)
+);
+
+create index if not exists operational_authority_sop_documents_profile_idx
+  on operational_authority_sop_documents (operational_authority_profile_id);
+
+create index if not exists operational_authority_sop_documents_org_idx
+  on operational_authority_sop_documents (organisation_id);
+
+create index if not exists operational_authority_sop_documents_status_idx
+  on operational_authority_sop_documents (status);

--- a/src/operational-authority/operational-authority.controller.ts
+++ b/src/operational-authority/operational-authority.controller.ts
@@ -181,6 +181,69 @@ export class OperationalAuthorityController {
     }
   };
 
+  listSopDocuments = async (
+    req: Request<ProfileIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const user = requireCurrentUser(req);
+      const organisationId =
+        await this.operationalAuthorityService.getProfileOrganisationId(
+          req.params.profileId,
+        );
+      await this.organisationMembershipsService.requireMembership(
+        user.id,
+        organisationId,
+        [
+          "viewer",
+          "operator",
+          "operations_manager",
+          "compliance_manager",
+          "accountable_manager",
+          "admin",
+        ],
+      );
+      const listed = await this.operationalAuthorityService.listSopDocuments(
+        req.params.profileId,
+      );
+      res.status(200).json(listed);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  createSopDocument = async (
+    req: Request<ProfileIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const user = requireCurrentUser(req);
+      const organisationId =
+        await this.operationalAuthorityService.getProfileOrganisationId(
+          req.params.profileId,
+        );
+      await this.organisationMembershipsService.requireMembership(
+        user.id,
+        organisationId,
+        [
+          "operations_manager",
+          "compliance_manager",
+          "accountable_manager",
+          "admin",
+        ],
+      );
+      const created = await this.operationalAuthorityService.createSopDocument(
+        req.params.profileId,
+        req.body,
+      );
+      res.status(201).json(created);
+    } catch (error) {
+      next(error);
+    }
+  };
+
   createPilotAuthorisation = async (
     req: Request<ProfileIdParams>,
     res: Response,

--- a/src/operational-authority/operational-authority.repository.ts
+++ b/src/operational-authority/operational-authority.repository.ts
@@ -6,6 +6,7 @@ import type {
   OperationalAuthorityPilotAuthorisation,
   OperationalAuthorityPilotAuthorisationReview,
   OperationalAuthorityProfile,
+  OperationalAuthoritySopDocument,
 } from "./operational-authority.types";
 
 interface MissionGovernanceRow extends QueryResultRow {
@@ -57,6 +58,25 @@ interface OperationalAuthorityConditionRow extends QueryResultRow {
   condition_title: string;
   clause_reference: string | null;
   condition_payload: Record<string, unknown>;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface OperationalAuthoritySopDocumentRow extends QueryResultRow {
+  id: string;
+  operational_authority_profile_id: string;
+  organisation_id: string;
+  sop_code: string;
+  title: string;
+  version: string;
+  status: OperationalAuthoritySopDocument["status"];
+  owner: string | null;
+  source_document_id: string | null;
+  source_document_type: string | null;
+  source_clause_refs: string[] | null;
+  linked_oa_condition_ids: string[] | null;
+  change_recommendation_scope: string[] | null;
+  review_notes: string | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -137,6 +157,27 @@ const toCondition = (
   conditionTitle: row.condition_title,
   clauseReference: row.clause_reference,
   conditionPayload: row.condition_payload,
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
+});
+
+const toSopDocument = (
+  row: OperationalAuthoritySopDocumentRow,
+): OperationalAuthoritySopDocument => ({
+  id: row.id,
+  operationalAuthorityProfileId: row.operational_authority_profile_id,
+  organisationId: row.organisation_id,
+  sopCode: row.sop_code,
+  title: row.title,
+  version: row.version,
+  status: row.status,
+  owner: row.owner,
+  sourceDocumentId: row.source_document_id,
+  sourceDocumentType: row.source_document_type,
+  sourceClauseRefs: row.source_clause_refs ?? [],
+  linkedOaConditionIds: row.linked_oa_condition_ids ?? [],
+  changeRecommendationScope: row.change_recommendation_scope ?? [],
+  reviewNotes: row.review_notes,
   createdAt: row.created_at.toISOString(),
   updatedAt: row.updated_at.toISOString(),
 });
@@ -487,6 +528,83 @@ export class OperationalAuthorityRepository {
     );
 
     return result.rows.map((row) => toCondition(row));
+  }
+
+  async insertSopDocument(
+    tx: PoolClient,
+    params: {
+      profileId: string;
+      organisationId: string;
+      sopCode: string;
+      title: string;
+      version: string;
+      status: OperationalAuthoritySopDocument["status"];
+      owner: string | null;
+      sourceDocumentId: string | null;
+      sourceDocumentType: string | null;
+      sourceClauseRefs: string[];
+      linkedOaConditionIds: string[];
+      changeRecommendationScope: string[];
+      reviewNotes: string | null;
+    },
+  ): Promise<OperationalAuthoritySopDocument> {
+    const result = await tx.query<OperationalAuthoritySopDocumentRow>(
+      `
+      insert into operational_authority_sop_documents (
+        id,
+        operational_authority_profile_id,
+        organisation_id,
+        sop_code,
+        title,
+        version,
+        status,
+        owner,
+        source_document_id,
+        source_document_type,
+        source_clause_refs,
+        linked_oa_condition_ids,
+        change_recommendation_scope,
+        review_notes
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb, $13::jsonb, $14)
+      returning *
+      `,
+      [
+        randomUUID(),
+        params.profileId,
+        params.organisationId,
+        params.sopCode,
+        params.title,
+        params.version,
+        params.status,
+        params.owner,
+        params.sourceDocumentId,
+        params.sourceDocumentType,
+        JSON.stringify(params.sourceClauseRefs),
+        JSON.stringify(params.linkedOaConditionIds),
+        JSON.stringify(params.changeRecommendationScope),
+        params.reviewNotes,
+      ],
+    );
+
+    return toSopDocument(result.rows[0]);
+  }
+
+  async listSopDocumentsForProfile(
+    tx: PoolClient,
+    profileId: string,
+  ): Promise<OperationalAuthoritySopDocument[]> {
+    const result = await tx.query<OperationalAuthoritySopDocumentRow>(
+      `
+      select *
+      from operational_authority_sop_documents
+      where operational_authority_profile_id = $1
+      order by status asc, sop_code asc, version desc, created_at asc, id asc
+      `,
+      [profileId],
+    );
+
+    return result.rows.map((row) => toSopDocument(row));
   }
 
   async getPilotAuthorisationForProfile(

--- a/src/operational-authority/operational-authority.routes.ts
+++ b/src/operational-authority/operational-authority.routes.ts
@@ -50,6 +50,14 @@ export function createOperationalAuthorityProfileRouter(
     "/:profileId/pilot-authorisations",
     controller.createPilotAuthorisation,
   );
+  router.get(
+    "/:profileId/sop-documents",
+    controller.listSopDocuments,
+  );
+  router.post(
+    "/:profileId/sop-documents",
+    controller.createSopDocument,
+  );
   router.post(
     "/:profileId/activate",
     controller.activateOperationalAuthorityProfile,

--- a/src/operational-authority/operational-authority.service.ts
+++ b/src/operational-authority/operational-authority.service.ts
@@ -11,6 +11,7 @@ import type {
   CreateOperationalAuthorityDocumentInput,
   CreateOperationalAuthorityPilotAuthorisationInput,
   CreateOperationalAuthorityPilotAuthorisationReviewInput,
+  CreateOperationalAuthoritySopDocumentInput,
   OperationalAuthorityAssessment,
   OperationalAuthorityAssessmentReason,
   OperationalAuthorityPilotAuthorisation,
@@ -22,6 +23,7 @@ import {
   validateCreateOperationalAuthorityDocumentInput,
   validateCreateOperationalAuthorityPilotAuthorisationInput,
   validateCreateOperationalAuthorityPilotAuthorisationReviewInput,
+  validateCreateOperationalAuthoritySopDocumentInput,
   validateUpdateOperationalAuthorityPilotAuthorisationInput,
   validateUploadOperationalAuthorityDocumentInput,
 } from "./operational-authority.validators";
@@ -229,6 +231,77 @@ export class OperationalAuthorityService {
       }
 
       return mission.organisationId;
+    } finally {
+      client.release();
+    }
+  }
+
+  async createSopDocument(
+    profileId: string,
+    input: CreateOperationalAuthoritySopDocumentInput | undefined,
+  ) {
+    const validated = validateCreateOperationalAuthoritySopDocumentInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      await client.query("BEGIN");
+
+      const profile = await this.operationalAuthorityRepository.getProfileById(
+        client,
+        profileId,
+      );
+
+      if (!profile) {
+        throw new OperationalAuthorityProfileNotFoundError(profileId);
+      }
+
+      const sopDocument =
+        await this.operationalAuthorityRepository.insertSopDocument(client, {
+          profileId,
+          organisationId: profile.organisationId,
+          sopCode: validated.sopCode,
+          title: validated.title,
+          version: validated.version,
+          status: validated.status,
+          owner: validated.owner,
+          sourceDocumentId: validated.sourceDocumentId,
+          sourceDocumentType: validated.sourceDocumentType,
+          sourceClauseRefs: validated.sourceClauseRefs,
+          linkedOaConditionIds: validated.linkedOaConditionIds,
+          changeRecommendationScope: validated.changeRecommendationScope,
+          reviewNotes: validated.reviewNotes,
+        });
+
+      await client.query("COMMIT");
+      return { profile, sopDocument };
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async listSopDocuments(profileId: string) {
+    const client = await this.pool.connect();
+
+    try {
+      const profile = await this.operationalAuthorityRepository.getProfileById(
+        client,
+        profileId,
+      );
+
+      if (!profile) {
+        throw new OperationalAuthorityProfileNotFoundError(profileId);
+      }
+
+      const sopDocuments =
+        await this.operationalAuthorityRepository.listSopDocumentsForProfile(
+          client,
+          profileId,
+        );
+
+      return { profile, sopDocuments };
     } finally {
       client.release();
     }

--- a/src/operational-authority/operational-authority.types.ts
+++ b/src/operational-authority/operational-authority.types.ts
@@ -53,6 +53,26 @@ export interface UploadOperationalAuthorityDocumentInput {
   uploadedBy?: string | null;
 }
 
+export type OperationalAuthoritySopDocumentStatus =
+  | "draft"
+  | "active"
+  | "under_review"
+  | "superseded";
+
+export interface CreateOperationalAuthoritySopDocumentInput {
+  sopCode?: string;
+  title?: string;
+  version?: string;
+  status?: OperationalAuthoritySopDocumentStatus;
+  owner?: string | null;
+  sourceDocumentId?: string | null;
+  sourceDocumentType?: string | null;
+  sourceClauseRefs?: string[] | null;
+  linkedOaConditionIds?: string[] | null;
+  changeRecommendationScope?: string[] | null;
+  reviewNotes?: string | null;
+}
+
 export interface ActivateOperationalAuthorityProfileInput {
   activatedBy?: string;
 }
@@ -135,6 +155,25 @@ export interface OperationalAuthorityCondition {
   conditionTitle: string;
   clauseReference: string | null;
   conditionPayload: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OperationalAuthoritySopDocument {
+  id: string;
+  operationalAuthorityProfileId: string;
+  organisationId: string;
+  sopCode: string;
+  title: string;
+  version: string;
+  status: OperationalAuthoritySopDocumentStatus;
+  owner: string | null;
+  sourceDocumentId: string | null;
+  sourceDocumentType: string | null;
+  sourceClauseRefs: string[];
+  linkedOaConditionIds: string[];
+  changeRecommendationScope: string[];
+  reviewNotes: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/operational-authority/operational-authority.validators.ts
+++ b/src/operational-authority/operational-authority.validators.ts
@@ -7,10 +7,12 @@ import type {
   CreateOperationalAuthorityDocumentInput,
   CreateOperationalAuthorityPilotAuthorisationInput,
   CreateOperationalAuthorityPilotAuthorisationReviewInput,
+  CreateOperationalAuthoritySopDocumentInput,
   MissionOperationType,
   OperationalAuthorityConditionCode,
   OperationalAuthorityPilotAuthorisationReviewDecision,
   OperationalAuthorityPilotAuthorisationState,
+  OperationalAuthoritySopDocumentStatus,
   UpdateOperationalAuthorityPilotAuthorisationInput,
   UploadOperationalAuthorityDocumentInput,
 } from "./operational-authority.types";
@@ -45,6 +47,13 @@ const PILOT_AUTHORISATION_REVIEW_DECISIONS =
     "deferred",
     "amendment_approved",
   ]);
+
+const SOP_DOCUMENT_STATUSES = new Set<OperationalAuthoritySopDocumentStatus>([
+  "draft",
+  "active",
+  "under_review",
+  "superseded",
+]);
 
 function requiredTrimmed(value: unknown, fieldName: string): string {
   if (typeof value !== "string") {
@@ -81,6 +90,22 @@ function optionalBoolean(value: unknown, fieldName: string): boolean | undefined
   }
 
   return value;
+}
+
+function optionalStringArray(value: unknown, fieldName: string): string[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new OperationalAuthorityValidationError(
+      `${fieldName} must be an array of strings`,
+    );
+  }
+
+  return value.map((item, index) =>
+    requiredTrimmed(item, `${fieldName}[${index}]`),
+  );
 }
 
 function requiredIsoDate(value: unknown, fieldName: string): string {
@@ -255,6 +280,23 @@ function validatePilotAuthorisationReviewDecision(
   return value as OperationalAuthorityPilotAuthorisationReviewDecision;
 }
 
+function validateSopDocumentStatus(
+  value: unknown,
+): OperationalAuthoritySopDocumentStatus {
+  if (value === undefined || value === null || value === "") {
+    return "draft";
+  }
+
+  if (
+    typeof value !== "string" ||
+    !SOP_DOCUMENT_STATUSES.has(value as OperationalAuthoritySopDocumentStatus)
+  ) {
+    throw new OperationalAuthorityValidationError("status is not supported");
+  }
+
+  return value as OperationalAuthoritySopDocumentStatus;
+}
+
 export function validateCreateOperationalAuthorityDocumentInput(
   input: CreateOperationalAuthorityDocumentInput | undefined,
 ) {
@@ -336,6 +378,43 @@ export function validateUploadOperationalAuthorityDocumentInput(
       "documentReviewNotes",
     ),
     uploadedBy: optionalTrimmed(input.uploadedBy, "uploadedBy"),
+  };
+}
+
+export function validateCreateOperationalAuthoritySopDocumentInput(
+  input: CreateOperationalAuthoritySopDocumentInput | undefined,
+) {
+  if (!input || typeof input !== "object") {
+    throw new OperationalAuthorityValidationError("Request body must be an object");
+  }
+
+  return {
+    sopCode: requiredTrimmed(input.sopCode, "sopCode"),
+    title: requiredTrimmed(input.title, "title"),
+    version: requiredTrimmed(input.version, "version"),
+    status: validateSopDocumentStatus(input.status),
+    owner: optionalTrimmed(input.owner, "owner"),
+    sourceDocumentId: optionalTrimmed(
+      input.sourceDocumentId,
+      "sourceDocumentId",
+    ),
+    sourceDocumentType: optionalTrimmed(
+      input.sourceDocumentType,
+      "sourceDocumentType",
+    ),
+    sourceClauseRefs: optionalStringArray(
+      input.sourceClauseRefs,
+      "sourceClauseRefs",
+    ),
+    linkedOaConditionIds: optionalStringArray(
+      input.linkedOaConditionIds,
+      "linkedOaConditionIds",
+    ),
+    changeRecommendationScope: optionalStringArray(
+      input.changeRecommendationScope,
+      "changeRecommendationScope",
+    ),
+    reviewNotes: optionalTrimmed(input.reviewNotes, "reviewNotes"),
   };
 }
 

--- a/src/tests/operational-authority.test.ts
+++ b/src/tests/operational-authority.test.ts
@@ -12,6 +12,7 @@ const clearTables = async () => {
   await pool.query("delete from organisation_documents");
   await pool.query("delete from operational_authority_pilot_authorisation_reviews");
   await pool.query("delete from operational_authority_pilot_authorisations");
+  await pool.query("delete from operational_authority_sop_documents");
   await pool.query("delete from operational_authority_conditions");
   await pool.query("delete from operational_authority_profiles");
   await pool.query("delete from operational_authority_documents");
@@ -577,6 +578,132 @@ describe("operational authority integration", () => {
       authorisationState: "authorised",
       bvlosAuthorised: true,
       requiresAccountableReview: false,
+    });
+  });
+
+  it("models SOPs as distinct linked documents under an OA profile", async () => {
+    const organisationId = randomUUID();
+    const validity = buildDateWindow(-30, 365);
+    const auth = await createUserAndSession("oa-sop-admin@example.com");
+    await createMembership(organisationId, auth.user.id, "compliance_manager");
+
+    const createResponse = await request(app)
+      .post(`/organisations/${organisationId}/operational-authority-documents`)
+      .set("X-Session-Token", auth.sessionToken)
+      .send({
+        authorityName: "CAA",
+        referenceNumber: "OA-SOP-001",
+        issueDate: validity.issueDate,
+        effectiveFrom: validity.effectiveFrom,
+        expiresAt: validity.expiresAt,
+        uploadedBy: "compliance-lead",
+        conditions: [
+          {
+            conditionCode: "ALLOWED_OPERATION_TYPE",
+            conditionTitle: "Permitted operations",
+            clauseReference: "OA 7.1",
+            conditionPayload: { allowedOperationTypes: ["inspection"] },
+          },
+        ],
+      });
+
+    expect(createResponse.status).toBe(201);
+    const conditionId = createResponse.body.conditions[0].id;
+
+    const createSopResponse = await request(app)
+      .post(
+        `/operational-authority-profiles/${createResponse.body.profile.id}/sop-documents`,
+      )
+      .set("X-Session-Token", auth.sessionToken)
+      .send({
+        sopCode: "SOP-FLT-003",
+        title: "Infrastructure Inspection Flight Procedure",
+        version: "2.1",
+        status: "active",
+        owner: "Head of Flight Operations",
+        sourceDocumentId: "stored-file-sop-003",
+        sourceDocumentType: "standard_operating_procedure",
+        sourceClauseRefs: ["SOP 3.2", "SOP 5.4"],
+        linkedOaConditionIds: [conditionId],
+        changeRecommendationScope: [
+          "weather_review",
+          "pilot_briefing",
+          "post_operation_learning",
+        ],
+        reviewNotes:
+          "Linked below the OA so change recommendations can point at the relevant SOP.",
+      });
+
+    expect(createSopResponse.status).toBe(201);
+    expect(createSopResponse.body.sopDocument).toMatchObject({
+      operationalAuthorityProfileId: createResponse.body.profile.id,
+      organisationId,
+      sopCode: "SOP-FLT-003",
+      title: "Infrastructure Inspection Flight Procedure",
+      version: "2.1",
+      status: "active",
+      sourceClauseRefs: ["SOP 3.2", "SOP 5.4"],
+      linkedOaConditionIds: [conditionId],
+      changeRecommendationScope: [
+        "weather_review",
+        "pilot_briefing",
+        "post_operation_learning",
+      ],
+    });
+
+    const listResponse = await request(app)
+      .get(
+        `/operational-authority-profiles/${createResponse.body.profile.id}/sop-documents`,
+      )
+      .set("X-Session-Token", auth.sessionToken);
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.sopDocuments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: createSopResponse.body.sopDocument.id,
+          sopCode: "SOP-FLT-003",
+          linkedOaConditionIds: [conditionId],
+        }),
+      ]),
+    );
+  });
+
+  it("prevents non-governance roles from creating OA-linked SOP documents", async () => {
+    const organisationId = randomUUID();
+    const validity = buildDateWindow(-30, 365);
+    const admin = await createUserAndSession("oa-sop-owner@example.com");
+    const operator = await createUserAndSession("oa-sop-operator@example.com");
+    await createMembership(organisationId, admin.user.id, "admin");
+    await createMembership(organisationId, operator.user.id, "operator");
+
+    const createResponse = await request(app)
+      .post(`/organisations/${organisationId}/operational-authority-documents`)
+      .set("X-Session-Token", admin.sessionToken)
+      .send({
+        authorityName: "CAA",
+        referenceNumber: "OA-SOP-DENIED-001",
+        issueDate: validity.issueDate,
+        effectiveFrom: validity.effectiveFrom,
+        expiresAt: validity.expiresAt,
+        uploadedBy: "admin",
+        conditions: [],
+      });
+
+    const response = await request(app)
+      .post(
+        `/operational-authority-profiles/${createResponse.body.profile.id}/sop-documents`,
+      )
+      .set("X-Session-Token", operator.sessionToken)
+      .send({
+        sopCode: "SOP-DENIED",
+        title: "Operator-created SOP",
+        version: "1.0",
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toMatchObject({
+      type: "organisation_membership_forbidden",
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds first-class SOP document records under Operational Authority profiles
- Keeps OA as the controlling approval envelope and SOPs as distinct linked procedures
- Adds SOP fields for SOP code, version, source clauses, linked OA condition IDs, and change recommendation scope
- Adds profile routes for creating and listing OA-linked SOP documents
- Updates OA/SOP architecture wording and save-point notes

## Validation
- npm.cmd run build
- npx.cmd vitest run src/tests/operational-authority.test.ts --pool=threads --reporter=verbose
- npm.cmd run validate:savepoint
- git diff --check
