### PR TITLE
Add live ops conflict vector focus controls

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -170,7 +170,8 @@
       "Live-ops conflict vectors now fall back to a bearing-only ownship ray when conflict map geometry is unavailable",
       "Live-ops conflict vector annotations now include source-quality, freshness, carry-forward, observed-time, and synthetic/local demo-source context",
       "Live-ops conflict vector annotations now link directly to the relevant source evidence panel for accountable review",
-      "Live-ops conflict vector source evidence panels now provide a return focus link that highlights the vector on the map"
+      "Live-ops conflict vector source evidence panels now provide a return focus link that highlights the vector on the map",
+      "Live-ops conflict vector source focus can now be set or cleared from the map and source evidence panels without changing assessment state"
     ],
     "auditTraceabilityImpact": [
       "Mission governance joins OA and insurance state into dispatch evidence",
@@ -236,11 +237,12 @@
       "Validated bearing-only fallback copy for live-ops conflict vectors without map-native conflict geometry",
       "Validated live-ops conflict vector source-quality labels for map-native and bearing-only vector states",
       "Validated live-ops conflict vector source drill-down link and evidence panel anchors",
-      "Validated live-ops conflict vector source focus state from evidence panels back to the map"
+      "Validated live-ops conflict vector source focus state from evidence panels back to the map",
+      "Validated live-ops conflict vector focus controls for setting and clearing source focus"
     ]
 
   },
-  "nextBuildStep": "Add live operations conflict vector focus controls for clearing or changing source focus.",
+  "nextBuildStep": "Add live operations conflict vector focus audit metadata to map view-state evidence snapshots.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2160,6 +2160,12 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("Focus conflict vector on map");
     expect(response.text).toContain("Focused conflict vector source evidence is open");
     expect(response.text).toContain("Focused conflict vector source provenance is open");
+    expect(response.text).toContain("setConflictVectorSourceFocus");
+    expect(response.text).toContain("data-conflict-vector-focus-control");
+    expect(response.text).toContain("Clear vector source focus");
+    expect(response.text).toContain("Clear vector focus");
+    expect(response.text).toContain("Focus vector source");
+    expect(response.text).toContain("Vector focus controls only change the review view");
     expect(response.text).toContain('id="conflict-evidence-panel"');
     expect(response.text).toContain('id="area-source-provenance-panel"');
     expect(response.text).toContain("fallbackConflictVectorPoint");

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -971,6 +971,13 @@ const conflictVectorSourceFocusUrl = (conflict, missionId = uiState.missionId) =
   return `${route}?${params.toString()}${target}`;
 };
 
+const setConflictVectorSourceFocus = (focused) => {
+  uiState.focusTargets.conflictVectorSource = focused ? "focused" : "";
+  updateUrl(normalizeMissionId(uiState.missionId));
+  renderMap();
+  renderStatus();
+};
+
 const fetchJson = async (url, options = {}) => {
   const response = await fetch(url, {
     headers: {
@@ -3172,6 +3179,19 @@ const buildMapMarkup = () => {
                     >Focused vector source from evidence panel</text>`
                   : ""
               }
+              <text
+                x="${midpoint.x + 12}"
+                y="${midpoint.y + (vectorSourceFocused ? 86 : 70)}"
+                fill="#bfdbfe"
+                font-size="10"
+                font-weight="800"
+                text-decoration="underline"
+                data-conflict-vector-focus-control="${escapeHtml(
+                  vectorSourceFocused ? "clear" : "focus",
+                )}"
+              >${escapeHtml(
+                vectorSourceFocused ? "Clear vector source focus" : "Focus vector source",
+              )}</text>
             </g>
           `;
         })()
@@ -3660,6 +3680,16 @@ const renderStatus = () => {
               : `${secondaryAdvisories.length} secondary item(s)`,
           )}</div>
         </div>
+        <div class="actions-row">
+          ${
+            conflictVectorSourceFocused
+              ? `<button type="button" class="secondary-button tone-muted" data-conflict-vector-focus-control="clear">Clear vector focus</button>`
+              : `<button type="button" class="secondary-button tone-info" data-conflict-vector-focus-control="focus" ${primaryConflict ? "" : "disabled"}>Focus conflict vector</button>`
+          }
+        </div>
+        <div class="alert-window-meta">
+          Vector focus controls only change the review view. They do not change conflict assessment, compliance state, or pilot guidance.
+        </div>
       </section>
       <section class="summary-block${focusClass(conflictVectorSourceFocused)}" id="area-source-provenance-panel">
         <h4>Area Source Provenance</h4>
@@ -3678,6 +3708,13 @@ const renderStatus = () => {
             conflictVectorSourceFocusLink
               ? `<a href="${escapeHtml(conflictVectorSourceFocusLink)}">Focus conflict vector on map</a>`
               : "No active vector source focus is available."
+          }
+        </div>
+        <div class="actions-row">
+          ${
+            conflictVectorSourceFocused
+              ? `<button type="button" class="secondary-button tone-muted" data-conflict-vector-focus-control="clear">Clear vector focus</button>`
+              : `<button type="button" class="secondary-button tone-info" data-conflict-vector-focus-control="focus" ${primaryConflict ? "" : "disabled"}>Focus conflict vector</button>`
           }
         </div>
         <div class="alert-window-meta">
@@ -4432,6 +4469,17 @@ statusPanel.addEventListener("click", (event) => {
     return;
   }
 
+  const conflictVectorFocusControl = target.closest(
+    "[data-conflict-vector-focus-control]",
+  );
+  if (conflictVectorFocusControl instanceof HTMLElement) {
+    setConflictVectorSourceFocus(
+      conflictVectorFocusControl.getAttribute("data-conflict-vector-focus-control") ===
+        "focus",
+    );
+    return;
+  }
+
   const telemetryToggle = target.closest("[data-telemetry-display-toggle]");
   if (telemetryToggle instanceof HTMLElement) {
     const key = telemetryToggle.getAttribute("data-telemetry-display-toggle");
@@ -4453,6 +4501,17 @@ statusPanel.addEventListener("click", (event) => {
 mapPanel.addEventListener("click", (event) => {
   const target = event.target;
   if (!(target instanceof HTMLElement)) {
+    return;
+  }
+
+  const conflictVectorFocusControl = target.closest(
+    "[data-conflict-vector-focus-control]",
+  );
+  if (conflictVectorFocusControl instanceof HTMLElement) {
+    setConflictVectorSourceFocus(
+      conflictVectorFocusControl.getAttribute("data-conflict-vector-focus-control") ===
+        "focus",
+    );
     return;
   }
 


### PR DESCRIPTION
Adds controls for setting and clearing live-ops conflict vector source focus.

This adds:
- “Focus vector source” control on the map vector
- “Clear vector source focus” when the vector is already focused
- evidence-panel controls to focus or clear the conflict vector
- shared handler that updates URL focus state and re-renders map/status panels
- review-only wording confirming focus controls do not change conflict assessment, compliance state, or pilot guidance

Validation:
- npm run build
- mission-planning.test.ts: 37/37 passed
- npm run validate:savepoint
- git diff --check
- nextBuildStep PR gate passed
