### PR TITLE
Capture conflict vector focus metadata

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -171,7 +171,8 @@
       "Live-ops conflict vector annotations now include source-quality, freshness, carry-forward, observed-time, and synthetic/local demo-source context",
       "Live-ops conflict vector annotations now link directly to the relevant source evidence panel for accountable review",
       "Live-ops conflict vector source evidence panels now provide a return focus link that highlights the vector on the map",
-      "Live-ops conflict vector source focus can now be set or cleared from the map and source evidence panels without changing assessment state"
+      "Live-ops conflict vector source focus can now be set or cleared from the map and source evidence panels without changing assessment state",
+      "Live-ops map view-state evidence snapshots now capture conflict vector focus, mode, source quality, source panel, and observed vector context"
     ],
     "auditTraceabilityImpact": [
       "Mission governance joins OA and insurance state into dispatch evidence",
@@ -238,11 +239,12 @@
       "Validated live-ops conflict vector source-quality labels for map-native and bearing-only vector states",
       "Validated live-ops conflict vector source drill-down link and evidence panel anchors",
       "Validated live-ops conflict vector source focus state from evidence panels back to the map",
-      "Validated live-ops conflict vector focus controls for setting and clearing source focus"
+      "Validated live-ops conflict vector focus controls for setting and clearing source focus",
+      "Validated live-ops conflict vector focus audit metadata in map view-state evidence snapshots"
     ]
 
   },
-  "nextBuildStep": "Add live operations conflict vector focus audit metadata to map view-state evidence snapshots.",
+  "nextBuildStep": "Add conflict vector focus metadata to post-operation evidence exports and reports.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -798,6 +798,16 @@ export class AuditEvidenceService {
       activeConflictCount: number;
       areaRefreshRunCount: number;
       viewStateUrl: string | null;
+      conflictVectorSourceFocus: string | null;
+      conflictVectorMode: string | null;
+      conflictVectorSourceQuality: string | null;
+      conflictVectorOverlayId: string | null;
+      conflictVectorOverlayLabel: string | null;
+      conflictVectorOverlayKind: string | null;
+      conflictVectorBearingDegrees: number | null;
+      conflictVectorRangeMeters: number | null;
+      conflictVectorObservedAt: string | null;
+      conflictVectorSourcePanel: string | null;
     },
   ): Record<string, unknown> {
     return {
@@ -819,6 +829,18 @@ export class AuditEvidenceService {
         activeConflictCount: input.activeConflictCount,
         areaRefreshRunCount: input.areaRefreshRunCount,
         viewStateUrl: input.viewStateUrl,
+        conflictVector: {
+          sourceFocus: input.conflictVectorSourceFocus ?? "not_focused",
+          mode: input.conflictVectorMode ?? "not_recorded",
+          sourceQuality: input.conflictVectorSourceQuality ?? "not_recorded",
+          overlayId: input.conflictVectorOverlayId,
+          overlayLabel: input.conflictVectorOverlayLabel,
+          overlayKind: input.conflictVectorOverlayKind,
+          bearingDegrees: input.conflictVectorBearingDegrees,
+          rangeMeters: input.conflictVectorRangeMeters,
+          observedAt: input.conflictVectorObservedAt,
+          sourcePanel: input.conflictVectorSourcePanel,
+        },
       },
       assuranceBoundary:
         "Live-ops map view-state capture is audit metadata only and does not issue pilot instructions or certify live regulatory compliance.",

--- a/src/audit-evidence/audit-evidence.types.ts
+++ b/src/audit-evidence/audit-evidence.types.ts
@@ -36,6 +36,16 @@ export interface CreateLiveOpsMapViewStateSnapshotInput {
   activeConflictCount?: number;
   areaRefreshRunCount?: number;
   viewStateUrl?: string | null;
+  conflictVectorSourceFocus?: string | null;
+  conflictVectorMode?: string | null;
+  conflictVectorSourceQuality?: string | null;
+  conflictVectorOverlayId?: string | null;
+  conflictVectorOverlayLabel?: string | null;
+  conflictVectorOverlayKind?: string | null;
+  conflictVectorBearingDegrees?: number | null;
+  conflictVectorRangeMeters?: number | null;
+  conflictVectorObservedAt?: string | null;
+  conflictVectorSourcePanel?: string | null;
   createdBy?: string | null;
 }
 

--- a/src/audit-evidence/audit-evidence.validators.ts
+++ b/src/audit-evidence/audit-evidence.validators.ts
@@ -105,6 +105,18 @@ function requiredNonNegativeInteger(value: unknown, fieldName: string): number {
   return value;
 }
 
+function optionalNumber(value: unknown, fieldName: string): number | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new AuditEvidenceValidationError(`${fieldName} must be a number`);
+  }
+
+  return value;
+}
+
 function requiredDecisionType(value: unknown): MissionDecisionType {
   if (typeof value !== "string" || !DECISION_TYPES.has(value as MissionDecisionType)) {
     throw new AuditEvidenceValidationError("decisionType is not supported");
@@ -281,6 +293,47 @@ export function validateCreateLiveOpsMapViewStateSnapshotInput(
       "areaRefreshRunCount",
     ),
     viewStateUrl: optionalTrimmed(input.viewStateUrl, "viewStateUrl"),
+    conflictVectorSourceFocus: optionalTrimmed(
+      input.conflictVectorSourceFocus,
+      "conflictVectorSourceFocus",
+    ),
+    conflictVectorMode: optionalTrimmed(
+      input.conflictVectorMode,
+      "conflictVectorMode",
+    ),
+    conflictVectorSourceQuality: optionalTrimmed(
+      input.conflictVectorSourceQuality,
+      "conflictVectorSourceQuality",
+    ),
+    conflictVectorOverlayId: optionalTrimmed(
+      input.conflictVectorOverlayId,
+      "conflictVectorOverlayId",
+    ),
+    conflictVectorOverlayLabel: optionalTrimmed(
+      input.conflictVectorOverlayLabel,
+      "conflictVectorOverlayLabel",
+    ),
+    conflictVectorOverlayKind: optionalTrimmed(
+      input.conflictVectorOverlayKind,
+      "conflictVectorOverlayKind",
+    ),
+    conflictVectorBearingDegrees: optionalNumber(
+      input.conflictVectorBearingDegrees,
+      "conflictVectorBearingDegrees",
+    ),
+    conflictVectorRangeMeters: optionalNumber(
+      input.conflictVectorRangeMeters,
+      "conflictVectorRangeMeters",
+    ),
+    conflictVectorObservedAt:
+      input.conflictVectorObservedAt === undefined ||
+      input.conflictVectorObservedAt === null
+        ? null
+        : requiredIsoDate(input.conflictVectorObservedAt, "conflictVectorObservedAt"),
+    conflictVectorSourcePanel: optionalTrimmed(
+      input.conflictVectorSourcePanel,
+      "conflictVectorSourcePanel",
+    ),
     createdBy: optionalTrimmed(input.createdBy, "createdBy"),
   };
 }

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -802,6 +802,17 @@ describe("audit evidence snapshots", () => {
         areaRefreshRunCount: 5,
         viewStateUrl:
           "/operator/missions/live-ops-demo/live-operations?areaFreshnessFilter=degraded",
+        conflictVectorSourceFocus: "focused",
+        conflictVectorMode: "bearing_only_fallback",
+        conflictVectorSourceQuality:
+          "Bearing-only vector | source partial | synthetic/local demo source",
+        conflictVectorOverlayId: "traffic-1",
+        conflictVectorOverlayLabel: "Traffic VA-INS-12",
+        conflictVectorOverlayKind: "drone_traffic",
+        conflictVectorBearingDegrees: 128,
+        conflictVectorRangeMeters: 420,
+        conflictVectorObservedAt: "2026-04-18T12:00:45.000Z",
+        conflictVectorSourcePanel: "#conflict-evidence-panel",
         createdBy: " live-ops-controller ",
       });
 
@@ -837,6 +848,19 @@ describe("audit evidence snapshots", () => {
           openAlertCount: 3,
           activeConflictCount: 1,
           areaRefreshRunCount: 5,
+          conflictVector: {
+            sourceFocus: "focused",
+            mode: "bearing_only_fallback",
+            sourceQuality:
+              "Bearing-only vector | source partial | synthetic/local demo source",
+            overlayId: "traffic-1",
+            overlayLabel: "Traffic VA-INS-12",
+            overlayKind: "drone_traffic",
+            bearingDegrees: 128,
+            rangeMeters: 420,
+            observedAt: "2026-04-18T12:00:45.000Z",
+            sourcePanel: "#conflict-evidence-panel",
+          },
         },
       },
     });

--- a/src/tests/mission-planning.test.ts
+++ b/src/tests/mission-planning.test.ts
@@ -2161,6 +2161,7 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("Focused conflict vector source evidence is open");
     expect(response.text).toContain("Focused conflict vector source provenance is open");
     expect(response.text).toContain("setConflictVectorSourceFocus");
+    expect(response.text).toContain("conflictVectorAuditMetadata");
     expect(response.text).toContain("data-conflict-vector-focus-control");
     expect(response.text).toContain("Clear vector source focus");
     expect(response.text).toContain("Clear vector focus");
@@ -2261,6 +2262,11 @@ describe("mission planning drafts", () => {
     expect(response.text).toContain("/live-operations/map-view-state/audit-snapshots");
     expect(response.text).toContain("visibleAreaOverlayCount");
     expect(response.text).toContain("degradedAreaOverlayCount");
+    expect(response.text).toContain("conflictVectorSourceFocus");
+    expect(response.text).toContain("conflictVectorMode");
+    expect(response.text).toContain("conflictVectorSourceQuality");
+    expect(response.text).toContain("Conflict vector focus");
+    expect(response.text).toContain("Conflict vector source");
     expect(response.text).toContain("openAlertCount");
     expect(response.text).toContain("activeConflictCount");
     expect(response.text).toContain("areaRefreshRunCount");

--- a/static/operator-live-operations-map.js
+++ b/static/operator-live-operations-map.js
@@ -978,6 +978,58 @@ const setConflictVectorSourceFocus = (focused) => {
   renderStatus();
 };
 
+const conflictVectorAuditMetadata = () => {
+  const conflict = primaryConflictAssessmentItem();
+  if (!conflict) {
+    return {
+      conflictVectorSourceFocus: uiState.focusTargets.conflictVectorSource || "not_focused",
+      conflictVectorMode: "not_available",
+      conflictVectorSourceQuality: "No active conflict vector",
+      conflictVectorOverlayId: null,
+      conflictVectorOverlayLabel: null,
+      conflictVectorOverlayKind: null,
+      conflictVectorBearingDegrees: null,
+      conflictVectorRangeMeters: null,
+      conflictVectorObservedAt: null,
+      conflictVectorSourcePanel: null,
+    };
+  }
+
+  const overlay = conflictOverlayForItem(conflict);
+  const hasMapGeometry =
+    Number.isFinite(Number(overlay?.geometry?.lat)) &&
+    Number.isFinite(Number(overlay?.geometry?.lng));
+  const hasBearing = Number.isFinite(Number(conflict?.metrics?.bearingDegrees));
+  const vectorMode = hasMapGeometry
+    ? "map_native"
+    : hasBearing
+      ? "bearing_only_fallback"
+      : "not_available";
+
+  return {
+    conflictVectorSourceFocus: uiState.focusTargets.conflictVectorSource || "not_focused",
+    conflictVectorMode: vectorMode,
+    conflictVectorSourceQuality: conflictVectorSourceQualityLabel(
+      conflict,
+      overlay,
+      vectorMode === "bearing_only_fallback",
+    ),
+    conflictVectorOverlayId: conflict.overlayId ?? null,
+    conflictVectorOverlayLabel: conflict.overlayLabel ?? null,
+    conflictVectorOverlayKind: conflict.overlayKind ?? null,
+    conflictVectorBearingDegrees: Number.isFinite(Number(conflict?.metrics?.bearingDegrees))
+      ? Number(conflict.metrics.bearingDegrees)
+      : null,
+    conflictVectorRangeMeters: Number.isFinite(
+      Number(conflict?.metrics?.rangeMeters ?? conflict?.metrics?.lateralDistanceMeters),
+    )
+      ? Number(conflict.metrics.rangeMeters ?? conflict.metrics.lateralDistanceMeters)
+      : null,
+    conflictVectorObservedAt: conflict.overlayObservedAt ?? null,
+    conflictVectorSourcePanel: conflictVectorSourceDrilldownTarget(conflict),
+  };
+};
+
 const fetchJson = async (url, options = {}) => {
   const response = await fetch(url, {
     headers: {
@@ -1995,6 +2047,7 @@ const mapViewStateMetadata = () => {
   const openAlerts = (uiState.alerts ?? []).filter((alert) => alert.status !== "resolved");
   const conflicts = activeConflictAssessmentItems();
   const refreshRuns = areaRefreshChronology()?.refreshRuns ?? [];
+  const conflictVector = conflictVectorAuditMetadata();
 
   return {
     missionId: uiState.missionId || "Not selected",
@@ -2010,6 +2063,9 @@ const mapViewStateMetadata = () => {
     openAlertCount: openAlerts.length,
     activeConflictCount: conflicts.length,
     areaRefreshRunCount: refreshRuns.length,
+    conflictVectorSourceFocus: conflictVector.conflictVectorSourceFocus,
+    conflictVectorMode: conflictVector.conflictVectorMode,
+    conflictVectorSourceQuality: conflictVector.conflictVectorSourceQuality,
     exportStatus: "View-state metadata only; no evidence export has been generated.",
   };
 };
@@ -2021,6 +2077,7 @@ const mapViewStateEvidencePayload = () => {
   const openAlerts = (uiState.alerts ?? []).filter((alert) => alert.status !== "resolved");
   const conflicts = activeConflictAssessmentItems();
   const refreshRuns = areaRefreshChronology()?.refreshRuns ?? [];
+  const conflictVector = conflictVectorAuditMetadata();
 
   return {
     replayCursor:
@@ -2036,6 +2093,7 @@ const mapViewStateEvidencePayload = () => {
     activeConflictCount: conflicts.length,
     areaRefreshRunCount: refreshRuns.length,
     viewStateUrl: `${window.location.pathname}${window.location.search}`,
+    ...conflictVector,
     createdBy: "live-ops-ui",
   };
 };
@@ -2151,6 +2209,8 @@ const renderMapViewStateEvidenceHistory = () => {
         .map(
           (snapshot, index) => {
             const isFocused = snapshot.id === focusedMapEvidenceId;
+            const conflictVector =
+              snapshot.snapshotMetadata?.viewState?.conflictVector ?? {};
 
             return `
             <article class="list-card${focusClass(isFocused)}" data-map-evidence-id="${escapeHtml(snapshot.id ?? "")}">
@@ -2172,6 +2232,12 @@ const renderMapViewStateEvidenceHistory = () => {
                 <div>${escapeHtml(`${snapshot.visibleAreaOverlayCount ?? 0} / ${snapshot.totalAreaOverlayCount ?? 0} visible, ${snapshot.degradedAreaOverlayCount ?? 0} degraded`)}</div>
                 <div class="k">Alerts / conflicts</div>
                 <div>${escapeHtml(`${snapshot.openAlertCount ?? 0} open alerts, ${snapshot.activeConflictCount ?? 0} active conflicts`)}</div>
+                <div class="k">Conflict vector focus</div>
+                <div>${renderBadge(conflictVector.sourceFocus ?? "not_recorded")}</div>
+                <div class="k">Conflict vector mode</div>
+                <div>${escapeHtml(conflictVector.mode ?? "not_recorded")}</div>
+                <div class="k">Conflict vector source</div>
+                <div>${escapeHtml(conflictVector.sourceQuality ?? "not_recorded")}</div>
                 <div class="k">Capture scope</div>
                 <div>${renderBadge(snapshot.captureScope ?? "metadata_only")}</div>
                 <div class="k">Pilot instruction status</div>
@@ -3472,6 +3538,12 @@ const renderStatus = () => {
           <div>${escapeHtml(String(viewStateMetadata.activeConflictCount))}</div>
           <div class="k">Area refresh runs</div>
           <div>${escapeHtml(String(viewStateMetadata.areaRefreshRunCount))}</div>
+          <div class="k">Conflict vector focus</div>
+          <div>${renderBadge(viewStateMetadata.conflictVectorSourceFocus)}</div>
+          <div class="k">Conflict vector mode</div>
+          <div>${escapeHtml(viewStateMetadata.conflictVectorMode)}</div>
+          <div class="k">Conflict vector source</div>
+          <div>${escapeHtml(viewStateMetadata.conflictVectorSourceQuality)}</div>
           <div class="k">Export status</div>
           <div>${escapeHtml(viewStateMetadata.exportStatus)}</div>
         </div>


### PR DESCRIPTION
Adds conflict vector focus/source context to live-ops map view-state evidence snapshots.

This captures and preserves:
- conflict vector focus state
- vector mode: map-native, bearing-only fallback, or unavailable
- source-quality label
- overlay ID, label, and kind
- bearing/range values where available
- observed timestamp
- source evidence panel target

The metadata is included in `snapshotMetadata.viewState.conflictVector` and displayed in the recent map view-state evidence history, preserving the review trail without changing conflict assessment, compliance state, or pilot guidance.

Validation:
- npm run build
- mission-planning.test.ts: 37/37 passed
- audit-evidence.test.ts: 64/64 passed
- npm run validate:savepoint
- git diff --check
- nextBuildStep PR gate passed
