### PR TITLE
Label live ops conflict vector source quality

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -167,7 +167,8 @@
       "Live-ops heading is treated as ownship mission telemetry, while range/bearing remains relative position and CPA remains a future closest-approach calculation",
       "Live-ops conflict range/bearing labels now identify the active conflict reference instead of implying they are ownship heading or CPA",
       "Live-ops conflict labels now present a single one-way mission-aircraft-to-conflict range and bearing line without showing a reciprocal bearing",
-      "Live-ops conflict vectors now fall back to a bearing-only ownship ray when conflict map geometry is unavailable"
+      "Live-ops conflict vectors now fall back to a bearing-only ownship ray when conflict map geometry is unavailable",
+      "Live-ops conflict vector annotations now include source-quality, freshness, carry-forward, observed-time, and synthetic/local demo-source context"
     ],
     "auditTraceabilityImpact": [
       "Mission governance joins OA and insurance state into dispatch evidence",
@@ -230,11 +231,12 @@
       "Validated dynamic conflict range/bearing vector wording in the live-ops UI bundle tests",
       "Validated conflict bearing wording as true bearing from mission aircraft plus relative left/right bearing against mission heading",
       "Validated one-way ownship-to-conflict range/bearing copy without displaying a reciprocal traffic bearing",
-      "Validated bearing-only fallback copy for live-ops conflict vectors without map-native conflict geometry"
+      "Validated bearing-only fallback copy for live-ops conflict vectors without map-native conflict geometry",
+      "Validated live-ops conflict vector source-quality labels for map-native and bearing-only vector states"
     ]
 
   },
-  "nextBuildStep": "Add live operations conflict vector freshness and source-quality labels.",
+  "nextBuildStep": "Add live operations conflict vector source drill-down link to the relevant evidence panel.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2146,6 +2146,10 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("Dynamic from current mission aircraft position to active conflict object");
     expect(response.text).toContain("Bearing-only fallback: conflict map geometry unavailable");
     expect(response.text).toContain("One-way ownship-to-conflict range and bearing");
+    expect(response.text).toContain("conflictVectorSourceQualityLabel");
+    expect(response.text).toContain("Map-native vector");
+    expect(response.text).toContain("Bearing-only vector");
+    expect(response.text).toContain("synthetic/local demo source");
     expect(response.text).toContain("fallbackConflictVectorPoint");
     expect(response.text).toContain("rangeMeters");
     expect(response.text).toContain("bearingDegrees");

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -926,6 +926,28 @@ const fallbackConflictVectorPoint = (originPoint, conflict) => {
   };
 };
 
+const conflictVectorSourceQualityLabel = (conflict, overlay, isBearingOnly) => {
+  const refreshState = areaOverlaySourceRefreshState(overlay);
+  const sourceParts = [
+    isBearingOnly ? "Bearing-only vector" : "Map-native vector",
+    refreshState?.status ? `source ${refreshState.status}` : "source quality not recorded",
+  ];
+
+  if (refreshState?.carriedForwardFromFailedRefresh === true) {
+    sourceParts.push("carried forward after failed refresh");
+  } else if (refreshState?.carriedForwardFromPartialRefresh === true) {
+    sourceParts.push("carried forward after partial refresh");
+  }
+
+  if (conflict?.overlayObservedAt) {
+    sourceParts.push(`observed ${formatDateTime(conflict.overlayObservedAt)}`);
+  }
+
+  sourceParts.push("synthetic/local demo source");
+
+  return sourceParts.join(" | ");
+};
+
 const fetchJson = async (url, options = {}) => {
   const response = await fetch(url, {
     headers: {
@@ -3004,6 +3026,8 @@ const buildMapMarkup = () => {
     currentMapPoint && (primaryConflictTarget || fallbackConflictPoint)
       ? (() => {
           const conflict = primaryConflictTarget?.conflict ?? fallbackPrimaryConflict;
+          const conflictOverlay =
+            primaryConflictTarget?.overlay ?? conflictOverlayForItem(conflict);
           const targetPoint =
             primaryConflictTarget != null
               ? toPoint(
@@ -3013,6 +3037,11 @@ const buildMapMarkup = () => {
               : fallbackConflictPoint;
           const stroke = severityStroke(conflict?.severity);
           const isBearingOnly = fallbackConflictPoint?.bearingOnly === true;
+          const sourceQualityLabel = conflictVectorSourceQualityLabel(
+            conflict,
+            conflictOverlay,
+            isBearingOnly,
+          );
           const midpoint = {
             x: (currentMapPoint.x + targetPoint.x) / 2,
             y: (currentMapPoint.y + targetPoint.y) / 2,
@@ -3057,6 +3086,13 @@ const buildMapMarkup = () => {
                 font-size="10"
                 font-weight="700"
               >One-way ownship-to-conflict range and bearing; not a reciprocal traffic bearing</text>
+              <text
+                x="${midpoint.x + 12}"
+                y="${midpoint.y + 38}"
+                fill="#fef3c7"
+                font-size="10"
+                font-weight="700"
+              >${escapeHtml(sourceQualityLabel)}</text>
             </g>
           `;
         })()


### PR DESCRIPTION
Adds source-quality context to the live operations conflict vector annotation.

The vector now labels whether it is:
- map-native or bearing-only fallback
- backed by a fresh/partial/stale source where refresh metadata exists
- carried forward after failed or partial refresh where applicable
- tied to an observed timestamp where available
- synthetic/local demo source rather than live authoritative connectivity

This keeps the operator view honest: the bearing line remains useful, but its evidence quality is visible.

Validation:
- npm run build
- mission-planning.test.ts: 37/37 passed
- npm run validate:savepoint
- git diff --check
- nextBuildStep PR gate passed
