### PR TITLE
Link live ops conflict vector source evidence

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -168,7 +168,8 @@
       "Live-ops conflict range/bearing labels now identify the active conflict reference instead of implying they are ownship heading or CPA",
       "Live-ops conflict labels now present a single one-way mission-aircraft-to-conflict range and bearing line without showing a reciprocal bearing",
       "Live-ops conflict vectors now fall back to a bearing-only ownship ray when conflict map geometry is unavailable",
-      "Live-ops conflict vector annotations now include source-quality, freshness, carry-forward, observed-time, and synthetic/local demo-source context"
+      "Live-ops conflict vector annotations now include source-quality, freshness, carry-forward, observed-time, and synthetic/local demo-source context",
+      "Live-ops conflict vector annotations now link directly to the relevant source evidence panel for accountable review"
     ],
     "auditTraceabilityImpact": [
       "Mission governance joins OA and insurance state into dispatch evidence",
@@ -232,11 +233,12 @@
       "Validated conflict bearing wording as true bearing from mission aircraft plus relative left/right bearing against mission heading",
       "Validated one-way ownship-to-conflict range/bearing copy without displaying a reciprocal traffic bearing",
       "Validated bearing-only fallback copy for live-ops conflict vectors without map-native conflict geometry",
-      "Validated live-ops conflict vector source-quality labels for map-native and bearing-only vector states"
+      "Validated live-ops conflict vector source-quality labels for map-native and bearing-only vector states",
+      "Validated live-ops conflict vector source drill-down link and evidence panel anchors"
     ]
 
   },
-  "nextBuildStep": "Add live operations conflict vector source drill-down link to the relevant evidence panel.",
+  "nextBuildStep": "Add live operations conflict vector focus state when opened from source evidence panels.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2147,9 +2147,14 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("Bearing-only fallback: conflict map geometry unavailable");
     expect(response.text).toContain("One-way ownship-to-conflict range and bearing");
     expect(response.text).toContain("conflictVectorSourceQualityLabel");
+    expect(response.text).toContain("conflictVectorSourceDrilldownTarget");
     expect(response.text).toContain("Map-native vector");
     expect(response.text).toContain("Bearing-only vector");
     expect(response.text).toContain("synthetic/local demo source");
+    expect(response.text).toContain("Open vector source evidence");
+    expect(response.text).toContain("#area-source-provenance-panel");
+    expect(response.text).toContain('id="conflict-evidence-panel"');
+    expect(response.text).toContain('id="area-source-provenance-panel"');
     expect(response.text).toContain("fallbackConflictVectorPoint");
     expect(response.text).toContain("rangeMeters");
     expect(response.text).toContain("bearingDegrees");

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -948,6 +948,11 @@ const conflictVectorSourceQualityLabel = (conflict, overlay, isBearingOnly) => {
   return sourceParts.join(" | ");
 };
 
+const conflictVectorSourceDrilldownTarget = (conflict) =>
+  conflict?.overlayKind === "area_conflict"
+    ? "#area-source-provenance-panel"
+    : "#conflict-evidence-panel";
+
 const fetchJson = async (url, options = {}) => {
   const response = await fetch(url, {
     headers: {
@@ -3042,6 +3047,8 @@ const buildMapMarkup = () => {
             conflictOverlay,
             isBearingOnly,
           );
+          const sourceDrilldownTarget =
+            conflictVectorSourceDrilldownTarget(conflict);
           const midpoint = {
             x: (currentMapPoint.x + targetPoint.x) / 2,
             y: (currentMapPoint.y + targetPoint.y) / 2,
@@ -3093,6 +3100,16 @@ const buildMapMarkup = () => {
                 font-size="10"
                 font-weight="700"
               >${escapeHtml(sourceQualityLabel)}</text>
+              <a href="${escapeHtml(sourceDrilldownTarget)}">
+                <text
+                  x="${midpoint.x + 12}"
+                  y="${midpoint.y + 54}"
+                  fill="#93c5fd"
+                  font-size="10"
+                  font-weight="800"
+                  text-decoration="underline"
+                >Open vector source evidence</text>
+              </a>
             </g>
           `;
         })()
@@ -3401,7 +3418,7 @@ const renderStatus = () => {
           Snapshot history is backend audit metadata only. It is not screenshot evidence, not an exported file, and not pilot command guidance.
         </div>
       </section>
-      <section class="summary-block">
+      <section class="summary-block" id="conflict-evidence-panel">
         <h4>Operational Posture</h4>
         <div class="kv">
           <div class="k">Approval</div>
@@ -3566,7 +3583,7 @@ const renderStatus = () => {
           )}</div>
         </div>
       </section>
-      <section class="summary-block">
+      <section class="summary-block" id="area-source-provenance-panel">
         <h4>Area Source Provenance</h4>
         ${
           areaProvenanceRows.length === 0
@@ -3580,7 +3597,7 @@ const renderStatus = () => {
           Synthetic/local demo provenance only. Review against authoritative CAA, NOTAM, and airspace feeds before operational use.
         </div>
       </section>
-      <section class="summary-block">
+      <section class="summary-block" id="area-refresh-chronology-panel">
         <h4>Area Refresh Chronology</h4>
         ${renderAreaRefreshChronologyReview()}
         <div class="alert-window-meta">


### PR DESCRIPTION
Adds a source evidence drill-down link directly to the live operations conflict vector annotation.

The vector now includes an “Open vector source evidence” link:
- area conflicts jump to the Area Source Provenance panel
- non-area/traffic conflicts jump to the Conflict Evidence panel

This makes the vector source-quality label actionable for accountable review without implying compliance certification or pilot command authority.

Validation:
- npm run build
- mission-planning.test.ts: 37/37 passed
- npm run validate:savepoint
- git diff --check
- nextBuildStep PR gate passed
