### PR TITLE
Add SOP recommendation review decisions

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,16 +1,16 @@
 # NEXT STEP
 
 ## Goal
-Add schema-backed SOP recommendation review decisions to mission evidence.
+Add schema-backed mission workspace display for SOP recommendation decisions.
 
 ---
 
 ## Build
 
 ### 1. Operator visibility
-- add migration-backed accountable review decisions for SOP change recommendations
-- capture decision state such as accepted for action, rejected, deferred, or closed
-- show latest decision state beside the SOP recommendation before accountable-manager sign-off
+- load schema-backed accountable review decisions for SOP change recommendations into the mission workspace
+- show latest decision state beside each SOP recommendation before accountable-manager sign-off
+- keep accepted, rejected, deferred, and closed states visually distinct from open recommendations
 
 ### 2. Product boundary
 - continue to label demo airspace data as synthetic/local
@@ -18,15 +18,14 @@ Add schema-backed SOP recommendation review decisions to mission evidence.
 - keep decisions framed as internal accountable review records, not automatic SOP amendment or regulatory submission
 
 ### 3. Tests
-- add backend, migration, and mission workspace UI tests for SOP recommendation review decisions
+- add mission workspace UI tests for SOP recommendation review decision display
 - run mission-planning UI tests
 - run TypeScript build and diff whitespace check
 
 ---
 
 ## Done When
-- SOP recommendations can carry explicit accountable review decisions
-- Mission workspace shows recommendation decision state without implying the SOP has been amended automatically
+- Mission workspace shows latest schema-backed recommendation decision state without implying the SOP has been amended automatically
 - Copy remains explicit that links support audit review, not compliance certification
 - Degraded or carried-forward overlays remain visually distinguishable
 - The demo remains clearly synthetic and safe for local presentation

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -39,7 +39,8 @@
       "Restored investor and architecture documentation for OA, insurance, SOP assurance, renewal readiness, evidence packs, deployment model, security, GDPR readiness, market positioning, and competitor framing",
       "Added governance-focused test coverage for OA, insurance, mission governance, risk map, accountable-manager dashboard, auth, stored files, and organisation documents",
       "Added first-class Operational Authority linked SOP document scaffolding so SOPs sit below the OA profile instead of being collapsed into OA conditions",
-      "Added schema-backed SOP change recommendation records linked to mission evidence, SOP documents, SOP clauses, and parent OA conditions"
+      "Added schema-backed SOP change recommendation records linked to mission evidence, SOP documents, SOP clauses, and parent OA conditions",
+      "Added schema-backed accountable review decisions for SOP change recommendations with accepted-for-action, rejected, deferred, and closed states"
     ],
     "modified": [
       "Merged the recovered governance build with latest main-branch live operations, regulatory review, evidence, map, and mission workspace improvements",
@@ -51,7 +52,8 @@
       "Added URL-driven visual focus for source-record drill-downs into live-ops map evidence, conflict acknowledgements, operations timeline, and regulatory matrix review sections",
       "Added focused safety/SOP and regulatory source-record detail panels inside the mission workspace timeline and regulatory review sections",
       "Documented the OA/SOP hierarchy as OA controlling approval envelope with SOPs as distinct linked procedures used for recommendation targeting",
-      "Added mission routes for creating and listing SOP-linked change recommendations as accountable review prompts"
+      "Added mission routes for creating and listing SOP-linked change recommendations as accountable review prompts",
+      "Added authenticated accountable-manager routes for recording and listing SOP recommendation review decisions"
     ],
     "removed": [],
     "fixed": [
@@ -83,6 +85,7 @@
       "Operational Authority profiles, conditions, pilot authorisations, and pilot authorisation reviews",
       "Operational Authority linked SOP documents with SOP code, version, source clauses, linked OA condition IDs, and change recommendation scope",
       "SOP change recommendations linked to mission evidence, SOP documents, parent OA conditions, and recommendation status",
+      "SOP recommendation review decisions linked to recommendation, mission, organisation, reviewer, rationale, evidence reference, and reviewed timestamp",
       "Insurance documents, profiles, conditions, source upload metadata, and assessment reasons",
       "Stored files, organisation documents, users, user sessions, and organisation memberships"
     ],
@@ -102,6 +105,7 @@
       "Operational Authority routes for document/profile/condition and pilot-authorisation management",
       "Operational Authority profile routes for listing and creating linked SOP documents",
       "Mission routes for listing and creating SOP-linked change recommendations",
+      "Operational Authority SOP change recommendation routes for accountable review decision creation and review history listing",
       "Insurance routes for policy/profile/condition assessment and source upload metadata",
       "Mission governance routes for combined OA and insurance mission readiness",
       "Risk-map and accountable-manager dashboard routes for early-warning summary surfaces",
@@ -136,7 +140,8 @@
       "Operators now see a focused review cue when a source-record drill-down lands on the relevant live-ops or mission-workspace evidence area",
       "Operators can review safety/SOP and regulatory source-record IDs, summaries, timestamps, source JSON links, and review surfaces without manually hunting through the workspace",
       "Compliance teams can record SOP documents as distinct linked procedures under the OA profile so later change recommendations can target the relevant SOP",
-      "Governance users can record draft SOP change recommendations against mission evidence without amending the SOP automatically"
+      "Governance users can record draft SOP change recommendations against mission evidence without amending the SOP automatically",
+      "Accountable managers can record review decisions against SOP recommendations while preserving the recommendation history as advisory evidence"
     ]
   },
   "complianceImplications": {
@@ -160,7 +165,8 @@
       "Source-record drill-down review URLs preserve evidence IDs and highlight the relevant review surface without treating the item as certified, closed, or automatically resolved",
       "Safety/SOP and regulatory drill-down sections now display source-record detail as accountable review support, not compliance certification or automatic closure",
       "Linked SOP documents create the first traceable target for future post-operation SOP amendment recommendations",
-      "SOP change recommendations now preserve mission evidence source, SOP clause, and parent OA condition context as draft accountable review records"
+      "SOP change recommendations now preserve mission evidence source, SOP clause, and parent OA condition context as draft accountable review records",
+      "SOP recommendation review decisions now preserve who reviewed the recommendation, why they decided, and any supporting evidence reference without automatically amending SOP content"
     ]
   },
   "risksLimitations": {
@@ -205,11 +211,12 @@
       "Validated source-record drill-down focus state with TypeScript build and mission-planning UI tests",
       "Validated safety/SOP and regulatory focused source-record detail panels with TypeScript build and mission-planning UI tests",
       "Validated OA-linked SOP document creation/listing, role access, TypeScript build, and operational-authority integration tests",
-      "Validated schema-backed SOP change recommendation creation/listing, role access, TypeScript build, and operational-authority integration tests"
+      "Validated schema-backed SOP change recommendation creation/listing, role access, TypeScript build, and operational-authority integration tests",
+      "Validated schema-backed SOP recommendation review decision creation/listing, accountable-manager role access, TypeScript build, and operational-authority integration tests"
     ]
 
   },
-  "nextBuildStep": "Add schema-backed SOP recommendation review decisions to mission evidence.",
+  "nextBuildStep": "Add schema-backed mission workspace display for SOP recommendation decisions.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -79,6 +79,7 @@ import {
   createOperationalAuthorityOrganisationRouter,
   createOperationalAuthorityPilotAuthorisationRouter,
   createOperationalAuthorityProfileRouter,
+  createOperationalAuthoritySopChangeRecommendationRouter,
 } from "./operational-authority/operational-authority.routes";
 import { InsuranceRepository } from "./insurance/insurance.repository";
 import { InsuranceService } from "./insurance/insurance.service";
@@ -414,6 +415,13 @@ app.use(
   "/operational-authority-pilot-authorisations",
   authMiddleware,
   createOperationalAuthorityPilotAuthorisationRouter(operationalAuthorityController),
+);
+app.use(
+  "/operational-authority-sop-change-recommendations",
+  authMiddleware,
+  createOperationalAuthoritySopChangeRecommendationRouter(
+    operationalAuthorityController,
+  ),
 );
 app.use(
   "/organisations",

--- a/src/migrations/050_create_operational_authority_sop_change_recommendation_reviews.sql
+++ b/src/migrations/050_create_operational_authority_sop_change_recommendation_reviews.sql
@@ -1,0 +1,23 @@
+create table if not exists operational_authority_sop_change_recommendation_reviews (
+  id uuid primary key,
+  operational_authority_sop_change_recommendation_id uuid not null references operational_authority_sop_change_recommendations(id) on delete cascade,
+  mission_id uuid not null references missions(id) on delete cascade,
+  organisation_id uuid not null,
+  decision text not null check (
+    decision in ('accepted_for_action', 'rejected', 'deferred', 'closed')
+  ),
+  reviewed_by text not null,
+  review_rationale text not null,
+  evidence_ref text,
+  reviewed_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists operational_authority_sop_change_recommendation_reviews_recommendation_idx
+  on operational_authority_sop_change_recommendation_reviews (operational_authority_sop_change_recommendation_id);
+
+create index if not exists operational_authority_sop_change_recommendation_reviews_mission_idx
+  on operational_authority_sop_change_recommendation_reviews (mission_id);
+
+create index if not exists operational_authority_sop_change_recommendation_reviews_org_idx
+  on operational_authority_sop_change_recommendation_reviews (organisation_id);

--- a/src/operational-authority/operational-authority.controller.ts
+++ b/src/operational-authority/operational-authority.controller.ts
@@ -23,6 +23,10 @@ type MissionIdParams = {
   missionId: string;
 };
 
+type SopChangeRecommendationIdParams = {
+  recommendationId: string;
+};
+
 export class OperationalAuthorityController {
   constructor(
     private readonly operationalAuthorityService: OperationalAuthorityService,
@@ -206,6 +210,66 @@ export class OperationalAuthorityController {
       const created =
         await this.operationalAuthorityService.createSopChangeRecommendation(
           req.params.missionId,
+          req.body,
+        );
+      res.status(201).json(created);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  listSopChangeRecommendationReviews = async (
+    req: Request<SopChangeRecommendationIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const user = requireCurrentUser(req);
+      const organisationId =
+        await this.operationalAuthorityService.getSopChangeRecommendationOrganisationId(
+          req.params.recommendationId,
+        );
+      await this.organisationMembershipsService.requireMembership(
+        user.id,
+        organisationId,
+        [
+          "viewer",
+          "operator",
+          "operations_manager",
+          "compliance_manager",
+          "accountable_manager",
+          "admin",
+        ],
+      );
+      const listed =
+        await this.operationalAuthorityService.listSopChangeRecommendationReviews(
+          req.params.recommendationId,
+        );
+      res.status(200).json(listed);
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  createSopChangeRecommendationReview = async (
+    req: Request<SopChangeRecommendationIdParams>,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const user = requireCurrentUser(req);
+      const organisationId =
+        await this.operationalAuthorityService.getSopChangeRecommendationOrganisationId(
+          req.params.recommendationId,
+        );
+      await this.organisationMembershipsService.requireMembership(
+        user.id,
+        organisationId,
+        ["accountable_manager", "admin"],
+      );
+      const created =
+        await this.operationalAuthorityService.createSopChangeRecommendationReview(
+          req.params.recommendationId,
           req.body,
         );
       res.status(201).json(created);

--- a/src/operational-authority/operational-authority.repository.ts
+++ b/src/operational-authority/operational-authority.repository.ts
@@ -7,6 +7,7 @@ import type {
   OperationalAuthorityPilotAuthorisationReview,
   OperationalAuthorityProfile,
   OperationalAuthoritySopChangeRecommendation,
+  OperationalAuthoritySopChangeRecommendationReview,
   OperationalAuthoritySopDocument,
 } from "./operational-authority.types";
 
@@ -100,6 +101,19 @@ interface OperationalAuthoritySopChangeRecommendationRow extends QueryResultRow 
   created_by: string;
   created_at: Date;
   updated_at: Date;
+}
+
+interface OperationalAuthoritySopChangeRecommendationReviewRow extends QueryResultRow {
+  id: string;
+  operational_authority_sop_change_recommendation_id: string;
+  mission_id: string;
+  organisation_id: string;
+  decision: OperationalAuthoritySopChangeRecommendationReview["decision"];
+  reviewed_by: string;
+  review_rationale: string;
+  evidence_ref: string | null;
+  reviewed_at: Date;
+  created_at: Date;
 }
 
 interface OperationalAuthorityPilotAuthorisationRow extends QueryResultRow {
@@ -223,6 +237,22 @@ const toSopChangeRecommendation = (
   createdBy: row.created_by,
   createdAt: row.created_at.toISOString(),
   updatedAt: row.updated_at.toISOString(),
+});
+
+const toSopChangeRecommendationReview = (
+  row: OperationalAuthoritySopChangeRecommendationReviewRow,
+): OperationalAuthoritySopChangeRecommendationReview => ({
+  id: row.id,
+  operationalAuthoritySopChangeRecommendationId:
+    row.operational_authority_sop_change_recommendation_id,
+  missionId: row.mission_id,
+  organisationId: row.organisation_id,
+  decision: row.decision,
+  reviewedBy: row.reviewed_by,
+  reviewRationale: row.review_rationale,
+  evidenceRef: row.evidence_ref,
+  reviewedAt: row.reviewed_at.toISOString(),
+  createdAt: row.created_at.toISOString(),
 });
 
 const toPilotAuthorisation = (
@@ -741,6 +771,104 @@ export class OperationalAuthorityRepository {
     );
 
     return result.rows.map((row) => toSopChangeRecommendation(row));
+  }
+
+  async getSopChangeRecommendationById(
+    tx: PoolClient,
+    recommendationId: string,
+  ): Promise<OperationalAuthoritySopChangeRecommendation | null> {
+    const result = await tx.query<OperationalAuthoritySopChangeRecommendationRow>(
+      `
+      select *
+      from operational_authority_sop_change_recommendations
+      where id = $1
+      `,
+      [recommendationId],
+    );
+
+    return result.rows[0] ? toSopChangeRecommendation(result.rows[0]) : null;
+  }
+
+  async updateSopChangeRecommendationStatus(
+    tx: PoolClient,
+    recommendationId: string,
+    status: OperationalAuthoritySopChangeRecommendation["status"],
+  ): Promise<OperationalAuthoritySopChangeRecommendation> {
+    const result = await tx.query<OperationalAuthoritySopChangeRecommendationRow>(
+      `
+      update operational_authority_sop_change_recommendations
+      set
+        status = $2,
+        updated_at = now()
+      where id = $1
+      returning *
+      `,
+      [recommendationId, status],
+    );
+
+    return toSopChangeRecommendation(result.rows[0]);
+  }
+
+  async insertSopChangeRecommendationReview(
+    tx: PoolClient,
+    params: {
+      recommendationId: string;
+      missionId: string;
+      organisationId: string;
+      decision: OperationalAuthoritySopChangeRecommendationReview["decision"];
+      reviewedBy: string;
+      reviewRationale: string;
+      evidenceRef: string | null;
+      reviewedAt: string | null;
+    },
+  ): Promise<OperationalAuthoritySopChangeRecommendationReview> {
+    const result = await tx.query<OperationalAuthoritySopChangeRecommendationReviewRow>(
+      `
+      insert into operational_authority_sop_change_recommendation_reviews (
+        id,
+        operational_authority_sop_change_recommendation_id,
+        mission_id,
+        organisation_id,
+        decision,
+        reviewed_by,
+        review_rationale,
+        evidence_ref,
+        reviewed_at
+      )
+      values ($1, $2, $3, $4, $5, $6, $7, $8, coalesce($9::timestamptz, now()))
+      returning *
+      `,
+      [
+        randomUUID(),
+        params.recommendationId,
+        params.missionId,
+        params.organisationId,
+        params.decision,
+        params.reviewedBy,
+        params.reviewRationale,
+        params.evidenceRef,
+        params.reviewedAt,
+      ],
+    );
+
+    return toSopChangeRecommendationReview(result.rows[0]);
+  }
+
+  async listSopChangeRecommendationReviews(
+    tx: PoolClient,
+    recommendationId: string,
+  ): Promise<OperationalAuthoritySopChangeRecommendationReview[]> {
+    const result = await tx.query<OperationalAuthoritySopChangeRecommendationReviewRow>(
+      `
+      select *
+      from operational_authority_sop_change_recommendation_reviews
+      where operational_authority_sop_change_recommendation_id = $1
+      order by reviewed_at desc, created_at desc, id desc
+      `,
+      [recommendationId],
+    );
+
+    return result.rows.map((row) => toSopChangeRecommendationReview(row));
   }
 
   async getPilotAuthorisationForProfile(

--- a/src/operational-authority/operational-authority.routes.ts
+++ b/src/operational-authority/operational-authority.routes.ts
@@ -94,3 +94,20 @@ export function createOperationalAuthorityPilotAuthorisationRouter(
 
   return router;
 }
+
+export function createOperationalAuthoritySopChangeRecommendationRouter(
+  controller: OperationalAuthorityController,
+): Router {
+  const router = Router();
+
+  router.get(
+    "/:recommendationId/reviews",
+    controller.listSopChangeRecommendationReviews,
+  );
+  router.post(
+    "/:recommendationId/reviews",
+    controller.createSopChangeRecommendationReview,
+  );
+
+  return router;
+}

--- a/src/operational-authority/operational-authority.service.ts
+++ b/src/operational-authority/operational-authority.service.ts
@@ -12,6 +12,7 @@ import type {
   CreateOperationalAuthorityPilotAuthorisationInput,
   CreateOperationalAuthorityPilotAuthorisationReviewInput,
   CreateOperationalAuthoritySopChangeRecommendationInput,
+  CreateOperationalAuthoritySopChangeRecommendationReviewInput,
   CreateOperationalAuthoritySopDocumentInput,
   OperationalAuthorityAssessment,
   OperationalAuthorityAssessmentReason,
@@ -25,6 +26,7 @@ import {
   validateCreateOperationalAuthorityPilotAuthorisationInput,
   validateCreateOperationalAuthorityPilotAuthorisationReviewInput,
   validateCreateOperationalAuthoritySopChangeRecommendationInput,
+  validateCreateOperationalAuthoritySopChangeRecommendationReviewInput,
   validateCreateOperationalAuthoritySopDocumentInput,
   validateUpdateOperationalAuthorityPilotAuthorisationInput,
   validateUploadOperationalAuthorityDocumentInput,
@@ -404,6 +406,116 @@ export class OperationalAuthorityService {
         );
 
       return { missionId, recommendations };
+    } finally {
+      client.release();
+    }
+  }
+
+  async createSopChangeRecommendationReview(
+    recommendationId: string,
+    input:
+      | CreateOperationalAuthoritySopChangeRecommendationReviewInput
+      | undefined,
+  ) {
+    const validated =
+      validateCreateOperationalAuthoritySopChangeRecommendationReviewInput(input);
+    const client = await this.pool.connect();
+
+    try {
+      await client.query("BEGIN");
+
+      const existing =
+        await this.operationalAuthorityRepository.getSopChangeRecommendationById(
+          client,
+          recommendationId,
+        );
+
+      if (!existing) {
+        throw new OperationalAuthorityMissionNotFoundError(recommendationId);
+      }
+
+      const review =
+        await this.operationalAuthorityRepository.insertSopChangeRecommendationReview(
+          client,
+          {
+            recommendationId,
+            missionId: existing.missionId,
+            organisationId: existing.organisationId,
+            decision: validated.decision,
+            reviewedBy: validated.reviewedBy,
+            reviewRationale: validated.reviewRationale,
+            evidenceRef: validated.evidenceRef,
+            reviewedAt: validated.reviewedAt,
+          },
+        );
+
+      const status =
+        validated.decision === "deferred" ? "under_review" : validated.decision;
+      const recommendation =
+        await this.operationalAuthorityRepository.updateSopChangeRecommendationStatus(
+          client,
+          recommendationId,
+          status,
+        );
+      const reviews =
+        await this.operationalAuthorityRepository.listSopChangeRecommendationReviews(
+          client,
+          recommendationId,
+        );
+
+      await client.query("COMMIT");
+      return { recommendation, review, reviews };
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async listSopChangeRecommendationReviews(recommendationId: string) {
+    const client = await this.pool.connect();
+
+    try {
+      const recommendation =
+        await this.operationalAuthorityRepository.getSopChangeRecommendationById(
+          client,
+          recommendationId,
+        );
+
+      if (!recommendation) {
+        throw new OperationalAuthorityMissionNotFoundError(recommendationId);
+      }
+
+      const reviews =
+        await this.operationalAuthorityRepository.listSopChangeRecommendationReviews(
+          client,
+          recommendationId,
+        );
+
+      return { recommendation, reviews };
+    } finally {
+      client.release();
+    }
+  }
+
+  async getSopChangeRecommendationOrganisationId(
+    recommendationId: string,
+  ): Promise<string> {
+    const client = await this.pool.connect();
+
+    try {
+      const recommendation =
+        await this.operationalAuthorityRepository.getSopChangeRecommendationById(
+          client,
+          recommendationId,
+        );
+
+      if (!recommendation) {
+        throw new OperationalAuthorityMissionNotFoundError(recommendationId);
+      }
+
+      return recommendation.organisationId;
     } finally {
       client.release();
     }

--- a/src/operational-authority/operational-authority.types.ts
+++ b/src/operational-authority/operational-authority.types.ts
@@ -99,6 +99,20 @@ export interface CreateOperationalAuthoritySopChangeRecommendationInput {
   createdBy?: string;
 }
 
+export type OperationalAuthoritySopChangeRecommendationDecision =
+  | "accepted_for_action"
+  | "rejected"
+  | "deferred"
+  | "closed";
+
+export interface CreateOperationalAuthoritySopChangeRecommendationReviewInput {
+  decision?: OperationalAuthoritySopChangeRecommendationDecision;
+  reviewedBy?: string;
+  reviewRationale?: string;
+  evidenceRef?: string | null;
+  reviewedAt?: string | null;
+}
+
 export interface ActivateOperationalAuthorityProfileInput {
   activatedBy?: string;
 }
@@ -222,6 +236,19 @@ export interface OperationalAuthoritySopChangeRecommendation {
   createdBy: string;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface OperationalAuthoritySopChangeRecommendationReview {
+  id: string;
+  operationalAuthoritySopChangeRecommendationId: string;
+  missionId: string;
+  organisationId: string;
+  decision: OperationalAuthoritySopChangeRecommendationDecision;
+  reviewedBy: string;
+  reviewRationale: string;
+  evidenceRef: string | null;
+  reviewedAt: string;
+  createdAt: string;
 }
 
 export type OperationalAuthorityPilotAuthorisationState =

--- a/src/operational-authority/operational-authority.validators.ts
+++ b/src/operational-authority/operational-authority.validators.ts
@@ -8,11 +8,13 @@ import type {
   CreateOperationalAuthorityPilotAuthorisationInput,
   CreateOperationalAuthorityPilotAuthorisationReviewInput,
   CreateOperationalAuthoritySopChangeRecommendationInput,
+  CreateOperationalAuthoritySopChangeRecommendationReviewInput,
   CreateOperationalAuthoritySopDocumentInput,
   MissionOperationType,
   OperationalAuthorityConditionCode,
   OperationalAuthorityPilotAuthorisationReviewDecision,
   OperationalAuthorityPilotAuthorisationState,
+  OperationalAuthoritySopChangeRecommendationDecision,
   OperationalAuthoritySopChangeRecommendationType,
   OperationalAuthoritySopDocumentStatus,
   UpdateOperationalAuthorityPilotAuthorisationInput,
@@ -63,6 +65,14 @@ const SOP_CHANGE_RECOMMENDATION_TYPES =
     "sop_amendment_recommended",
     "new_sop_required",
     "oa_variation_review_recommended",
+  ]);
+
+const SOP_CHANGE_RECOMMENDATION_DECISIONS =
+  new Set<OperationalAuthoritySopChangeRecommendationDecision>([
+    "accepted_for_action",
+    "rejected",
+    "deferred",
+    "closed",
   ]);
 
 function requiredTrimmed(value: unknown, fieldName: string): string {
@@ -324,6 +334,21 @@ function validateSopChangeRecommendationType(
   return value as OperationalAuthoritySopChangeRecommendationType;
 }
 
+function validateSopChangeRecommendationDecision(
+  value: unknown,
+): OperationalAuthoritySopChangeRecommendationDecision {
+  if (
+    typeof value !== "string" ||
+    !SOP_CHANGE_RECOMMENDATION_DECISIONS.has(
+      value as OperationalAuthoritySopChangeRecommendationDecision,
+    )
+  ) {
+    throw new OperationalAuthorityValidationError("decision is not supported");
+  }
+
+  return value as OperationalAuthoritySopChangeRecommendationDecision;
+}
+
 export function validateCreateOperationalAuthorityDocumentInput(
   input: CreateOperationalAuthorityDocumentInput | undefined,
 ) {
@@ -474,6 +499,27 @@ export function validateCreateOperationalAuthoritySopChangeRecommendationInput(
     findingSummary: requiredTrimmed(input.findingSummary, "findingSummary"),
     recommendation: requiredTrimmed(input.recommendation, "recommendation"),
     createdBy: requiredTrimmed(input.createdBy, "createdBy"),
+  };
+}
+
+export function validateCreateOperationalAuthoritySopChangeRecommendationReviewInput(
+  input:
+    | CreateOperationalAuthoritySopChangeRecommendationReviewInput
+    | undefined,
+) {
+  if (!input || typeof input !== "object") {
+    throw new OperationalAuthorityValidationError("Request body must be an object");
+  }
+
+  return {
+    decision: validateSopChangeRecommendationDecision(input.decision),
+    reviewedBy: requiredTrimmed(input.reviewedBy, "reviewedBy"),
+    reviewRationale: requiredTrimmed(
+      input.reviewRationale,
+      "reviewRationale",
+    ),
+    evidenceRef: optionalTrimmed(input.evidenceRef, "evidenceRef"),
+    reviewedAt: optionalIsoDate(input.reviewedAt, "reviewedAt"),
   };
 }
 

--- a/src/tests/operational-authority.test.ts
+++ b/src/tests/operational-authority.test.ts
@@ -12,6 +12,7 @@ const clearTables = async () => {
   await pool.query("delete from organisation_documents");
   await pool.query("delete from operational_authority_pilot_authorisation_reviews");
   await pool.query("delete from operational_authority_pilot_authorisations");
+  await pool.query("delete from operational_authority_sop_change_recommendation_reviews");
   await pool.query("delete from operational_authority_sop_change_recommendations");
   await pool.query("delete from operational_authority_sop_documents");
   await pool.query("delete from operational_authority_conditions");
@@ -847,6 +848,175 @@ describe("operational authority integration", () => {
         findingSummary: "Operator should not be able to create this.",
         recommendation: "Should be blocked.",
         createdBy: "operator",
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toMatchObject({
+      type: "organisation_membership_forbidden",
+    });
+  });
+
+  it("records accountable review decisions for SOP change recommendations", async () => {
+    const organisationId = randomUUID();
+    const missionId = await insertMission({ organisationId });
+    const validity = buildDateWindow(-30, 365);
+    const auth = await createUserAndSession("oa-sop-decision@example.com");
+    await createMembership(organisationId, auth.user.id, "accountable_manager");
+
+    const createResponse = await request(app)
+      .post(`/organisations/${organisationId}/operational-authority-documents`)
+      .set("X-Session-Token", auth.sessionToken)
+      .send({
+        authorityName: "CAA",
+        referenceNumber: "OA-SOP-DEC-001",
+        issueDate: validity.issueDate,
+        effectiveFrom: validity.effectiveFrom,
+        expiresAt: validity.expiresAt,
+        uploadedBy: "accountable-manager",
+        conditions: [
+          {
+            conditionCode: "ALLOWED_OPERATION_TYPE",
+            conditionTitle: "Permitted inspections",
+            clauseReference: "OA 9.1",
+            conditionPayload: { allowedOperationTypes: ["inspection"] },
+          },
+        ],
+      });
+
+    const conditionId = createResponse.body.conditions[0].id;
+    const sopResponse = await request(app)
+      .post(
+        `/operational-authority-profiles/${createResponse.body.profile.id}/sop-documents`,
+      )
+      .set("X-Session-Token", auth.sessionToken)
+      .send({
+        sopCode: "SOP-FLT-010",
+        title: "Accountable SOP decision procedure",
+        version: "1.0",
+        status: "active",
+        sourceClauseRefs: ["SOP 10.1"],
+        linkedOaConditionIds: [conditionId],
+        changeRecommendationScope: ["post_operation_learning"],
+      });
+
+    const recommendationResponse = await request(app)
+      .post(`/missions/${missionId}/sop-change-recommendations`)
+      .set("X-Session-Token", auth.sessionToken)
+      .send({
+        profileId: createResponse.body.profile.id,
+        sopDocumentId: sopResponse.body.sopDocument.id,
+        parentOaConditionId: conditionId,
+        sopClauseRef: "SOP 10.1",
+        recommendationType: "sop_review_recommended",
+        evidenceSourceType: "post_operation_evidence_snapshot",
+        evidenceSourceId: "snapshot-010",
+        findingSummary: "Review found repeated dispatch evidence delay.",
+        recommendation:
+          "Accountable manager should decide whether SOP 10.1 needs amendment.",
+        createdBy: "accountable-manager",
+      });
+
+    const recommendationId = recommendationResponse.body.recommendation.id;
+    const reviewResponse = await request(app)
+      .post(
+        `/operational-authority-sop-change-recommendations/${recommendationId}/reviews`,
+      )
+      .set("X-Session-Token", auth.sessionToken)
+      .send({
+        decision: "accepted_for_action",
+        reviewedBy: "Accountable Manager",
+        reviewRationale:
+          "Accepted for action as an internal SOP review task; no automatic SOP amendment is made.",
+        evidenceRef: "AM-SOP-DEC-001",
+      });
+
+    expect(reviewResponse.status).toBe(201);
+    expect(reviewResponse.body.recommendation).toMatchObject({
+      id: recommendationId,
+      status: "accepted_for_action",
+    });
+    expect(reviewResponse.body.review).toMatchObject({
+      operationalAuthoritySopChangeRecommendationId: recommendationId,
+      missionId,
+      organisationId,
+      decision: "accepted_for_action",
+      reviewedBy: "Accountable Manager",
+      evidenceRef: "AM-SOP-DEC-001",
+    });
+
+    const listResponse = await request(app)
+      .get(
+        `/operational-authority-sop-change-recommendations/${recommendationId}/reviews`,
+      )
+      .set("X-Session-Token", auth.sessionToken);
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.reviews).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: reviewResponse.body.review.id,
+          decision: "accepted_for_action",
+        }),
+      ]),
+    );
+  });
+
+  it("prevents non-accountable roles from reviewing SOP change recommendations", async () => {
+    const organisationId = randomUUID();
+    const missionId = await insertMission({ organisationId });
+    const validity = buildDateWindow(-30, 365);
+    const admin = await createUserAndSession("oa-sop-decision-admin@example.com");
+    const operator = await createUserAndSession("oa-sop-decision-operator@example.com");
+    await createMembership(organisationId, admin.user.id, "admin");
+    await createMembership(organisationId, operator.user.id, "operator");
+
+    const createResponse = await request(app)
+      .post(`/organisations/${organisationId}/operational-authority-documents`)
+      .set("X-Session-Token", admin.sessionToken)
+      .send({
+        authorityName: "CAA",
+        referenceNumber: "OA-SOP-DEC-DENIED-001",
+        issueDate: validity.issueDate,
+        effectiveFrom: validity.effectiveFrom,
+        expiresAt: validity.expiresAt,
+        uploadedBy: "admin",
+        conditions: [],
+      });
+
+    const sopResponse = await request(app)
+      .post(
+        `/operational-authority-profiles/${createResponse.body.profile.id}/sop-documents`,
+      )
+      .set("X-Session-Token", admin.sessionToken)
+      .send({
+        sopCode: "SOP-DEC-DENIED",
+        title: "Denied decision SOP",
+        version: "1.0",
+      });
+
+    const recommendationResponse = await request(app)
+      .post(`/missions/${missionId}/sop-change-recommendations`)
+      .set("X-Session-Token", admin.sessionToken)
+      .send({
+        profileId: createResponse.body.profile.id,
+        sopDocumentId: sopResponse.body.sopDocument.id,
+        recommendationType: "sop_review_recommended",
+        evidenceSourceType: "timeline",
+        evidenceSourceId: "timeline-denied",
+        findingSummary: "Operator should not decide this.",
+        recommendation: "Should be blocked.",
+        createdBy: "admin",
+      });
+
+    const response = await request(app)
+      .post(
+        `/operational-authority-sop-change-recommendations/${recommendationResponse.body.recommendation.id}/reviews`,
+      )
+      .set("X-Session-Token", operator.sessionToken)
+      .send({
+        decision: "accepted_for_action",
+        reviewedBy: "Operator",
+        reviewRationale: "Should not be accepted from this role.",
       });
 
     expect(response.status).toBe(403);


### PR DESCRIPTION
Adds schema-backed accountable review decisions for SOP change recommendations.

Includes:
- New migration for SOP recommendation review records
- Review decisions: accepted for action, rejected, deferred, closed
- Accountable-manager/admin-only creation route
- Review history listing route
- Parent recommendation status update after review
- Focused operational-authority integration tests
- Save-point and next-build-step updated

Validation:
- npm run build
- operational-authority.test.ts: 17/17 passed
- npm run validate:savepoint
- git diff --check
- nextBuildStep PR gate passed
