### PR TITLE
Clarify conflict bearing from mission aircraft

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -225,11 +225,12 @@
       "Validated schema-backed SOP recommendation review decision creation/listing, accountable-manager role access, TypeScript build, and operational-authority integration tests",
       "Validated role-controlled SOP recommendation visibility and mission workspace decision display copy with TypeScript build, operational-authority tests, and mission-planning UI bundle tests",
       "Validated live-ops mission heading telemetry display and toggle copy with TypeScript build and mission-planning UI bundle tests",
-      "Validated dynamic conflict range/bearing vector wording in the live-ops UI bundle tests"
+      "Validated dynamic conflict range/bearing vector wording in the live-ops UI bundle tests",
+      "Validated conflict bearing wording as true bearing from mission aircraft plus relative left/right bearing against mission heading"
     ]
 
   },
-  "nextBuildStep": "Add explicit traffic bearing and CPA conflict labels in live operations.",
+  "nextBuildStep": "Add reciprocal-bearing guardrails to live operations conflict labels.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2141,8 +2141,10 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("Heading is ownship mission telemetry");
     expect(response.text).toContain("CPA is a future closest-approach calculation");
     expect(response.text).toContain("conflict-range-bearing-vector");
-    expect(response.text).toContain("Range/bearing to conflict");
+    expect(response.text).toContain("Conflict from mission aircraft");
+    expect(response.text).toContain("true /");
     expect(response.text).toContain("Dynamic from current mission aircraft position to active conflict object");
+    expect(response.text).toContain("relative bearing is left/right of mission heading");
     expect(response.text).toContain("rangeMeters");
     expect(response.text).toContain("bearingDegrees");
     expect(response.text).toContain("insideArea");

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -874,10 +874,35 @@ const formatRangeBearing = (metrics) => {
 };
 
 const formatConflictRangeBearing = (conflict) => {
-  const formatted = formatRangeBearing(conflict?.metrics);
-  return formatted === "Not recorded"
-    ? "Range/bearing to conflict not recorded"
-    : `Range/bearing to conflict: ${formatted}`;
+  const rangeMeters =
+    conflict?.metrics?.rangeMeters ?? conflict?.metrics?.lateralDistanceMeters;
+  const trueBearing = conflict?.metrics?.bearingDegrees;
+  const missionHeading =
+    activeReplayPoint()?.headingDeg ?? uiState.latestTelemetry?.telemetry?.headingDeg;
+
+  if (rangeMeters == null && trueBearing == null) {
+    return "Conflict bearing from mission aircraft not recorded";
+  }
+
+  const rangeText =
+    rangeMeters == null || Number.isNaN(rangeMeters)
+      ? "unknown range"
+      : `${Math.round(rangeMeters)} m`;
+  const trueBearingText = formatBearingDegrees(trueBearing ?? null);
+  const relativeBearing =
+    trueBearing == null || missionHeading == null
+      ? null
+      : ((trueBearing - missionHeading + 540) % 360) - 180;
+  const relativeBearingText =
+    relativeBearing == null || Number.isNaN(relativeBearing)
+      ? "relative bearing unavailable"
+      : relativeBearing === 0
+        ? "dead ahead"
+        : `${Math.abs(Math.round(relativeBearing))}\u00B0 ${
+            relativeBearing > 0 ? "right" : "left"
+          }`;
+
+  return `Conflict from mission aircraft: ${rangeText} / ${trueBearingText} true / ${relativeBearingText}`;
 };
 
 const fetchJson = async (url, options = {}) => {
@@ -2990,6 +3015,13 @@ const buildMapMarkup = () => {
                 font-size="10"
                 font-weight="700"
               >Dynamic from current mission aircraft position to active conflict object</text>
+              <text
+                x="${midpoint.x + 12}"
+                y="${midpoint.y + 22}"
+                fill="#d8ecff"
+                font-size="10"
+                font-weight="700"
+              >True bearing is from mission aircraft to conflict; relative bearing is left/right of mission heading</text>
             </g>
           `;
         })()


### PR DESCRIPTION
Clarifies the live operations conflict bearing label so operators understand the range/bearing line as ownship-referenced guidance.

This updates the conflict range/bearing label to show:
- range from the mission aircraft to the active conflict object
- true bearing from the mission aircraft to the conflict
- relative left/right bearing against current mission heading

This keeps CPA separate as a future closest-approach prediction, while the map vector answers the immediate operational question: if I am at the mission aircraft, where do I look for the conflict?

Validation:
- npm run build
- vitest mission-planning tests
- npm run validate:savepoint
- git diff --check
- nextBuildStep PR gate passed
