### PR TITLE
Add conflict vector metadata to reports

### DIFF
--- a/fsms-save-point.json
+++ b/fsms-save-point.json
@@ -148,7 +148,8 @@
       "Accountable managers can record review decisions against SOP recommendations while preserving the recommendation history as advisory evidence",
       "Authorised governance users can see SOP recommendation decision state in the mission workspace before sign-off; unauthorised users see controlled-access advisory wording instead",
       "Operators can now view or hide ownship mission heading in the live-ops telemetry surface, separate from traffic range/bearing and CPA advisory context",
-      "Operators can see a moving range/bearing-to-conflict line on the live-ops map when the active conflict has map-native point geometry"
+      "Operators can see a moving range/bearing-to-conflict line on the live-ops map when the active conflict has map-native point geometry",
+      "Accountable managers can now review conflict vector focus, source quality, source panel, overlay, bearing/range, and observed-time metadata in post-operation reports"
     ]
   },
   "complianceImplications": {
@@ -172,7 +173,8 @@
       "Live-ops conflict vector annotations now link directly to the relevant source evidence panel for accountable review",
       "Live-ops conflict vector source evidence panels now provide a return focus link that highlights the vector on the map",
       "Live-ops conflict vector source focus can now be set or cleared from the map and source evidence panels without changing assessment state",
-      "Live-ops map view-state evidence snapshots now capture conflict vector focus, mode, source quality, source panel, and observed vector context"
+      "Live-ops map view-state evidence snapshots now capture conflict vector focus, mode, source quality, source panel, and observed vector context",
+      "Post-operation evidence reports now surface conflict vector metadata as accountable review context rather than pilot command guidance"
     ],
     "auditTraceabilityImpact": [
       "Mission governance joins OA and insurance state into dispatch evidence",
@@ -183,7 +185,8 @@
       "Linked SOP documents create the first traceable target for future post-operation SOP amendment recommendations",
       "SOP change recommendations now preserve mission evidence source, SOP clause, and parent OA condition context as draft accountable review records",
       "SOP recommendation review decisions now preserve who reviewed the recommendation, why they decided, and any supporting evidence reference without automatically amending SOP content",
-      "SOP recommendation decision visibility is now treated as role-controlled accountable review support, not operational instruction to pilots or operators"
+      "SOP recommendation decision visibility is now treated as role-controlled accountable review support, not operational instruction to pilots or operators",
+      "Conflict vector focus metadata now carries through post-operation export and rendered report/PDF evidence so later reviews can see what map source was focused"
     ]
   },
   "risksLimitations": {
@@ -240,11 +243,12 @@
       "Validated live-ops conflict vector source drill-down link and evidence panel anchors",
       "Validated live-ops conflict vector source focus state from evidence panels back to the map",
       "Validated live-ops conflict vector focus controls for setting and clearing source focus",
-      "Validated live-ops conflict vector focus audit metadata in map view-state evidence snapshots"
+      "Validated live-ops conflict vector focus audit metadata in map view-state evidence snapshots",
+      "Validated conflict vector focus metadata in post-operation exports, rendered reports, and PDF report text"
     ]
 
   },
-  "nextBuildStep": "Add conflict vector focus metadata to post-operation evidence exports and reports.",
+  "nextBuildStep": "Add conflict vector metadata to post-operation evidence readiness prompts.",
   "doNotChangeRules": {
     "criticalInvariants": [],
     "orderingRules": [

--- a/src/audit-evidence/audit-evidence.service.ts
+++ b/src/audit-evidence/audit-evidence.service.ts
@@ -14,6 +14,7 @@ import { AuditEvidenceRepository } from "./audit-evidence.repository";
 import type {
   AuditEvidenceSnapshot,
   AuditEvidenceReadinessSnapshot,
+  AuditReportField,
   AuditReportSection,
   AuditReportSmsControlMapping,
   ConflictGuidanceAcknowledgement,
@@ -1106,6 +1107,10 @@ export class AuditEvidenceService {
                     label: `Map view-state snapshot ${index + 1} alerts and conflicts`,
                     value: `${snapshot.openAlertCount} open alerts; ${snapshot.activeConflictCount} active conflicts`,
                   },
+                  ...this.buildLiveOpsConflictVectorReportFields(
+                    snapshot,
+                    index,
+                  ),
                   {
                     label: `Map view-state snapshot ${index + 1} refresh runs`,
                     value: snapshot.areaRefreshRunCount,
@@ -1356,6 +1361,93 @@ export class AuditEvidenceService {
               ],
       },
     ];
+  }
+
+  private buildLiveOpsConflictVectorReportFields(
+    snapshot: LiveOpsMapViewStateSnapshot,
+    index: number,
+  ): AuditReportField[] {
+    const prefix = `Map view-state snapshot ${index + 1} conflict vector`;
+    const conflictVector = this.getLiveOpsConflictVectorMetadata(snapshot);
+    const overlay = [
+      this.optionalReportString(conflictVector.overlayLabel),
+      this.optionalReportString(conflictVector.overlayId),
+      this.optionalReportString(conflictVector.overlayKind),
+    ]
+      .filter((value): value is string => Boolean(value))
+      .join(" | ");
+    const bearing = this.optionalReportNumber(conflictVector.bearingDegrees);
+    const range = this.optionalReportNumber(conflictVector.rangeMeters);
+
+    return [
+      {
+        label: `${prefix} focus`,
+        value:
+          this.optionalReportString(conflictVector.sourceFocus) ??
+          "not_recorded",
+      },
+      {
+        label: `${prefix} mode`,
+        value:
+          this.optionalReportString(conflictVector.mode) ?? "not_recorded",
+      },
+      {
+        label: `${prefix} source quality`,
+        value:
+          this.optionalReportString(conflictVector.sourceQuality) ??
+          "not_recorded",
+      },
+      {
+        label: `${prefix} source panel`,
+        value:
+          this.optionalReportString(conflictVector.sourcePanel) ??
+          "not_recorded",
+      },
+      {
+        label: `${prefix} overlay`,
+        value: overlay || "not_recorded",
+      },
+      {
+        label: `${prefix} bearing/range`,
+        value:
+          bearing === null && range === null
+            ? "not_recorded"
+            : `${bearing ?? "not_recorded"} deg / ${range ?? "not_recorded"} m`,
+      },
+      {
+        label: `${prefix} observed at`,
+        value:
+          this.optionalReportString(conflictVector.observedAt) ??
+          "not_recorded",
+      },
+    ];
+  }
+
+  private getLiveOpsConflictVectorMetadata(
+    snapshot: LiveOpsMapViewStateSnapshot,
+  ): Record<string, unknown> {
+    const viewState =
+      snapshot.snapshotMetadata &&
+      typeof snapshot.snapshotMetadata.viewState === "object" &&
+      snapshot.snapshotMetadata.viewState !== null
+        ? (snapshot.snapshotMetadata.viewState as Record<string, unknown>)
+        : null;
+
+    return viewState &&
+      typeof viewState.conflictVector === "object" &&
+      viewState.conflictVector !== null
+      ? (viewState.conflictVector as Record<string, unknown>)
+      : {};
+  }
+
+  private optionalReportString(value: unknown): string | null {
+    return typeof value === "string" && value.trim().length > 0
+      ? value
+      : null;
+  }
+
+  private optionalReportNumber(value: unknown): number | null {
+    return typeof value === "number" && Number.isFinite(value) ? value : null;
   }
 
   private renderSectionsAsPlainText(

--- a/src/tests/audit-evidence.test.ts
+++ b/src/tests/audit-evidence.test.ts
@@ -1619,6 +1619,17 @@ describe("audit evidence snapshots", () => {
         areaRefreshRunCount: 5,
         viewStateUrl:
           "/operator/missions/live-ops-demo/live-operations?areaFreshnessFilter=degraded",
+        conflictVectorSourceFocus: "focused",
+        conflictVectorMode: "map_native",
+        conflictVectorSourceQuality:
+          "Full vector | source current | operational feed",
+        conflictVectorOverlayId: "traffic-export-1",
+        conflictVectorOverlayLabel: "Traffic VA-INS-12",
+        conflictVectorOverlayKind: "drone_traffic",
+        conflictVectorBearingDegrees: 128,
+        conflictVectorRangeMeters: 420,
+        conflictVectorObservedAt: "2026-04-18T12:02:45.000Z",
+        conflictVectorSourcePanel: "#conflict-vector-evidence",
         createdBy: "live-ops-ui",
       });
     const snapshotResponse = await request(app)
@@ -1654,6 +1665,20 @@ describe("audit evidence snapshots", () => {
       snapshotMetadata: {
         screenshotStatus: "not_captured",
         fileGenerationStatus: "not_requested",
+        viewState: {
+          conflictVector: {
+            sourceFocus: "focused",
+            mode: "map_native",
+            sourceQuality: "Full vector | source current | operational feed",
+            overlayId: "traffic-export-1",
+            overlayLabel: "Traffic VA-INS-12",
+            overlayKind: "drone_traffic",
+            bearingDegrees: 128,
+            rangeMeters: 420,
+            observedAt: "2026-04-18T12:02:45.000Z",
+            sourcePanel: "#conflict-vector-evidence",
+          },
+        },
       },
     });
     expect(await countRows(missionId)).toEqual(before);
@@ -2310,6 +2335,17 @@ describe("audit evidence snapshots", () => {
         areaRefreshRunCount: 5,
         viewStateUrl:
           "/operator/missions/live-ops-demo/live-operations?areaFreshnessFilter=degraded",
+        conflictVectorSourceFocus: "focused",
+        conflictVectorMode: "map_native",
+        conflictVectorSourceQuality:
+          "Full vector | source current | operational feed",
+        conflictVectorOverlayId: "traffic-report-1",
+        conflictVectorOverlayLabel: "Traffic VA-INS-12",
+        conflictVectorOverlayKind: "drone_traffic",
+        conflictVectorBearingDegrees: 128,
+        conflictVectorRangeMeters: 420,
+        conflictVectorObservedAt: "2026-04-18T12:02:45.000Z",
+        conflictVectorSourcePanel: "#conflict-vector-evidence",
       });
     const snapshotResponse = await request(app)
       .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
@@ -2370,6 +2406,30 @@ describe("audit evidence snapshots", () => {
           value: "3 open alerts; 1 active conflicts",
         },
         {
+          label: "Map view-state snapshot 1 conflict vector focus",
+          value: "focused",
+        },
+        {
+          label: "Map view-state snapshot 1 conflict vector mode",
+          value: "map_native",
+        },
+        {
+          label: "Map view-state snapshot 1 conflict vector source quality",
+          value: "Full vector | source current | operational feed",
+        },
+        {
+          label: "Map view-state snapshot 1 conflict vector source panel",
+          value: "#conflict-vector-evidence",
+        },
+        {
+          label: "Map view-state snapshot 1 conflict vector overlay",
+          value: "Traffic VA-INS-12 | traffic-report-1 | drone_traffic",
+        },
+        {
+          label: "Map view-state snapshot 1 conflict vector bearing/range",
+          value: "128 deg / 420 m",
+        },
+        {
           label: "Map view-state snapshot 1 capture scope",
           value: "metadata_only",
         },
@@ -2398,6 +2458,15 @@ describe("audit evidence snapshots", () => {
     );
     expect(response.body.report.report.plainText).toContain(
       "Map view-state snapshot 1 area overlays: 2/4 visible; 2 degraded",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Map view-state snapshot 1 conflict vector focus: focused",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Map view-state snapshot 1 conflict vector source quality: Full vector | source current | operational feed",
+    );
+    expect(response.body.report.report.plainText).toContain(
+      "Map view-state snapshot 1 conflict vector bearing/range: 128 deg / 420 m",
     );
     expect(response.body.report.report.plainText).toContain(
       "Map view-state snapshot 1 pilot instruction status: not_a_pilot_command",
@@ -2909,6 +2978,17 @@ describe("audit evidence snapshots", () => {
         areaRefreshRunCount: 5,
         viewStateUrl:
           "/operator/missions/live-ops-demo/live-operations?areaFreshnessFilter=degraded",
+        conflictVectorSourceFocus: "focused",
+        conflictVectorMode: "bearing_only_fallback",
+        conflictVectorSourceQuality:
+          "Bearing-only vector | source partial | synthetic/local demo source",
+        conflictVectorOverlayId: "traffic-pdf-1",
+        conflictVectorOverlayLabel: "Traffic VA-INS-12",
+        conflictVectorOverlayKind: "drone_traffic",
+        conflictVectorBearingDegrees: 128,
+        conflictVectorRangeMeters: 420,
+        conflictVectorObservedAt: "2026-04-18T12:02:45.000Z",
+        conflictVectorSourcePanel: "#conflict-vector-evidence",
       });
     const snapshotResponse = await request(app)
       .post(`/missions/${missionId}/post-operation/evidence-snapshots`)
@@ -2935,6 +3015,21 @@ describe("audit evidence snapshots", () => {
       "Map view-state snapshot 1 pilot instruction status",
     );
     expect(pdfText).toContain("not_a_pilot_command");
+    expect(pdfText).toContain(
+      "Map view-state snapshot 1 conflict vector focus: focused",
+    );
+    expect(pdfText).toContain(
+      "Map view-state snapshot 1 conflict vector mode: bearing_only_fallback",
+    );
+    expect(pdfText).toContain(
+      "Map view-state snapshot 1 conflict vector source quality: Bearing-only vector | source",
+    );
+    expect(pdfText).toContain(
+      "partial | synthetic/local demo source",
+    );
+    expect(pdfText).toContain(
+      "Map view-state snapshot 1 conflict vector bearing/range: 128 deg / 420 m",
+    );
     expect(pdfText).toContain("Metadata-only evidence; no screenshot/file");
     expect(pdfText).toContain("not pilot command guidance.");
     expect(await countRows(missionId)).toEqual(before);


### PR DESCRIPTION
Adds live-ops conflict vector focus metadata into post-operation evidence exports, rendered reports, and PDF report text.

- Surfaces focus state, vector mode, source quality, source panel, overlay, bearing/range, and observed time in post-operation reports
- Keeps the wording framed as metadata-only accountable review evidence, not pilot command guidance
- Extends audit evidence tests across export, rendered report, and PDF output
- Updates the FSMS save point and next build step
