### PR TITLE
Show mission heading in live ops telemetry

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,31 +1,34 @@
 # NEXT STEP
 
 ## Goal
-Add accountable-manager controls for recording SOP recommendation decisions from the workspace.
+Separate traffic bearing and CPA conflict labels in live operations.
 
 ---
 
 ## Build
 
 ### 1. Operator visibility
-- add a role-controlled accountable-manager action path from the mission workspace SOP decision summary
-- record accepted, rejected, deferred, or closed decisions without treating draft recommendations as operating instructions
-- keep decision controls separate from post-operation evidence sign-off
+- label ownship mission heading separately from relative traffic bearing
+- make range/bearing read as current relative position from mission aircraft to traffic or boundary
+- make CPA read as a future closest-approach calculation, not a range/bearing line
 
 ### 2. Product boundary
 - continue to label demo airspace data as synthetic/local
 - do not imply live CAA, NOTAM, or manufacturer feed connectivity
-- keep decisions framed as internal accountable review records, not automatic SOP amendment, operational authorisation, or regulatory submission
+- keep conflict guidance framed as advisory situational awareness, not pilot command authority
+- keep map annotations clear about whether they are current telemetry, relative position, or predicted future CPA
 
 ### 3. Tests
-- add mission workspace UI tests for role-controlled SOP recommendation decision recording controls
-- run mission-planning UI tests
+- add live-ops UI bundle tests for heading, relative bearing, and CPA wording
+- run mission-planning/live-ops UI tests
 - run TypeScript build and diff whitespace check
 
 ---
 
 ## Done When
-- Accountable managers can initiate SOP recommendation review decisions from the workspace without exposing draft SOP changes as operating instructions
+- Mission heading is displayed or toggleable in the telemetry/status surface
+- Traffic range/bearing labels explicitly identify the reference point
+- CPA labels explicitly describe predicted closest approach and time/separation
 - Copy remains explicit that links support audit review, not compliance certification
 - Degraded or carried-forward overlays remain visually distinguishable
 - The demo remains clearly synthetic and safe for local presentation

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -56,7 +56,8 @@
       "Added authenticated accountable-manager routes for recording and listing SOP recommendation review decisions",
       "Added mission workspace SOP recommendation decision display that loads schema-backed recommendation review state when an authorised governance session is present",
       "Restricted SOP recommendation and review-history read access to governance and management roles so draft SOP changes are not exposed as operator instructions",
-      "Added a live-ops mission telemetry display strip with toggleable mission heading, speed, altitude, and progress fields"
+      "Added a live-ops mission telemetry display strip with toggleable mission heading, speed, altitude, and progress fields",
+      "Added a dynamic live-ops range/bearing vector from current mission aircraft position to the active conflict object"
     ],
     "removed": [],
     "fixed": [
@@ -146,7 +147,8 @@
       "Governance users can record draft SOP change recommendations against mission evidence without amending the SOP automatically",
       "Accountable managers can record review decisions against SOP recommendations while preserving the recommendation history as advisory evidence",
       "Authorised governance users can see SOP recommendation decision state in the mission workspace before sign-off; unauthorised users see controlled-access advisory wording instead",
-      "Operators can now view or hide ownship mission heading in the live-ops telemetry surface, separate from traffic range/bearing and CPA advisory context"
+      "Operators can now view or hide ownship mission heading in the live-ops telemetry surface, separate from traffic range/bearing and CPA advisory context",
+      "Operators can see a moving range/bearing-to-conflict line on the live-ops map when the active conflict has map-native point geometry"
     ]
   },
   "complianceImplications": {
@@ -162,7 +164,8 @@
       "The system surfaces where operations may need accountable review, policy change, SOP amendment, OA renewal, insurance renewal, or mission adjustment",
       "SOP change recommendations should target the relevant SOP code or clause while preserving the parent OA condition context",
       "Insurance assessment can advise what mission characteristic may need changing to remain within cover rather than presenting a stark no-go",
-      "Live-ops heading is treated as ownship mission telemetry, while range/bearing remains relative position and CPA remains a future closest-approach calculation"
+      "Live-ops heading is treated as ownship mission telemetry, while range/bearing remains relative position and CPA remains a future closest-approach calculation",
+      "Live-ops conflict range/bearing labels now identify the active conflict reference instead of implying they are ownship heading or CPA"
     ],
     "auditTraceabilityImpact": [
       "Mission governance joins OA and insurance state into dispatch evidence",
@@ -221,7 +224,8 @@
       "Validated schema-backed SOP change recommendation creation/listing, role access, TypeScript build, and operational-authority integration tests",
       "Validated schema-backed SOP recommendation review decision creation/listing, accountable-manager role access, TypeScript build, and operational-authority integration tests",
       "Validated role-controlled SOP recommendation visibility and mission workspace decision display copy with TypeScript build, operational-authority tests, and mission-planning UI bundle tests",
-      "Validated live-ops mission heading telemetry display and toggle copy with TypeScript build and mission-planning UI bundle tests"
+      "Validated live-ops mission heading telemetry display and toggle copy with TypeScript build and mission-planning UI bundle tests",
+      "Validated dynamic conflict range/bearing vector wording in the live-ops UI bundle tests"
     ]
 
   },

--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -55,7 +55,8 @@
       "Added mission routes for creating and listing SOP-linked change recommendations as accountable review prompts",
       "Added authenticated accountable-manager routes for recording and listing SOP recommendation review decisions",
       "Added mission workspace SOP recommendation decision display that loads schema-backed recommendation review state when an authorised governance session is present",
-      "Restricted SOP recommendation and review-history read access to governance and management roles so draft SOP changes are not exposed as operator instructions"
+      "Restricted SOP recommendation and review-history read access to governance and management roles so draft SOP changes are not exposed as operator instructions",
+      "Added a live-ops mission telemetry display strip with toggleable mission heading, speed, altitude, and progress fields"
     ],
     "removed": [],
     "fixed": [
@@ -144,7 +145,8 @@
       "Compliance teams can record SOP documents as distinct linked procedures under the OA profile so later change recommendations can target the relevant SOP",
       "Governance users can record draft SOP change recommendations against mission evidence without amending the SOP automatically",
       "Accountable managers can record review decisions against SOP recommendations while preserving the recommendation history as advisory evidence",
-      "Authorised governance users can see SOP recommendation decision state in the mission workspace before sign-off; unauthorised users see controlled-access advisory wording instead"
+      "Authorised governance users can see SOP recommendation decision state in the mission workspace before sign-off; unauthorised users see controlled-access advisory wording instead",
+      "Operators can now view or hide ownship mission heading in the live-ops telemetry surface, separate from traffic range/bearing and CPA advisory context"
     ]
   },
   "complianceImplications": {
@@ -159,7 +161,8 @@
     "advisory": [
       "The system surfaces where operations may need accountable review, policy change, SOP amendment, OA renewal, insurance renewal, or mission adjustment",
       "SOP change recommendations should target the relevant SOP code or clause while preserving the parent OA condition context",
-      "Insurance assessment can advise what mission characteristic may need changing to remain within cover rather than presenting a stark no-go"
+      "Insurance assessment can advise what mission characteristic may need changing to remain within cover rather than presenting a stark no-go",
+      "Live-ops heading is treated as ownship mission telemetry, while range/bearing remains relative position and CPA remains a future closest-approach calculation"
     ],
     "auditTraceabilityImpact": [
       "Mission governance joins OA and insurance state into dispatch evidence",
@@ -217,11 +220,12 @@
       "Validated OA-linked SOP document creation/listing, role access, TypeScript build, and operational-authority integration tests",
       "Validated schema-backed SOP change recommendation creation/listing, role access, TypeScript build, and operational-authority integration tests",
       "Validated schema-backed SOP recommendation review decision creation/listing, accountable-manager role access, TypeScript build, and operational-authority integration tests",
-      "Validated role-controlled SOP recommendation visibility and mission workspace decision display copy with TypeScript build, operational-authority tests, and mission-planning UI bundle tests"
+      "Validated role-controlled SOP recommendation visibility and mission workspace decision display copy with TypeScript build, operational-authority tests, and mission-planning UI bundle tests",
+      "Validated live-ops mission heading telemetry display and toggle copy with TypeScript build and mission-planning UI bundle tests"
     ]
 
   },
-  "nextBuildStep": "Add accountable-manager workspace controls for SOP recommendation decisions.",
+  "nextBuildStep": "Add explicit traffic bearing and CPA conflict labels in live operations.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2129,6 +2129,7 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("conflictAdvisorySummary");
     expect(response.text).toContain("refreshContext");
     expect(response.text).toContain("formatRangeBearing");
+    expect(response.text).toContain("formatConflictRangeBearing");
     expect(response.text).toContain("formatTemporalContext");
     expect(response.text).toContain("formatVerticalContext");
     expect(response.text).toContain("formatBearingDegrees");
@@ -2139,6 +2140,9 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("data-telemetry-display-toggle");
     expect(response.text).toContain("Heading is ownship mission telemetry");
     expect(response.text).toContain("CPA is a future closest-approach calculation");
+    expect(response.text).toContain("conflict-range-bearing-vector");
+    expect(response.text).toContain("Range/bearing to conflict");
+    expect(response.text).toContain("Dynamic from current mission aircraft position to active conflict object");
     expect(response.text).toContain("rangeMeters");
     expect(response.text).toContain("bearingDegrees");
     expect(response.text).toContain("insideArea");

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2132,6 +2132,13 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("formatTemporalContext");
     expect(response.text).toContain("formatVerticalContext");
     expect(response.text).toContain("formatBearingDegrees");
+    expect(response.text).toContain("formatHeadingDegrees");
+    expect(response.text).toContain("Mission Telemetry Display");
+    expect(response.text).toContain("Mission heading");
+    expect(response.text).toContain("Latest live heading");
+    expect(response.text).toContain("data-telemetry-display-toggle");
+    expect(response.text).toContain("Heading is ownship mission telemetry");
+    expect(response.text).toContain("CPA is a future closest-approach calculation");
     expect(response.text).toContain("rangeMeters");
     expect(response.text).toContain("bearingDegrees");
     expect(response.text).toContain("insideArea");

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -873,6 +873,13 @@ const formatRangeBearing = (metrics) => {
   return `${rangeText} @ ${bearingText}`;
 };
 
+const formatConflictRangeBearing = (conflict) => {
+  const formatted = formatRangeBearing(conflict?.metrics);
+  return formatted === "Not recorded"
+    ? "Range/bearing to conflict not recorded"
+    : `Range/bearing to conflict: ${formatted}`;
+};
+
 const fetchJson = async (url, options = {}) => {
   const response = await fetch(url, {
     headers: {
@@ -2656,6 +2663,7 @@ const buildMapMarkup = () => {
   const conflictWindowSummary = currentConflictWindowSummary();
   const conflictEnvelopeSummary = conflictProximityEnvelopeSummary();
   const conflictEnvelopeTargets = activeConflictEnvelopeTargets();
+  const primaryConflictTarget = conflictEnvelopeTargets[0] ?? null;
   const conflictTrackWindow = conflictTrackWindowPoints();
   const mapRiskSeverity = [highestAlertSeverity, readinessState.tone, dispatchState.tone, riskState.tone, airspaceState.tone]
     .sort((left, right) => severityRank(right) - severityRank(left))[0];
@@ -2941,6 +2949,51 @@ const buildMapMarkup = () => {
       `;
     })
     .join("");
+  const conflictRangeBearingVector =
+    currentMapPoint && primaryConflictTarget
+      ? (() => {
+          const targetPoint = toPoint(
+            Number(primaryConflictTarget.lat),
+            Number(primaryConflictTarget.lng),
+          );
+          const stroke = severityStroke(primaryConflictTarget.conflict.severity);
+          const midpoint = {
+            x: (currentMapPoint.x + targetPoint.x) / 2,
+            y: (currentMapPoint.y + targetPoint.y) / 2,
+          };
+
+          return `
+            <g class="conflict-range-bearing-vector">
+              <line
+                x1="${currentMapPoint.x}"
+                y1="${currentMapPoint.y}"
+                x2="${targetPoint.x}"
+                y2="${targetPoint.y}"
+                stroke="${stroke}"
+                stroke-width="3"
+                stroke-dasharray="10 8"
+                stroke-linecap="round"
+                opacity="0.92"
+              />
+              <circle cx="${targetPoint.x}" cy="${targetPoint.y}" r="7" fill="${stroke}" fill-opacity="0.86" stroke="#edf3fb" stroke-width="2" />
+              <text
+                x="${midpoint.x + 12}"
+                y="${midpoint.y - 10}"
+                fill="${stroke}"
+                font-size="12"
+                font-weight="800"
+              >${escapeHtml(formatConflictRangeBearing(primaryConflictTarget.conflict))}</text>
+              <text
+                x="${midpoint.x + 12}"
+                y="${midpoint.y + 6}"
+                fill="#d8ecff"
+                font-size="10"
+                font-weight="700"
+              >Dynamic from current mission aircraft position to active conflict object</text>
+            </g>
+          `;
+        })()
+      : "";
 
   return `
     <div class="map-grid"></div>
@@ -2960,6 +3013,7 @@ const buildMapMarkup = () => {
       ${completedReplayPath ? `<polyline points="${completedReplayPath}" fill="none" stroke="#38bdf8" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.98" />` : ""}
       ${conflictTrackHighlight}
       ${alertTrackHighlight}
+      ${conflictRangeBearingVector}
       ${replayDots}
       ${weatherMarker}
       ${conflictSeverityBands}
@@ -3362,7 +3416,7 @@ const renderStatus = () => {
           <div class="k">Range / bearing</div>
           <div>${escapeHtml(
             primaryConflict
-              ? formatRangeBearing(primaryConflict.metrics)
+              ? formatConflictRangeBearing(primaryConflict)
               : "Not recorded",
           )}</div>
           <div class="k">Time relevance</div>
@@ -3595,7 +3649,7 @@ const renderConflictAssessment = () => {
                   <br />`
                       : ""
                   }
-                  Range / bearing: ${escapeHtml(formatRangeBearing(primaryConflict.metrics))}<br />
+                  ${escapeHtml(formatConflictRangeBearing(primaryConflict))}<br />
                   Time relevance: ${escapeHtml(primaryConflict.overlayKind === "area_conflict" ? formatTemporalContext(primaryConflict) : "Not applicable")}<br />
                   Vertical context: ${escapeHtml(primaryConflict.overlayKind === "area_conflict" ? formatVerticalContext(primaryConflict) : formatVerticalSeparation(primaryConflict.metrics?.altitudeDeltaFt))}<br />
                   Replay relevance: ${escapeHtml(primaryConflict.replayRelevant ? "Current replay window" : `${primaryConflict.replayTimeDeltaSeconds} s from replay cursor`)}

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -66,6 +66,12 @@ const uiState = {
     snapshotId: null,
     createdAt: null,
   },
+  telemetryDisplay: {
+    heading: true,
+    speed: true,
+    altitude: true,
+    progress: true,
+  },
 };
 
 const toneClass = (value) => {
@@ -768,6 +774,32 @@ const formatBearingDegrees = (value) => {
 
   return `${Math.round(value)}\u00B0 ${cardinalFromBearing(value)}`;
 };
+
+const normalizeHeadingDegrees = (value) => {
+  if (value == null || Number.isNaN(value)) {
+    return null;
+  }
+
+  return ((Number(value) % 360) + 360) % 360;
+};
+
+const formatHeadingDegrees = (value) => {
+  const normalized = normalizeHeadingDegrees(value);
+  if (normalized == null) {
+    return "Not recorded";
+  }
+
+  return `${Math.round(normalized)}\u00B0 ${cardinalFromBearing(normalized)}`;
+};
+
+const formatTelemetrySpeed = (value) =>
+  value == null || Number.isNaN(value) ? "Not recorded" : `${value} m/s`;
+
+const formatTelemetryAltitude = (value) =>
+  value == null || Number.isNaN(value) ? "Not recorded" : `${value} m`;
+
+const formatTelemetryProgress = (value) =>
+  value == null || Number.isNaN(value) ? "Not recorded" : `${value}%`;
 
 const formatVerticalSeparation = (value) =>
   value == null || Number.isNaN(value) ? "Not recorded" : `${Math.round(value)} ft`;
@@ -2970,6 +3002,83 @@ const renderMap = () => {
   mapPanel.innerHTML = buildMapMarkup();
 };
 
+const renderTelemetryDisplayToggle = (key, label) => `
+  <button
+    type="button"
+    class="secondary-button ${uiState.telemetryDisplay[key] ? "tone-ok" : "tone-muted"}"
+    data-telemetry-display-toggle="${escapeHtml(key)}"
+  >
+    ${escapeHtml(label)} ${uiState.telemetryDisplay[key] ? "shown" : "hidden"}
+  </button>
+`;
+
+const renderMissionTelemetryStrip = (currentReplayPoint, latestTelemetry) => {
+  const telemetrySource = currentReplayPoint ?? latestTelemetry ?? {};
+  const display = uiState.telemetryDisplay;
+  const fields = [
+    display.heading
+      ? {
+          label: "Mission heading",
+          value: formatHeadingDegrees(telemetrySource.headingDeg),
+          meta: "Track/heading of mission aircraft, not relative bearing to traffic.",
+        }
+      : null,
+    display.speed
+      ? {
+          label: "Mission speed",
+          value: formatTelemetrySpeed(telemetrySource.speedMps),
+          meta: "Mission aircraft ground/telemetry speed.",
+        }
+      : null,
+    display.altitude
+      ? {
+          label: "Mission altitude",
+          value: formatTelemetryAltitude(telemetrySource.altitudeM),
+          meta: "Mission aircraft telemetry altitude.",
+        }
+      : null,
+    display.progress
+      ? {
+          label: "Mission progress",
+          value: formatTelemetryProgress(telemetrySource.progressPct),
+          meta: "Recorded mission progress percentage.",
+        }
+      : null,
+  ].filter(Boolean);
+
+  return `
+    <section class="summary-block" style="margin-bottom: 14px;">
+      <h4>Mission Telemetry Display</h4>
+      <div class="action-footer" style="justify-content: flex-start; margin-bottom: 12px;">
+        ${renderTelemetryDisplayToggle("heading", "Heading")}
+        ${renderTelemetryDisplayToggle("speed", "Speed")}
+        ${renderTelemetryDisplayToggle("altitude", "Altitude")}
+        ${renderTelemetryDisplayToggle("progress", "Progress")}
+      </div>
+      <div class="kv">
+        ${
+          fields.length === 0
+            ? `
+              <div class="k">Display</div>
+              <div>No telemetry fields selected.</div>
+            `
+            : fields
+                .map(
+                  (field) => `
+                    <div class="k">${escapeHtml(field.label)}</div>
+                    <div>${escapeHtml(field.value)}<br /><span class="meta">${escapeHtml(field.meta)}</span></div>
+                  `,
+                )
+                .join("")
+        }
+      </div>
+      <div class="alert-window-meta">
+        Heading is ownship mission telemetry. Range/bearing elsewhere is relative position to traffic or an assessed conflict object, and CPA is a future closest-approach calculation.
+      </div>
+    </section>
+  `;
+};
+
 const renderStatus = () => {
   if (!uiState.planningWorkspace || !uiState.dispatchWorkspace) {
     statusPanel.innerHTML =
@@ -3046,6 +3155,7 @@ const renderStatus = () => {
   ];
 
   statusPanel.innerHTML = `
+    ${renderMissionTelemetryStrip(currentReplayPoint, latestTelemetry)}
     <div class="summary-grid">
       <section class="summary-block">
         <h4>Replay State</h4>
@@ -3060,11 +3170,15 @@ const renderStatus = () => {
           )}</div>
           <div class="k">Altitude</div>
           <div>${escapeHtml(
-            currentReplayPoint?.altitudeM != null ? `${currentReplayPoint.altitudeM} m` : "Not recorded",
+            formatTelemetryAltitude(currentReplayPoint?.altitudeM),
           )}</div>
           <div class="k">Speed</div>
           <div>${escapeHtml(
-            currentReplayPoint?.speedMps != null ? `${currentReplayPoint.speedMps} m/s` : "Not recorded",
+            formatTelemetrySpeed(currentReplayPoint?.speedMps),
+          )}</div>
+          <div class="k">Mission heading</div>
+          <div>${escapeHtml(
+            formatHeadingDegrees(currentReplayPoint?.headingDeg),
           )}</div>
           <div class="k">Replay progress</div>
           <div>${escapeHtml(
@@ -3074,6 +3188,8 @@ const renderStatus = () => {
           )}</div>
           <div class="k">Latest live telemetry</div>
           <div>${escapeHtml(formatDateTime(latestTelemetry?.timestamp))}</div>
+          <div class="k">Latest live heading</div>
+          <div>${escapeHtml(formatHeadingDegrees(latestTelemetry?.headingDeg))}</div>
         </div>
       </section>
       <section class="summary-block">
@@ -4049,6 +4165,16 @@ jumpControlsPanel.addEventListener("click", (event) => {
 statusPanel.addEventListener("click", (event) => {
   const target = event.target;
   if (!(target instanceof HTMLElement)) {
+    return;
+  }
+
+  const telemetryToggle = target.closest("[data-telemetry-display-toggle]");
+  if (telemetryToggle instanceof HTMLElement) {
+    const key = telemetryToggle.getAttribute("data-telemetry-display-toggle");
+    if (key && Object.prototype.hasOwnProperty.call(uiState.telemetryDisplay, key)) {
+      uiState.telemetryDisplay[key] = !uiState.telemetryDisplay[key];
+      renderStatus();
+    }
     return;
   }
 


### PR DESCRIPTION
Adds clearer live-ops telemetry and conflict vector presentation.

Includes:
- Mission Telemetry Display panel in live operations
- Toggleable ownship fields: heading, speed, altitude, and progress
- Mission heading shown as ownship telemetry, separate from traffic bearing
- Dynamic range/bearing-to-conflict vector on the live map
- Range/bearing vector recomputes from current mission aircraft/replay position to the active conflict object
- Conflict range/bearing labels now say “Range/bearing to conflict”
- CPA remains described separately as a future closest-approach calculation
- Save-point and next-build-step updated for the next live-ops label clarification slice

Validation:
- npm run build
- mission-planning.test.ts: 37/37 passed
- npm run validate:savepoint
- git diff --check
- nextBuildStep PR gate passed
