### PR TITLE
Add live ops conflict vector fallback

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -166,7 +166,8 @@
       "Insurance assessment can advise what mission characteristic may need changing to remain within cover rather than presenting a stark no-go",
       "Live-ops heading is treated as ownship mission telemetry, while range/bearing remains relative position and CPA remains a future closest-approach calculation",
       "Live-ops conflict range/bearing labels now identify the active conflict reference instead of implying they are ownship heading or CPA",
-      "Live-ops conflict labels now present a single one-way mission-aircraft-to-conflict range and bearing line without showing a reciprocal bearing"
+      "Live-ops conflict labels now present a single one-way mission-aircraft-to-conflict range and bearing line without showing a reciprocal bearing",
+      "Live-ops conflict vectors now fall back to a bearing-only ownship ray when conflict map geometry is unavailable"
     ],
     "auditTraceabilityImpact": [
       "Mission governance joins OA and insurance state into dispatch evidence",
@@ -228,11 +229,12 @@
       "Validated live-ops mission heading telemetry display and toggle copy with TypeScript build and mission-planning UI bundle tests",
       "Validated dynamic conflict range/bearing vector wording in the live-ops UI bundle tests",
       "Validated conflict bearing wording as true bearing from mission aircraft plus relative left/right bearing against mission heading",
-      "Validated one-way ownship-to-conflict range/bearing copy without displaying a reciprocal traffic bearing"
+      "Validated one-way ownship-to-conflict range/bearing copy without displaying a reciprocal traffic bearing",
+      "Validated bearing-only fallback copy for live-ops conflict vectors without map-native conflict geometry"
     ]
 
   },
-  "nextBuildStep": "Add live operations conflict vector fallback when map-native conflict geometry is unavailable.",
+  "nextBuildStep": "Add live operations conflict vector freshness and source-quality labels.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2144,7 +2144,9 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("One-way from mission aircraft to conflict");
     expect(response.text).toContain("true /");
     expect(response.text).toContain("Dynamic from current mission aircraft position to active conflict object");
+    expect(response.text).toContain("Bearing-only fallback: conflict map geometry unavailable");
     expect(response.text).toContain("One-way ownship-to-conflict range and bearing");
+    expect(response.text).toContain("fallbackConflictVectorPoint");
     expect(response.text).toContain("rangeMeters");
     expect(response.text).toContain("bearingDegrees");
     expect(response.text).toContain("insideArea");

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -905,6 +905,27 @@ const formatConflictRangeBearing = (conflict) => {
   return `One-way from mission aircraft to conflict: ${rangeText} / ${trueBearingText} true / ${relativeBearingText}`;
 };
 
+const fallbackConflictVectorPoint = (originPoint, conflict) => {
+  const bearing = normalizeHeadingDegrees(conflict?.metrics?.bearingDegrees);
+  if (!originPoint || bearing == null) {
+    return null;
+  }
+
+  const rangeMeters =
+    conflict?.metrics?.rangeMeters ?? conflict?.metrics?.lateralDistanceMeters;
+  const rangeScale =
+    rangeMeters == null || Number.isNaN(rangeMeters)
+      ? 110
+      : Math.min(190, Math.max(70, Math.round(Number(rangeMeters) / 12)));
+  const bearingRadians = (bearing * Math.PI) / 180;
+
+  return {
+    x: originPoint.x + Math.sin(bearingRadians) * rangeScale,
+    y: originPoint.y - Math.cos(bearingRadians) * rangeScale,
+    bearingOnly: true,
+  };
+};
+
 const fetchJson = async (url, options = {}) => {
   const response = await fetch(url, {
     headers: {
@@ -2974,14 +2995,24 @@ const buildMapMarkup = () => {
       `;
     })
     .join("");
+  const fallbackPrimaryConflict = primaryConflictAssessmentItem();
+  const fallbackConflictPoint =
+    currentMapPoint && !primaryConflictTarget
+      ? fallbackConflictVectorPoint(currentMapPoint, fallbackPrimaryConflict)
+      : null;
   const conflictRangeBearingVector =
-    currentMapPoint && primaryConflictTarget
+    currentMapPoint && (primaryConflictTarget || fallbackConflictPoint)
       ? (() => {
-          const targetPoint = toPoint(
-            Number(primaryConflictTarget.lat),
-            Number(primaryConflictTarget.lng),
-          );
-          const stroke = severityStroke(primaryConflictTarget.conflict.severity);
+          const conflict = primaryConflictTarget?.conflict ?? fallbackPrimaryConflict;
+          const targetPoint =
+            primaryConflictTarget != null
+              ? toPoint(
+                  Number(primaryConflictTarget.lat),
+                  Number(primaryConflictTarget.lng),
+                )
+              : fallbackConflictPoint;
+          const stroke = severityStroke(conflict?.severity);
+          const isBearingOnly = fallbackConflictPoint?.bearingOnly === true;
           const midpoint = {
             x: (currentMapPoint.x + targetPoint.x) / 2,
             y: (currentMapPoint.y + targetPoint.y) / 2,
@@ -3007,14 +3038,18 @@ const buildMapMarkup = () => {
                 fill="${stroke}"
                 font-size="12"
                 font-weight="800"
-              >${escapeHtml(formatConflictRangeBearing(primaryConflictTarget.conflict))}</text>
+              >${escapeHtml(formatConflictRangeBearing(conflict))}</text>
               <text
                 x="${midpoint.x + 12}"
                 y="${midpoint.y + 6}"
                 fill="#d8ecff"
                 font-size="10"
                 font-weight="700"
-              >Dynamic from current mission aircraft position to active conflict object</text>
+              >${escapeHtml(
+                isBearingOnly
+                  ? "Bearing-only fallback: conflict map geometry unavailable"
+                  : "Dynamic from current mission aircraft position to active conflict object",
+              )}</text>
               <text
                 x="${midpoint.x + 12}"
                 y="${midpoint.y + 22}"


### PR DESCRIPTION
Adds a fallback live-operations conflict vector when the active conflict has bearing/range data but no map-native conflict geometry.

If conflict geometry is available, the map still draws the vector to the actual conflict object. If geometry is unavailable, it now draws a bearing-only ownship ray from the mission aircraft using the recorded one-way bearing/range, clearly labelled as a fallback.

This preserves the operator meaning: one-way mission-aircraft-to-conflict range and bearing, not a reciprocal traffic bearing and not CPA.

Validation:
- npm run build
- mission-planning.test.ts: 37/37 passed
- npm run validate:savepoint
- git diff --check
- nextBuildStep PR gate passed
