### PR TITLE
Add SOP change recommendations

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,32 +1,32 @@
 # NEXT STEP
 
 ## Goal
-Add schema-backed SOP-linked change recommendations to mission evidence.
+Add schema-backed SOP recommendation review decisions to mission evidence.
 
 ---
 
 ## Build
 
 ### 1. Operator visibility
-- add migration-backed draft change recommendation records against linked SOP documents
-- show which SOP code, SOP clause, and parent OA condition a recommendation relates to
-- keep the recommendation visible in the post-operation review flow before accountable-manager sign-off
+- add migration-backed accountable review decisions for SOP change recommendations
+- capture decision state such as accepted for action, rejected, deferred, or closed
+- show latest decision state beside the SOP recommendation before accountable-manager sign-off
 
 ### 2. Product boundary
 - continue to label demo airspace data as synthetic/local
 - do not imply live CAA, NOTAM, or manufacturer feed connectivity
-- keep recommendations framed as accountable review prompts, not automatic SOP amendment or regulatory submission
+- keep decisions framed as internal accountable review records, not automatic SOP amendment or regulatory submission
 
 ### 3. Tests
-- add backend, migration, and mission workspace UI tests for SOP-linked recommendation records
+- add backend, migration, and mission workspace UI tests for SOP recommendation review decisions
 - run mission-planning UI tests
 - run TypeScript build and diff whitespace check
 
 ---
 
 ## Done When
-- Post-operation review can show draft recommendations linked to a specific SOP and parent OA condition
-- Mission workspace shows recommendation state without implying the SOP has been amended automatically
+- SOP recommendations can carry explicit accountable review decisions
+- Mission workspace shows recommendation decision state without implying the SOP has been amended automatically
 - Copy remains explicit that links support audit review, not compliance certification
 - Degraded or carried-forward overlays remain visually distinguishable
 - The demo remains clearly synthetic and safe for local presentation

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -38,7 +38,8 @@
       "Integrated governance migrations 031-047 into the recovered branch, including OA/insurance profiles, stored files, users, sessions, memberships, and pilot authorisation review tables",
       "Restored investor and architecture documentation for OA, insurance, SOP assurance, renewal readiness, evidence packs, deployment model, security, GDPR readiness, market positioning, and competitor framing",
       "Added governance-focused test coverage for OA, insurance, mission governance, risk map, accountable-manager dashboard, auth, stored files, and organisation documents",
-      "Added first-class Operational Authority linked SOP document scaffolding so SOPs sit below the OA profile instead of being collapsed into OA conditions"
+      "Added first-class Operational Authority linked SOP document scaffolding so SOPs sit below the OA profile instead of being collapsed into OA conditions",
+      "Added schema-backed SOP change recommendation records linked to mission evidence, SOP documents, SOP clauses, and parent OA conditions"
     ],
     "modified": [
       "Merged the recovered governance build with latest main-branch live operations, regulatory review, evidence, map, and mission workspace improvements",
@@ -49,7 +50,8 @@
       "Extended post-operation evidence readiness categories with source record metadata for latest map, conflict, safety, and regulatory evidence",
       "Added URL-driven visual focus for source-record drill-downs into live-ops map evidence, conflict acknowledgements, operations timeline, and regulatory matrix review sections",
       "Added focused safety/SOP and regulatory source-record detail panels inside the mission workspace timeline and regulatory review sections",
-      "Documented the OA/SOP hierarchy as OA controlling approval envelope with SOPs as distinct linked procedures used for recommendation targeting"
+      "Documented the OA/SOP hierarchy as OA controlling approval envelope with SOPs as distinct linked procedures used for recommendation targeting",
+      "Added mission routes for creating and listing SOP-linked change recommendations as accountable review prompts"
     ],
     "removed": [],
     "fixed": [
@@ -80,6 +82,7 @@
     "newRuntimeVariables": [
       "Operational Authority profiles, conditions, pilot authorisations, and pilot authorisation reviews",
       "Operational Authority linked SOP documents with SOP code, version, source clauses, linked OA condition IDs, and change recommendation scope",
+      "SOP change recommendations linked to mission evidence, SOP documents, parent OA conditions, and recommendation status",
       "Insurance documents, profiles, conditions, source upload metadata, and assessment reasons",
       "Stored files, organisation documents, users, user sessions, and organisation memberships"
     ],
@@ -98,6 +101,7 @@
     "endpointsUsed": [
       "Operational Authority routes for document/profile/condition and pilot-authorisation management",
       "Operational Authority profile routes for listing and creating linked SOP documents",
+      "Mission routes for listing and creating SOP-linked change recommendations",
       "Insurance routes for policy/profile/condition assessment and source upload metadata",
       "Mission governance routes for combined OA and insurance mission readiness",
       "Risk-map and accountable-manager dashboard routes for early-warning summary surfaces",
@@ -131,7 +135,8 @@
       "Operators can open the latest source record or source JSON behind each populated post-operation readiness category",
       "Operators now see a focused review cue when a source-record drill-down lands on the relevant live-ops or mission-workspace evidence area",
       "Operators can review safety/SOP and regulatory source-record IDs, summaries, timestamps, source JSON links, and review surfaces without manually hunting through the workspace",
-      "Compliance teams can record SOP documents as distinct linked procedures under the OA profile so later change recommendations can target the relevant SOP"
+      "Compliance teams can record SOP documents as distinct linked procedures under the OA profile so later change recommendations can target the relevant SOP",
+      "Governance users can record draft SOP change recommendations against mission evidence without amending the SOP automatically"
     ]
   },
   "complianceImplications": {
@@ -154,7 +159,8 @@
       "Post-operation readiness now carries source record IDs, review URLs, and API URLs so audit prompts remain traceable to underlying evidence",
       "Source-record drill-down review URLs preserve evidence IDs and highlight the relevant review surface without treating the item as certified, closed, or automatically resolved",
       "Safety/SOP and regulatory drill-down sections now display source-record detail as accountable review support, not compliance certification or automatic closure",
-      "Linked SOP documents create the first traceable target for future post-operation SOP amendment recommendations"
+      "Linked SOP documents create the first traceable target for future post-operation SOP amendment recommendations",
+      "SOP change recommendations now preserve mission evidence source, SOP clause, and parent OA condition context as draft accountable review records"
     ]
   },
   "risksLimitations": {
@@ -198,11 +204,12 @@
       "Validated source-record drill-down metadata with audit evidence and mission planning focused tests",
       "Validated source-record drill-down focus state with TypeScript build and mission-planning UI tests",
       "Validated safety/SOP and regulatory focused source-record detail panels with TypeScript build and mission-planning UI tests",
-      "Validated OA-linked SOP document creation/listing, role access, TypeScript build, and operational-authority integration tests"
+      "Validated OA-linked SOP document creation/listing, role access, TypeScript build, and operational-authority integration tests",
+      "Validated schema-backed SOP change recommendation creation/listing, role access, TypeScript build, and operational-authority integration tests"
     ]
 
   },
-  "nextBuildStep": "Add schema-backed SOP-linked change recommendations to mission evidence.",
+  "nextBuildStep": "Add schema-backed SOP recommendation review decisions to mission evidence.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/migrations/049_create_operational_authority_sop_change_recommendations.sql
+++ b/src/migrations/049_create_operational_authority_sop_change_recommendations.sql
@@ -1,0 +1,37 @@
+create table if not exists operational_authority_sop_change_recommendations (
+  id uuid primary key,
+  mission_id uuid not null references missions(id) on delete cascade,
+  organisation_id uuid not null,
+  operational_authority_profile_id uuid not null references operational_authority_profiles(id) on delete cascade,
+  operational_authority_sop_document_id uuid not null references operational_authority_sop_documents(id) on delete cascade,
+  parent_oa_condition_id uuid references operational_authority_conditions(id) on delete set null,
+  sop_code text not null,
+  sop_clause_ref text,
+  recommendation_type text not null check (
+    recommendation_type in (
+      'sop_review_recommended',
+      'sop_amendment_recommended',
+      'new_sop_required',
+      'oa_variation_review_recommended'
+    )
+  ),
+  status text not null default 'draft' check (
+    status in ('draft', 'under_review', 'accepted_for_action', 'rejected', 'closed')
+  ),
+  evidence_source_type text not null,
+  evidence_source_id text not null,
+  finding_summary text not null,
+  recommendation text not null,
+  created_by text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists operational_authority_sop_change_recommendations_mission_idx
+  on operational_authority_sop_change_recommendations (mission_id);
+
+create index if not exists operational_authority_sop_change_recommendations_sop_idx
+  on operational_authority_sop_change_recommendations (operational_authority_sop_document_id);
+
+create index if not exists operational_authority_sop_change_recommendations_status_idx
+  on operational_authority_sop_change_recommendations (status);

--- a/src/operational-authority/operational-authority.controller.ts
+++ b/src/operational-authority/operational-authority.controller.ts
@@ -149,6 +149,71 @@ export class OperationalAuthorityController {
     }
   };
 
+  listMissionSopChangeRecommendations = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const user = requireCurrentUser(req);
+      const organisationId =
+        await this.operationalAuthorityService.getMissionOrganisationId(
+          req.params.missionId,
+        );
+      await this.organisationMembershipsService.requireMembership(
+        user.id,
+        organisationId,
+        [
+          "viewer",
+          "operator",
+          "operations_manager",
+          "compliance_manager",
+          "accountable_manager",
+          "admin",
+        ],
+      );
+      const listed =
+        await this.operationalAuthorityService.listSopChangeRecommendations(
+          req.params.missionId,
+        );
+      res.status(200).json(listed);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  createMissionSopChangeRecommendation = async (
+    req: Request<MissionIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const user = requireCurrentUser(req);
+      const organisationId =
+        await this.operationalAuthorityService.getMissionOrganisationId(
+          req.params.missionId,
+        );
+      await this.organisationMembershipsService.requireMembership(
+        user.id,
+        organisationId,
+        [
+          "operations_manager",
+          "compliance_manager",
+          "accountable_manager",
+          "admin",
+        ],
+      );
+      const created =
+        await this.operationalAuthorityService.createSopChangeRecommendation(
+          req.params.missionId,
+          req.body,
+        );
+      res.status(201).json(created);
+    } catch (error) {
+      next(error);
+    }
+  };
+
   listPilotAuthorisations = async (
     req: Request<ProfileIdParams>,
     res: Response,

--- a/src/operational-authority/operational-authority.repository.ts
+++ b/src/operational-authority/operational-authority.repository.ts
@@ -6,6 +6,7 @@ import type {
   OperationalAuthorityPilotAuthorisation,
   OperationalAuthorityPilotAuthorisationReview,
   OperationalAuthorityProfile,
+  OperationalAuthoritySopChangeRecommendation,
   OperationalAuthoritySopDocument,
 } from "./operational-authority.types";
 
@@ -77,6 +78,26 @@ interface OperationalAuthoritySopDocumentRow extends QueryResultRow {
   linked_oa_condition_ids: string[] | null;
   change_recommendation_scope: string[] | null;
   review_notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface OperationalAuthoritySopChangeRecommendationRow extends QueryResultRow {
+  id: string;
+  mission_id: string;
+  organisation_id: string;
+  operational_authority_profile_id: string;
+  operational_authority_sop_document_id: string;
+  parent_oa_condition_id: string | null;
+  sop_code: string;
+  sop_clause_ref: string | null;
+  recommendation_type: OperationalAuthoritySopChangeRecommendation["recommendationType"];
+  status: OperationalAuthoritySopChangeRecommendation["status"];
+  evidence_source_type: string;
+  evidence_source_id: string;
+  finding_summary: string;
+  recommendation: string;
+  created_by: string;
   created_at: Date;
   updated_at: Date;
 }
@@ -178,6 +199,28 @@ const toSopDocument = (
   linkedOaConditionIds: row.linked_oa_condition_ids ?? [],
   changeRecommendationScope: row.change_recommendation_scope ?? [],
   reviewNotes: row.review_notes,
+  createdAt: row.created_at.toISOString(),
+  updatedAt: row.updated_at.toISOString(),
+});
+
+const toSopChangeRecommendation = (
+  row: OperationalAuthoritySopChangeRecommendationRow,
+): OperationalAuthoritySopChangeRecommendation => ({
+  id: row.id,
+  missionId: row.mission_id,
+  organisationId: row.organisation_id,
+  operationalAuthorityProfileId: row.operational_authority_profile_id,
+  operationalAuthoritySopDocumentId: row.operational_authority_sop_document_id,
+  parentOaConditionId: row.parent_oa_condition_id,
+  sopCode: row.sop_code,
+  sopClauseRef: row.sop_clause_ref,
+  recommendationType: row.recommendation_type,
+  status: row.status,
+  evidenceSourceType: row.evidence_source_type,
+  evidenceSourceId: row.evidence_source_id,
+  findingSummary: row.finding_summary,
+  recommendation: row.recommendation,
+  createdBy: row.created_by,
   createdAt: row.created_at.toISOString(),
   updatedAt: row.updated_at.toISOString(),
 });
@@ -605,6 +648,99 @@ export class OperationalAuthorityRepository {
     );
 
     return result.rows.map((row) => toSopDocument(row));
+  }
+
+  async getSopDocumentById(
+    tx: PoolClient,
+    sopDocumentId: string,
+  ): Promise<OperationalAuthoritySopDocument | null> {
+    const result = await tx.query<OperationalAuthoritySopDocumentRow>(
+      `
+      select *
+      from operational_authority_sop_documents
+      where id = $1
+      `,
+      [sopDocumentId],
+    );
+
+    return result.rows[0] ? toSopDocument(result.rows[0]) : null;
+  }
+
+  async insertSopChangeRecommendation(
+    tx: PoolClient,
+    params: {
+      missionId: string;
+      organisationId: string;
+      profileId: string;
+      sopDocumentId: string;
+      parentOaConditionId: string | null;
+      sopCode: string;
+      sopClauseRef: string | null;
+      recommendationType: OperationalAuthoritySopChangeRecommendation["recommendationType"];
+      evidenceSourceType: string;
+      evidenceSourceId: string;
+      findingSummary: string;
+      recommendation: string;
+      createdBy: string;
+    },
+  ): Promise<OperationalAuthoritySopChangeRecommendation> {
+    const result = await tx.query<OperationalAuthoritySopChangeRecommendationRow>(
+      `
+      insert into operational_authority_sop_change_recommendations (
+        id,
+        mission_id,
+        organisation_id,
+        operational_authority_profile_id,
+        operational_authority_sop_document_id,
+        parent_oa_condition_id,
+        sop_code,
+        sop_clause_ref,
+        recommendation_type,
+        evidence_source_type,
+        evidence_source_id,
+        finding_summary,
+        recommendation,
+        created_by
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+      returning *
+      `,
+      [
+        randomUUID(),
+        params.missionId,
+        params.organisationId,
+        params.profileId,
+        params.sopDocumentId,
+        params.parentOaConditionId,
+        params.sopCode,
+        params.sopClauseRef,
+        params.recommendationType,
+        params.evidenceSourceType,
+        params.evidenceSourceId,
+        params.findingSummary,
+        params.recommendation,
+        params.createdBy,
+      ],
+    );
+
+    return toSopChangeRecommendation(result.rows[0]);
+  }
+
+  async listSopChangeRecommendationsForMission(
+    tx: PoolClient,
+    missionId: string,
+  ): Promise<OperationalAuthoritySopChangeRecommendation[]> {
+    const result = await tx.query<OperationalAuthoritySopChangeRecommendationRow>(
+      `
+      select *
+      from operational_authority_sop_change_recommendations
+      where mission_id = $1
+      order by created_at desc, id desc
+      `,
+      [missionId],
+    );
+
+    return result.rows.map((row) => toSopChangeRecommendation(row));
   }
 
   async getPilotAuthorisationForProfile(

--- a/src/operational-authority/operational-authority.routes.ts
+++ b/src/operational-authority/operational-authority.routes.ts
@@ -20,6 +20,14 @@ export function createOperationalAuthorityMissionRouter(
   const router = Router();
 
   router.get("/:missionId/oa-assessment", controller.getMissionOperationalAuthorityAssessment);
+  router.get(
+    "/:missionId/sop-change-recommendations",
+    controller.listMissionSopChangeRecommendations,
+  );
+  router.post(
+    "/:missionId/sop-change-recommendations",
+    controller.createMissionSopChangeRecommendation,
+  );
 
   return router;
 }

--- a/src/operational-authority/operational-authority.service.ts
+++ b/src/operational-authority/operational-authority.service.ts
@@ -11,6 +11,7 @@ import type {
   CreateOperationalAuthorityDocumentInput,
   CreateOperationalAuthorityPilotAuthorisationInput,
   CreateOperationalAuthorityPilotAuthorisationReviewInput,
+  CreateOperationalAuthoritySopChangeRecommendationInput,
   CreateOperationalAuthoritySopDocumentInput,
   OperationalAuthorityAssessment,
   OperationalAuthorityAssessmentReason,
@@ -23,6 +24,7 @@ import {
   validateCreateOperationalAuthorityDocumentInput,
   validateCreateOperationalAuthorityPilotAuthorisationInput,
   validateCreateOperationalAuthorityPilotAuthorisationReviewInput,
+  validateCreateOperationalAuthoritySopChangeRecommendationInput,
   validateCreateOperationalAuthoritySopDocumentInput,
   validateUpdateOperationalAuthorityPilotAuthorisationInput,
   validateUploadOperationalAuthorityDocumentInput,
@@ -302,6 +304,106 @@ export class OperationalAuthorityService {
         );
 
       return { profile, sopDocuments };
+    } finally {
+      client.release();
+    }
+  }
+
+  async createSopChangeRecommendation(
+    missionId: string,
+    input: CreateOperationalAuthoritySopChangeRecommendationInput | undefined,
+  ) {
+    const validated =
+      validateCreateOperationalAuthoritySopChangeRecommendationInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      await client.query("BEGIN");
+
+      const mission =
+        await this.operationalAuthorityRepository.getMissionGovernanceContext(
+          client,
+          missionId,
+        );
+
+      if (!mission?.organisationId) {
+        throw new OperationalAuthorityMissionNotFoundError(missionId);
+      }
+
+      const profile = await this.operationalAuthorityRepository.getProfileById(
+        client,
+        validated.profileId,
+      );
+
+      if (!profile || profile.organisationId !== mission.organisationId) {
+        throw new OperationalAuthorityProfileNotFoundError(validated.profileId);
+      }
+
+      const sopDocument =
+        await this.operationalAuthorityRepository.getSopDocumentById(
+          client,
+          validated.sopDocumentId,
+        );
+
+      if (
+        !sopDocument ||
+        sopDocument.organisationId !== mission.organisationId ||
+        sopDocument.operationalAuthorityProfileId !== profile.id
+      ) {
+        throw new OperationalAuthorityProfileNotFoundError(validated.profileId);
+      }
+
+      const recommendation =
+        await this.operationalAuthorityRepository.insertSopChangeRecommendation(
+          client,
+          {
+            missionId,
+            organisationId: mission.organisationId,
+            profileId: profile.id,
+            sopDocumentId: sopDocument.id,
+            parentOaConditionId: validated.parentOaConditionId,
+            sopCode: sopDocument.sopCode,
+            sopClauseRef: validated.sopClauseRef,
+            recommendationType: validated.recommendationType,
+            evidenceSourceType: validated.evidenceSourceType,
+            evidenceSourceId: validated.evidenceSourceId,
+            findingSummary: validated.findingSummary,
+            recommendation: validated.recommendation,
+            createdBy: validated.createdBy,
+          },
+        );
+
+      await client.query("COMMIT");
+      return { recommendation };
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async listSopChangeRecommendations(missionId: string) {
+    const client = await this.pool.connect();
+
+    try {
+      const mission =
+        await this.operationalAuthorityRepository.getMissionGovernanceContext(
+          client,
+          missionId,
+        );
+
+      if (!mission) {
+        throw new OperationalAuthorityMissionNotFoundError(missionId);
+      }
+
+      const recommendations =
+        await this.operationalAuthorityRepository.listSopChangeRecommendationsForMission(
+          client,
+          missionId,
+        );
+
+      return { missionId, recommendations };
     } finally {
       client.release();
     }

--- a/src/operational-authority/operational-authority.types.ts
+++ b/src/operational-authority/operational-authority.types.ts
@@ -73,6 +73,32 @@ export interface CreateOperationalAuthoritySopDocumentInput {
   reviewNotes?: string | null;
 }
 
+export type OperationalAuthoritySopChangeRecommendationType =
+  | "sop_review_recommended"
+  | "sop_amendment_recommended"
+  | "new_sop_required"
+  | "oa_variation_review_recommended";
+
+export type OperationalAuthoritySopChangeRecommendationStatus =
+  | "draft"
+  | "under_review"
+  | "accepted_for_action"
+  | "rejected"
+  | "closed";
+
+export interface CreateOperationalAuthoritySopChangeRecommendationInput {
+  profileId?: string;
+  sopDocumentId?: string;
+  parentOaConditionId?: string | null;
+  sopClauseRef?: string | null;
+  recommendationType?: OperationalAuthoritySopChangeRecommendationType;
+  evidenceSourceType?: string;
+  evidenceSourceId?: string;
+  findingSummary?: string;
+  recommendation?: string;
+  createdBy?: string;
+}
+
 export interface ActivateOperationalAuthorityProfileInput {
   activatedBy?: string;
 }
@@ -174,6 +200,26 @@ export interface OperationalAuthoritySopDocument {
   linkedOaConditionIds: string[];
   changeRecommendationScope: string[];
   reviewNotes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OperationalAuthoritySopChangeRecommendation {
+  id: string;
+  missionId: string;
+  organisationId: string;
+  operationalAuthorityProfileId: string;
+  operationalAuthoritySopDocumentId: string;
+  parentOaConditionId: string | null;
+  sopCode: string;
+  sopClauseRef: string | null;
+  recommendationType: OperationalAuthoritySopChangeRecommendationType;
+  status: OperationalAuthoritySopChangeRecommendationStatus;
+  evidenceSourceType: string;
+  evidenceSourceId: string;
+  findingSummary: string;
+  recommendation: string;
+  createdBy: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/operational-authority/operational-authority.validators.ts
+++ b/src/operational-authority/operational-authority.validators.ts
@@ -7,11 +7,13 @@ import type {
   CreateOperationalAuthorityDocumentInput,
   CreateOperationalAuthorityPilotAuthorisationInput,
   CreateOperationalAuthorityPilotAuthorisationReviewInput,
+  CreateOperationalAuthoritySopChangeRecommendationInput,
   CreateOperationalAuthoritySopDocumentInput,
   MissionOperationType,
   OperationalAuthorityConditionCode,
   OperationalAuthorityPilotAuthorisationReviewDecision,
   OperationalAuthorityPilotAuthorisationState,
+  OperationalAuthoritySopChangeRecommendationType,
   OperationalAuthoritySopDocumentStatus,
   UpdateOperationalAuthorityPilotAuthorisationInput,
   UploadOperationalAuthorityDocumentInput,
@@ -54,6 +56,14 @@ const SOP_DOCUMENT_STATUSES = new Set<OperationalAuthoritySopDocumentStatus>([
   "under_review",
   "superseded",
 ]);
+
+const SOP_CHANGE_RECOMMENDATION_TYPES =
+  new Set<OperationalAuthoritySopChangeRecommendationType>([
+    "sop_review_recommended",
+    "sop_amendment_recommended",
+    "new_sop_required",
+    "oa_variation_review_recommended",
+  ]);
 
 function requiredTrimmed(value: unknown, fieldName: string): string {
   if (typeof value !== "string") {
@@ -297,6 +307,23 @@ function validateSopDocumentStatus(
   return value as OperationalAuthoritySopDocumentStatus;
 }
 
+function validateSopChangeRecommendationType(
+  value: unknown,
+): OperationalAuthoritySopChangeRecommendationType {
+  if (
+    typeof value !== "string" ||
+    !SOP_CHANGE_RECOMMENDATION_TYPES.has(
+      value as OperationalAuthoritySopChangeRecommendationType,
+    )
+  ) {
+    throw new OperationalAuthorityValidationError(
+      "recommendationType is not supported",
+    );
+  }
+
+  return value as OperationalAuthoritySopChangeRecommendationType;
+}
+
 export function validateCreateOperationalAuthorityDocumentInput(
   input: CreateOperationalAuthorityDocumentInput | undefined,
 ) {
@@ -415,6 +442,38 @@ export function validateCreateOperationalAuthoritySopDocumentInput(
       "changeRecommendationScope",
     ),
     reviewNotes: optionalTrimmed(input.reviewNotes, "reviewNotes"),
+  };
+}
+
+export function validateCreateOperationalAuthoritySopChangeRecommendationInput(
+  input: CreateOperationalAuthoritySopChangeRecommendationInput | undefined,
+) {
+  if (!input || typeof input !== "object") {
+    throw new OperationalAuthorityValidationError("Request body must be an object");
+  }
+
+  return {
+    profileId: requiredTrimmed(input.profileId, "profileId"),
+    sopDocumentId: requiredTrimmed(input.sopDocumentId, "sopDocumentId"),
+    parentOaConditionId: optionalTrimmed(
+      input.parentOaConditionId,
+      "parentOaConditionId",
+    ),
+    sopClauseRef: optionalTrimmed(input.sopClauseRef, "sopClauseRef"),
+    recommendationType: validateSopChangeRecommendationType(
+      input.recommendationType,
+    ),
+    evidenceSourceType: requiredTrimmed(
+      input.evidenceSourceType,
+      "evidenceSourceType",
+    ),
+    evidenceSourceId: requiredTrimmed(
+      input.evidenceSourceId,
+      "evidenceSourceId",
+    ),
+    findingSummary: requiredTrimmed(input.findingSummary, "findingSummary"),
+    recommendation: requiredTrimmed(input.recommendation, "recommendation"),
+    createdBy: requiredTrimmed(input.createdBy, "createdBy"),
   };
 }
 

--- a/src/tests/operational-authority.test.ts
+++ b/src/tests/operational-authority.test.ts
@@ -12,6 +12,7 @@ const clearTables = async () => {
   await pool.query("delete from organisation_documents");
   await pool.query("delete from operational_authority_pilot_authorisation_reviews");
   await pool.query("delete from operational_authority_pilot_authorisations");
+  await pool.query("delete from operational_authority_sop_change_recommendations");
   await pool.query("delete from operational_authority_sop_documents");
   await pool.query("delete from operational_authority_conditions");
   await pool.query("delete from operational_authority_profiles");
@@ -699,6 +700,153 @@ describe("operational authority integration", () => {
         sopCode: "SOP-DENIED",
         title: "Operator-created SOP",
         version: "1.0",
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toMatchObject({
+      type: "organisation_membership_forbidden",
+    });
+  });
+
+  it("creates and lists schema-backed SOP change recommendations against mission evidence", async () => {
+    const organisationId = randomUUID();
+    const missionId = await insertMission({ organisationId });
+    const validity = buildDateWindow(-30, 365);
+    const auth = await createUserAndSession("oa-sop-change@example.com");
+    await createMembership(organisationId, auth.user.id, "operations_manager");
+
+    const createResponse = await request(app)
+      .post(`/organisations/${organisationId}/operational-authority-documents`)
+      .set("X-Session-Token", auth.sessionToken)
+      .send({
+        authorityName: "CAA",
+        referenceNumber: "OA-SOP-REC-001",
+        issueDate: validity.issueDate,
+        effectiveFrom: validity.effectiveFrom,
+        expiresAt: validity.expiresAt,
+        uploadedBy: "ops-manager",
+        conditions: [
+          {
+            conditionCode: "ALLOWED_OPERATION_TYPE",
+            conditionTitle: "Permitted inspections",
+            clauseReference: "OA 8.1",
+            conditionPayload: { allowedOperationTypes: ["inspection"] },
+          },
+        ],
+      });
+
+    const conditionId = createResponse.body.conditions[0].id;
+    const sopResponse = await request(app)
+      .post(
+        `/operational-authority-profiles/${createResponse.body.profile.id}/sop-documents`,
+      )
+      .set("X-Session-Token", auth.sessionToken)
+      .send({
+        sopCode: "SOP-FLT-009",
+        title: "Post-operation review procedure",
+        version: "1.0",
+        status: "active",
+        sourceClauseRefs: ["SOP 9.4"],
+        linkedOaConditionIds: [conditionId],
+        changeRecommendationScope: ["post_operation_learning"],
+      });
+
+    expect(sopResponse.status).toBe(201);
+
+    const createRecommendationResponse = await request(app)
+      .post(`/missions/${missionId}/sop-change-recommendations`)
+      .set("X-Session-Token", auth.sessionToken)
+      .send({
+        profileId: createResponse.body.profile.id,
+        sopDocumentId: sopResponse.body.sopDocument.id,
+        parentOaConditionId: conditionId,
+        sopClauseRef: "SOP 9.4",
+        recommendationType: "sop_amendment_recommended",
+        evidenceSourceType: "post_operation_evidence_snapshot",
+        evidenceSourceId: "snapshot-001",
+        findingSummary:
+          "Post-operation review found repeated late weather evidence capture.",
+        recommendation:
+          "Review SOP 9.4 to clarify weather evidence timing before future inspections.",
+        createdBy: "ops-manager",
+      });
+
+    expect(createRecommendationResponse.status).toBe(201);
+    expect(createRecommendationResponse.body.recommendation).toMatchObject({
+      missionId,
+      organisationId,
+      operationalAuthorityProfileId: createResponse.body.profile.id,
+      operationalAuthoritySopDocumentId: sopResponse.body.sopDocument.id,
+      parentOaConditionId: conditionId,
+      sopCode: "SOP-FLT-009",
+      sopClauseRef: "SOP 9.4",
+      recommendationType: "sop_amendment_recommended",
+      status: "draft",
+      evidenceSourceType: "post_operation_evidence_snapshot",
+      evidenceSourceId: "snapshot-001",
+    });
+
+    const listResponse = await request(app)
+      .get(`/missions/${missionId}/sop-change-recommendations`)
+      .set("X-Session-Token", auth.sessionToken);
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.recommendations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: createRecommendationResponse.body.recommendation.id,
+          sopCode: "SOP-FLT-009",
+          status: "draft",
+        }),
+      ]),
+    );
+  });
+
+  it("prevents operators from creating SOP change recommendations", async () => {
+    const organisationId = randomUUID();
+    const missionId = await insertMission({ organisationId });
+    const validity = buildDateWindow(-30, 365);
+    const admin = await createUserAndSession("oa-sop-change-admin@example.com");
+    const operator = await createUserAndSession("oa-sop-change-operator@example.com");
+    await createMembership(organisationId, admin.user.id, "admin");
+    await createMembership(organisationId, operator.user.id, "operator");
+
+    const createResponse = await request(app)
+      .post(`/organisations/${organisationId}/operational-authority-documents`)
+      .set("X-Session-Token", admin.sessionToken)
+      .send({
+        authorityName: "CAA",
+        referenceNumber: "OA-SOP-REC-DENIED-001",
+        issueDate: validity.issueDate,
+        effectiveFrom: validity.effectiveFrom,
+        expiresAt: validity.expiresAt,
+        uploadedBy: "admin",
+        conditions: [],
+      });
+
+    const sopResponse = await request(app)
+      .post(
+        `/operational-authority-profiles/${createResponse.body.profile.id}/sop-documents`,
+      )
+      .set("X-Session-Token", admin.sessionToken)
+      .send({
+        sopCode: "SOP-DENIED-REC",
+        title: "Operator denied recommendation",
+        version: "1.0",
+      });
+
+    const response = await request(app)
+      .post(`/missions/${missionId}/sop-change-recommendations`)
+      .set("X-Session-Token", operator.sessionToken)
+      .send({
+        profileId: createResponse.body.profile.id,
+        sopDocumentId: sopResponse.body.sopDocument.id,
+        recommendationType: "sop_review_recommended",
+        evidenceSourceType: "timeline",
+        evidenceSourceId: "timeline-1",
+        findingSummary: "Operator should not be able to create this.",
+        recommendation: "Should be blocked.",
+        createdBy: "operator",
       });
 
     expect(response.status).toBe(403);


### PR DESCRIPTION
## Summary
- Adds schema-backed SOP change recommendation records linked to mission evidence
- Links each recommendation to a SOP document, SOP clause, and parent OA condition
- Adds mission routes for creating and listing SOP change recommendations
- Keeps recommendations as draft accountable-review prompts, not automatic SOP amendments
- Updates save-point and next-step notes for the follow-on review-decision workflow

## Validation
- npm.cmd run build
- npx.cmd vitest run src/tests/operational-authority.test.ts --pool=threads --reporter=verbose
- npm.cmd run validate:savepoint
- git diff --check
- node scripts/check-next-build-step-pr.mjs origin/main
