### PR TITLE
Clarify one-way live ops conflict bearing

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./fsms-save-point.schema.json",
   "module": "VerityATLAS Governance Recovery",
-"date": "2026-04-26",
+"date": "2026-04-27",
 "buildId": "v0.4-governance-recovery-integration",
   "systemLayerMap": [
     "Replay",
@@ -165,7 +165,8 @@
       "SOP change recommendations should target the relevant SOP code or clause while preserving the parent OA condition context",
       "Insurance assessment can advise what mission characteristic may need changing to remain within cover rather than presenting a stark no-go",
       "Live-ops heading is treated as ownship mission telemetry, while range/bearing remains relative position and CPA remains a future closest-approach calculation",
-      "Live-ops conflict range/bearing labels now identify the active conflict reference instead of implying they are ownship heading or CPA"
+      "Live-ops conflict range/bearing labels now identify the active conflict reference instead of implying they are ownship heading or CPA",
+      "Live-ops conflict labels now present a single one-way mission-aircraft-to-conflict range and bearing line without showing a reciprocal bearing"
     ],
     "auditTraceabilityImpact": [
       "Mission governance joins OA and insurance state into dispatch evidence",
@@ -226,11 +227,12 @@
       "Validated role-controlled SOP recommendation visibility and mission workspace decision display copy with TypeScript build, operational-authority tests, and mission-planning UI bundle tests",
       "Validated live-ops mission heading telemetry display and toggle copy with TypeScript build and mission-planning UI bundle tests",
       "Validated dynamic conflict range/bearing vector wording in the live-ops UI bundle tests",
-      "Validated conflict bearing wording as true bearing from mission aircraft plus relative left/right bearing against mission heading"
+      "Validated conflict bearing wording as true bearing from mission aircraft plus relative left/right bearing against mission heading",
+      "Validated one-way ownship-to-conflict range/bearing copy without displaying a reciprocal traffic bearing"
     ]
 
   },
-  "nextBuildStep": "Add reciprocal-bearing guardrails to live operations conflict labels.",
+  "nextBuildStep": "Add live operations conflict vector fallback when map-native conflict geometry is unavailable.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2141,10 +2141,10 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("Heading is ownship mission telemetry");
     expect(response.text).toContain("CPA is a future closest-approach calculation");
     expect(response.text).toContain("conflict-range-bearing-vector");
-    expect(response.text).toContain("Conflict from mission aircraft");
+    expect(response.text).toContain("One-way from mission aircraft to conflict");
     expect(response.text).toContain("true /");
     expect(response.text).toContain("Dynamic from current mission aircraft position to active conflict object");
-    expect(response.text).toContain("relative bearing is left/right of mission heading");
+    expect(response.text).toContain("One-way ownship-to-conflict range and bearing");
     expect(response.text).toContain("rangeMeters");
     expect(response.text).toContain("bearingDegrees");
     expect(response.text).toContain("insideArea");

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -902,7 +902,7 @@ const formatConflictRangeBearing = (conflict) => {
             relativeBearing > 0 ? "right" : "left"
           }`;
 
-  return `Conflict from mission aircraft: ${rangeText} / ${trueBearingText} true / ${relativeBearingText}`;
+  return `One-way from mission aircraft to conflict: ${rangeText} / ${trueBearingText} true / ${relativeBearingText}`;
 };
 
 const fetchJson = async (url, options = {}) => {
@@ -3021,7 +3021,7 @@ const buildMapMarkup = () => {
                 fill="#d8ecff"
                 font-size="10"
                 font-weight="700"
-              >True bearing is from mission aircraft to conflict; relative bearing is left/right of mission heading</text>
+              >One-way ownship-to-conflict range and bearing; not a reciprocal traffic bearing</text>
             </g>
           `;
         })()


### PR DESCRIPTION
Clarifies live operations conflict bearing so the map shows one directional range/bearing line only: from the mission aircraft to the conflict.

This avoids reciprocal-bearing confusion by keeping the display as an ownship-to-conflict look direction, with no traffic-to-ownship reciprocal bearing shown.

Validation:
- npm run build
- mission-planning.test.ts: 37/37 passed using thread pool
- npm run validate:savepoint
- git diff --check
- nextBuildStep PR gate passed
