### PR TITLE
Show SOP decisions in mission workspace

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,31 +1,31 @@
 # NEXT STEP
 
 ## Goal
-Add schema-backed mission workspace display for SOP recommendation decisions.
+Add accountable-manager controls for recording SOP recommendation decisions from the workspace.
 
 ---
 
 ## Build
 
 ### 1. Operator visibility
-- load schema-backed accountable review decisions for SOP change recommendations into the mission workspace
-- show latest decision state beside each SOP recommendation before accountable-manager sign-off
-- keep accepted, rejected, deferred, and closed states visually distinct from open recommendations
+- add a role-controlled accountable-manager action path from the mission workspace SOP decision summary
+- record accepted, rejected, deferred, or closed decisions without treating draft recommendations as operating instructions
+- keep decision controls separate from post-operation evidence sign-off
 
 ### 2. Product boundary
 - continue to label demo airspace data as synthetic/local
 - do not imply live CAA, NOTAM, or manufacturer feed connectivity
-- keep decisions framed as internal accountable review records, not automatic SOP amendment or regulatory submission
+- keep decisions framed as internal accountable review records, not automatic SOP amendment, operational authorisation, or regulatory submission
 
 ### 3. Tests
-- add mission workspace UI tests for SOP recommendation review decision display
+- add mission workspace UI tests for role-controlled SOP recommendation decision recording controls
 - run mission-planning UI tests
 - run TypeScript build and diff whitespace check
 
 ---
 
 ## Done When
-- Mission workspace shows latest schema-backed recommendation decision state without implying the SOP has been amended automatically
+- Accountable managers can initiate SOP recommendation review decisions from the workspace without exposing draft SOP changes as operating instructions
 - Copy remains explicit that links support audit review, not compliance certification
 - Degraded or carried-forward overlays remain visually distinguishable
 - The demo remains clearly synthetic and safe for local presentation

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -53,7 +53,9 @@
       "Added focused safety/SOP and regulatory source-record detail panels inside the mission workspace timeline and regulatory review sections",
       "Documented the OA/SOP hierarchy as OA controlling approval envelope with SOPs as distinct linked procedures used for recommendation targeting",
       "Added mission routes for creating and listing SOP-linked change recommendations as accountable review prompts",
-      "Added authenticated accountable-manager routes for recording and listing SOP recommendation review decisions"
+      "Added authenticated accountable-manager routes for recording and listing SOP recommendation review decisions",
+      "Added mission workspace SOP recommendation decision display that loads schema-backed recommendation review state when an authorised governance session is present",
+      "Restricted SOP recommendation and review-history read access to governance and management roles so draft SOP changes are not exposed as operator instructions"
     ],
     "removed": [],
     "fixed": [
@@ -141,7 +143,8 @@
       "Operators can review safety/SOP and regulatory source-record IDs, summaries, timestamps, source JSON links, and review surfaces without manually hunting through the workspace",
       "Compliance teams can record SOP documents as distinct linked procedures under the OA profile so later change recommendations can target the relevant SOP",
       "Governance users can record draft SOP change recommendations against mission evidence without amending the SOP automatically",
-      "Accountable managers can record review decisions against SOP recommendations while preserving the recommendation history as advisory evidence"
+      "Accountable managers can record review decisions against SOP recommendations while preserving the recommendation history as advisory evidence",
+      "Authorised governance users can see SOP recommendation decision state in the mission workspace before sign-off; unauthorised users see controlled-access advisory wording instead"
     ]
   },
   "complianceImplications": {
@@ -166,7 +169,8 @@
       "Safety/SOP and regulatory drill-down sections now display source-record detail as accountable review support, not compliance certification or automatic closure",
       "Linked SOP documents create the first traceable target for future post-operation SOP amendment recommendations",
       "SOP change recommendations now preserve mission evidence source, SOP clause, and parent OA condition context as draft accountable review records",
-      "SOP recommendation review decisions now preserve who reviewed the recommendation, why they decided, and any supporting evidence reference without automatically amending SOP content"
+      "SOP recommendation review decisions now preserve who reviewed the recommendation, why they decided, and any supporting evidence reference without automatically amending SOP content",
+      "SOP recommendation decision visibility is now treated as role-controlled accountable review support, not operational instruction to pilots or operators"
     ]
   },
   "risksLimitations": {
@@ -212,11 +216,12 @@
       "Validated safety/SOP and regulatory focused source-record detail panels with TypeScript build and mission-planning UI tests",
       "Validated OA-linked SOP document creation/listing, role access, TypeScript build, and operational-authority integration tests",
       "Validated schema-backed SOP change recommendation creation/listing, role access, TypeScript build, and operational-authority integration tests",
-      "Validated schema-backed SOP recommendation review decision creation/listing, accountable-manager role access, TypeScript build, and operational-authority integration tests"
+      "Validated schema-backed SOP recommendation review decision creation/listing, accountable-manager role access, TypeScript build, and operational-authority integration tests",
+      "Validated role-controlled SOP recommendation visibility and mission workspace decision display copy with TypeScript build, operational-authority tests, and mission-planning UI bundle tests"
     ]
 
   },
-  "nextBuildStep": "Add schema-backed mission workspace display for SOP recommendation decisions.",
+  "nextBuildStep": "Add accountable-manager workspace controls for SOP recommendation decisions.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/operational-authority/operational-authority.controller.ts
+++ b/src/operational-authority/operational-authority.controller.ts
@@ -168,8 +168,6 @@ export class OperationalAuthorityController {
         user.id,
         organisationId,
         [
-          "viewer",
-          "operator",
           "operations_manager",
           "compliance_manager",
           "accountable_manager",
@@ -233,8 +231,6 @@ export class OperationalAuthorityController {
         user.id,
         organisationId,
         [
-          "viewer",
-          "operator",
           "operations_manager",
           "compliance_manager",
           "accountable_manager",

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2004,6 +2004,17 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("Pre-sign-off Evidence Summary");
     expect(response.text).toContain("Rendered Report Readiness Summary");
     expect(response.text).toContain("renderReportReadinessSummary");
+    expect(response.text).toContain("SOP Recommendation Decisions");
+    expect(response.text).toContain("renderSopRecommendationDecisionSummary");
+    expect(response.text).toContain("/sop-change-recommendations");
+    expect(response.text).toContain("/operational-authority-sop-change-recommendations/");
+    expect(response.text).toContain("Accepted for action");
+    expect(response.text).toContain("Awaiting accountable review");
+    expect(response.text).toContain("Role-controlled accountable review record only");
+    expect(response.text).toContain("no automatic SOP amendment, operational authorisation, or regulatory submission");
+    expect(response.text).toContain("Sign in with an authorised governance or management role");
+    expect(response.text).toContain("does not authorise operators to use draft changes");
+    expect(response.text).toContain("Draft recommendations are not operating instructions");
     expect(response.text).toContain("Evidence Drill-down Links");
     expect(response.text).toContain("renderReadinessDrilldowns");
     expect(response.text).toContain("renderReadinessDrilldownCard");

--- a/src/tests/operational-authority.test.ts
+++ b/src/tests/operational-authority.test.ts
@@ -836,6 +836,20 @@ describe("operational authority integration", () => {
         version: "1.0",
       });
 
+    const recommendationResponse = await request(app)
+      .post(`/missions/${missionId}/sop-change-recommendations`)
+      .set("X-Session-Token", admin.sessionToken)
+      .send({
+        profileId: createResponse.body.profile.id,
+        sopDocumentId: sopResponse.body.sopDocument.id,
+        recommendationType: "sop_review_recommended",
+        evidenceSourceType: "timeline",
+        evidenceSourceId: "timeline-admin",
+        findingSummary: "Governance-owned recommendation for read access test.",
+        recommendation: "Only governance roles should read this.",
+        createdBy: "admin",
+      });
+
     const response = await request(app)
       .post(`/missions/${missionId}/sop-change-recommendations`)
       .set("X-Session-Token", operator.sessionToken)
@@ -852,6 +866,26 @@ describe("operational authority integration", () => {
 
     expect(response.status).toBe(403);
     expect(response.body.error).toMatchObject({
+      type: "organisation_membership_forbidden",
+    });
+
+    const listRecommendationsResponse = await request(app)
+      .get(`/missions/${missionId}/sop-change-recommendations`)
+      .set("X-Session-Token", operator.sessionToken);
+
+    expect(listRecommendationsResponse.status).toBe(403);
+    expect(listRecommendationsResponse.body.error).toMatchObject({
+      type: "organisation_membership_forbidden",
+    });
+
+    const listReviewsResponse = await request(app)
+      .get(
+        `/operational-authority-sop-change-recommendations/${recommendationResponse.body.recommendation.id}/reviews`,
+      )
+      .set("X-Session-Token", operator.sessionToken);
+
+    expect(listReviewsResponse.status).toBe(403);
+    expect(listReviewsResponse.body.error).toMatchObject({
       type: "organisation_membership_forbidden",
     });
   });
@@ -961,7 +995,7 @@ describe("operational authority integration", () => {
     );
   });
 
-  it("prevents non-accountable roles from reviewing SOP change recommendations", async () => {
+  it("prevents non-governance roles from viewing or reviewing SOP change recommendations", async () => {
     const organisationId = randomUUID();
     const missionId = await insertMission({ organisationId });
     const validity = buildDateWindow(-30, 365);

--- a/static/operator-mission-workspace.js
+++ b/static/operator-mission-workspace.js
@@ -17,6 +17,8 @@ const planningPanel = document.getElementById("planning-panel");
 const dispatchPanel = document.getElementById("dispatch-panel");
 const timelinePanel = document.getElementById("timeline-panel");
 
+const SESSION_STORAGE_KEY = "verityatlas_document_portal_session_token";
+
 const ACTION_ORDER = ["submit", "approve", "launch", "complete", "abort"];
 const ACTION_DEFINITIONS = {
   submit: {
@@ -164,6 +166,8 @@ const uiState = {
   postOperationEvidenceReport: null,
   postOperationEvidenceReadiness: null,
   postOperationEvidenceReportError: "",
+  sopChangeRecommendations: [],
+  sopChangeRecommendationError: "",
   missionList: [],
   missionQuery: "",
   transitionChecks: {},
@@ -633,6 +637,114 @@ const renderReportReadinessSummary = () => {
   `;
 };
 
+const formatSopRecommendationDecision = (decision) => {
+  const labels = {
+    accepted_for_action: "Accepted for action",
+    rejected: "Rejected",
+    deferred: "Deferred",
+    closed: "Closed",
+  };
+
+  return labels[decision] ?? "Awaiting accountable review";
+};
+
+const renderSopRecommendationDecisionSummary = () => {
+  const recommendations = uiState.sopChangeRecommendations ?? [];
+  const decidedCount = recommendations.filter(
+    (recommendation) => recommendation.latestReview,
+  ).length;
+  const openCount = recommendations.length - decidedCount;
+
+  if (uiState.sopChangeRecommendationError) {
+    return `
+      <section id="sop-recommendation-decision-summary" class="summary-block">
+        <h4>SOP Recommendation Decisions</h4>
+        <div class="empty-state">
+          ${escapeHtml(uiState.sopChangeRecommendationError)}
+        </div>
+        <div class="action-meta" style="margin-top: 12px;">
+          SOP change recommendation visibility is role-controlled. This panel is advisory/accountable review support only and does not authorise operators to use draft changes.
+        </div>
+      </section>
+    `;
+  }
+
+  if (recommendations.length === 0) {
+    return `
+      <section id="sop-recommendation-decision-summary" class="summary-block">
+        <h4>SOP Recommendation Decisions</h4>
+        <div class="kv">
+          <div class="k">Recommendations</div>
+          <div>${renderBadge("None recorded")}</div>
+          <div class="k">Decision state</div>
+          <div>${renderBadge("No accountable review needed")}</div>
+        </div>
+        <div class="action-meta" style="margin-top: 12px;">
+          No schema-backed SOP change recommendations are recorded for this mission.
+        </div>
+      </section>
+    `;
+  }
+
+  return `
+    <section id="sop-recommendation-decision-summary" class="summary-block">
+      <h4>SOP Recommendation Decisions</h4>
+      <div class="kv">
+        <div class="k">Recommendations</div>
+        <div>${renderBadge(`${recommendations.length} recorded`)}</div>
+        <div class="k">Latest decisions</div>
+        <div>${renderBadge(`${decidedCount} decided`)}</div>
+        <div class="k">Awaiting review</div>
+        <div>${renderBadge(openCount > 0 ? `${openCount} open` : "Clear")}</div>
+        <div class="k">Boundary</div>
+        <div>Role-controlled accountable review record only; no automatic SOP amendment, operational authorisation, or regulatory submission.</div>
+      </div>
+      <div class="list" style="margin-top: 12px;">
+        ${recommendations
+          .map((recommendation) => {
+            const latestReview = recommendation.latestReview;
+            const decisionLabel = formatSopRecommendationDecision(
+              latestReview?.decision,
+            );
+            const reviewDetail = latestReview
+              ? `${latestReview.reviewedBy} | ${formatDateTime(
+                  latestReview.reviewedAt,
+                )} | ${latestReview.reviewRationale}`
+              : recommendation.reviewError ??
+                "Awaiting accountable-manager review decision before sign-off.";
+
+            return `
+              <article class="list-item">
+                <strong>${escapeHtml(recommendation.sopCode ?? "SOP not linked")}</strong>
+                <div>
+                  ${renderBadge(decisionLabel)}
+                  ${renderBadge(recommendation.status ?? "draft")}
+                  ${recommendation.sopClauseRef ? renderBadge(recommendation.sopClauseRef) : ""}
+                </div>
+                <div style="margin-top: 8px;">
+                  ${escapeHtml(recommendation.findingSummary)}
+                </div>
+                <div class="timeline-meta" style="margin-top: 8px;">
+                  Recommendation: ${escapeHtml(recommendation.recommendation)}<br />
+                  Latest review: ${escapeHtml(reviewDetail)}
+                  ${
+                    latestReview?.evidenceRef
+                      ? `<br />Evidence reference: ${escapeHtml(latestReview.evidenceRef)}`
+                      : ""
+                  }
+                </div>
+              </article>
+            `;
+          })
+          .join("")}
+      </div>
+      <div class="action-meta" style="margin-top: 12px;">
+        Decision states make accountable review visible before sign-off while preserving SOP change control outside the automated evidence pack. Draft recommendations are not operating instructions.
+      </div>
+    </section>
+  `;
+};
+
 const postOperationExportLinks = (snapshotId) => {
   if (!uiState.missionId || !snapshotId) {
     return { renderUrl: "", pdfUrl: "" };
@@ -721,11 +833,17 @@ const getMissionIdFromLocation = () => {
   return queryMissionId?.trim() || "";
 };
 
+const getSessionHeaders = () => {
+  const sessionToken = window.localStorage.getItem(SESSION_STORAGE_KEY) ?? "";
+  return sessionToken ? { "X-Session-Token": sessionToken } : {};
+};
+
 const fetchJson = async (url, options = {}) => {
   const response = await fetch(url, {
     headers: {
       Accept: "application/json",
       ...(options.body ? { "Content-Type": "application/json" } : {}),
+      ...getSessionHeaders(),
       ...(options.headers ?? {}),
     },
     ...options,
@@ -738,6 +856,50 @@ const fetchJson = async (url, options = {}) => {
   }
 
   return payload;
+};
+
+const loadSopRecommendationDecisionState = async (missionId) => {
+  if (!window.localStorage.getItem(SESSION_STORAGE_KEY)) {
+    return {
+      recommendations: [],
+      error:
+        "Sign in with an authorised governance or management role to load schema-backed SOP recommendation decisions.",
+    };
+  }
+
+  const listed = await fetchJson(
+    `/missions/${encodeURIComponent(missionId)}/sop-change-recommendations`,
+  );
+  const recommendations = listed.recommendations ?? [];
+  const enriched = await Promise.all(
+    recommendations.map(async (recommendation) => {
+      try {
+        const reviewState = await fetchJson(
+          `/operational-authority-sop-change-recommendations/${encodeURIComponent(
+            recommendation.id,
+          )}/reviews`,
+        );
+        const reviews = reviewState.reviews ?? [];
+        return {
+          ...recommendation,
+          reviews,
+          latestReview: reviews[0] ?? null,
+        };
+      } catch (error) {
+        return {
+          ...recommendation,
+          reviews: [],
+          latestReview: null,
+          reviewError:
+            error instanceof Error
+              ? error.message
+              : "Review decision history unavailable",
+        };
+      }
+    }),
+  );
+
+  return { recommendations: enriched, error: "" };
 };
 
 const collectActionPayload = (action) => {
@@ -1156,6 +1318,7 @@ const renderEvidenceHelpers = () => {
         <h4>Rendered Report Readiness Summary</h4>
         ${renderReportReadinessSummary()}
       </section>
+      ${renderSopRecommendationDecisionSummary()}
     </div>
     ${renderReadinessDrilldowns({
       mapEvidenceUrl,
@@ -1846,6 +2009,8 @@ const loadMissionWorkspace = async (missionId, options = {}) => {
     uiState.postOperationEvidenceReport = null;
     uiState.postOperationEvidenceReadiness = null;
     uiState.postOperationEvidenceReportError = "";
+    uiState.sopChangeRecommendations = [];
+    uiState.sopChangeRecommendationError = "";
     renderMissionBrowser();
     uiState.transitionChecks = {};
     uiState.actionStatus = {};
@@ -1881,12 +2046,20 @@ const loadMissionWorkspace = async (missionId, options = {}) => {
       timelineResponse,
       regulatoryReviewImpactResponse,
       postOperationSnapshotsResponse,
+      sopRecommendationDecisionState,
     ] = await Promise.all([
       fetchJson(`/missions/${missionId}/planning-workspace`),
       fetchJson(`/missions/${missionId}/dispatch-workspace`),
       fetchJson(`/missions/${missionId}/operations-timeline`),
       fetchJson(`/missions/${missionId}/regulatory-review-impact`),
       fetchJson(`/missions/${missionId}/post-operation/evidence-snapshots`),
+      loadSopRecommendationDecisionState(missionId).catch((error) => ({
+        recommendations: [],
+        error:
+          error instanceof Error
+            ? error.message
+            : "SOP recommendation decision state unavailable",
+      })),
     ]);
 
     uiState.planningWorkspace = planningResponse.workspace;
@@ -1894,6 +2067,10 @@ const loadMissionWorkspace = async (missionId, options = {}) => {
     uiState.timeline = timelineResponse.timeline;
     uiState.regulatoryReviewImpact = regulatoryReviewImpactResponse;
     uiState.postOperationSnapshots = postOperationSnapshotsResponse.snapshots ?? [];
+    uiState.sopChangeRecommendations =
+      sopRecommendationDecisionState.recommendations ?? [];
+    uiState.sopChangeRecommendationError =
+      sopRecommendationDecisionState.error ?? "";
     uiState.postOperationEvidenceReport = null;
     uiState.postOperationEvidenceReadiness = null;
     uiState.postOperationEvidenceReportError = "";
@@ -1940,6 +2117,8 @@ const loadMissionWorkspace = async (missionId, options = {}) => {
     uiState.postOperationEvidenceReport = null;
     uiState.postOperationEvidenceReadiness = null;
     uiState.postOperationEvidenceReportError = "";
+    uiState.sopChangeRecommendations = [];
+    uiState.sopChangeRecommendationError = "";
     uiState.transitionChecks = {};
     renderMissionBrowser();
     uiState.helperStatus = {};


### PR DESCRIPTION
Shows schema-backed SOP recommendation decision state inside the operator mission workspace, while keeping SOP change visibility role-controlled.

Includes:
- Mission workspace panel for SOP recommendation decisions
- Loads recommendation review history when an authorised governance/management session is present
- Shows accepted, rejected, deferred, closed, and awaiting-review states
- Blocks general operator/viewer access to SOP recommendation lists and review history
- Adds clear boundary wording that draft SOP recommendations are not operating instructions
- Updates save-point and next-build-step tracking

Validation:
- npm run build
- operational-authority.test.ts + mission-planning.test.ts: 54/54 passed
- npm run validate:savepoint
- git diff --check
- nextBuildStep PR gate passed
